### PR TITLE
Migrate issues #34 and #111 from ExpGraph

### DIFF
--- a/ats/parser/ax_test.go
+++ b/ats/parser/ax_test.go
@@ -668,7 +668,7 @@ func TestEnhancedNaturalLanguagePatterns(t *testing.T) {
 				Format:   "table",
 			},
 		},
-		// TODO: Fix single word parsing without 'is' keyword - see issue #34
+		// TODO: Fix single word parsing without 'is' keyword - see issue #2
 		{
 			name:  "profession with explicit subject",
 			query: []string{"ALICE", "is", "analyst"},
@@ -788,7 +788,7 @@ func TestNaturalLanguageDetection(t *testing.T) {
 				Format:     "table",
 			},
 		},
-		// TODO: Fix single word parsing without 'is' keyword - see issue #34
+		// TODO: Fix single word parsing without 'is' keyword - see issue #2
 		// TODO: Add back quoted string handling later
 		// {
 		//   name:  "no splitting for quoted strings",

--- a/ats/parser/semantic.go
+++ b/ats/parser/semantic.go
@@ -124,7 +124,7 @@ func isCommand(s string) bool {
 }
 
 // isKeyword checks if value is an ATS grammatical keyword
-// TODO(issue #111): Refactor to use map for O(1) lookup instead of O(n) linear search
+// TODO(issue #3): Refactor to use map for O(1) lookup instead of O(n) linear search
 func isKeyword(s string) bool {
 	lower := strings.ToLower(s)
 	keywords := append(GrammaticalConnectors, ContextTransitionKeywords...)


### PR DESCRIPTION
## Summary

- Created issue #2: Support single word parsing without 'is' keyword (migrated from sbvh-nl/qntx#34)
- Created issue #3: LSP enhancements for code quality and features (migrated from sbvh-nl/qntx#111)
- Updated code references to point to new issue numbers

## Changes

- `ats/parser/semantic.go`: Updated TODO from #111 to #3
- `ats/parser/ax_test.go`: Updated TODOs from #34 to #2