### PR TITLE
Fix Go syntax highlighting crash

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -13,7 +13,7 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/theme-one-dark": "6.1.3",
         "@codemirror/view": "6.38.1",
-        "@lezer/highlight": "1.2.1",
+        "@lezer/highlight": "1.2.3",
         "@types/d3": "7.4.3",
         "codemirror-languageserver": "1.17.0",
         "d3": "7.9.0",
@@ -39,6 +39,7 @@
     "@codemirror/lint": "6.8.5",
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "6.38.1",
+    "@lezer/common": "1.4.0",
   },
   "packages": {
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.18.6", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg=="],
@@ -57,11 +58,11 @@
 
     "@codemirror/view": ["@codemirror/view@6.38.1", "", { "dependencies": { "@codemirror/state": "^6.5.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ=="],
 
-    "@lezer/common": ["@lezer/common@1.5.0", "", {}, "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA=="],
+    "@lezer/common": ["@lezer/common@1.4.0", "", {}, "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="],
 
     "@lezer/go": ["@lezer/go@1.0.1", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ=="],
 
-    "@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
 
     "@lezer/lr": ["@lezer/lr@1.4.4", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-LHL17Mq0OcFXm1pGQssuGTQFPPdxARjKM8f7GA5+sGtHi0K3R84YaSbmche0+RKWHnCsx9asEe5OWOI4FHfe4A=="],
 
@@ -303,12 +304,10 @@
 
     "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "@codemirror/lang-go/@lezer/common": ["@lezer/common@1.4.0", "", {}, "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="],
+    "@codemirror/language/@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
 
-    "@lezer/go/@lezer/common": ["@lezer/common@1.4.0", "", {}, "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="],
+    "@codemirror/theme-one-dark/@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
 
-    "@lezer/highlight/@lezer/common": ["@lezer/common@1.4.0", "", {}, "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="],
-
-    "@lezer/lr/@lezer/common": ["@lezer/common@1.4.0", "", {}, "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="],
+    "@lezer/go/@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/theme-one-dark": "6.1.3",
     "@codemirror/view": "6.38.1",
-    "@lezer/highlight": "1.2.1",
+    "@lezer/highlight": "1.2.3",
     "@types/d3": "7.4.3",
     "codemirror-languageserver": "1.17.0",
     "d3": "7.9.0",
@@ -42,6 +42,7 @@
     "@codemirror/view": "6.38.1",
     "@codemirror/autocomplete": "6.18.6",
     "@codemirror/lint": "6.8.5",
-    "@codemirror/language": "6.10.3"
+    "@codemirror/language": "6.10.3",
+    "@lezer/common": "1.4.0"
   }
 }

--- a/web/ts/prose/nodes/go-code-block.ts
+++ b/web/ts/prose/nodes/go-code-block.ts
@@ -30,7 +30,14 @@ export class GoCodeBlockNodeView {
 
     private async initializeEditor(): Promise<void> {
         // Load Go language support dynamically to avoid bundling issues
-        const { go } = await import('@codemirror/lang-go');
+        let goExtension;
+        try {
+            const goModule = await import('@codemirror/lang-go');
+            goExtension = goModule.go();
+        } catch (err) {
+            console.error('[Go Block] Go language support unavailable:', err);
+            goExtension = [];  // Editor works without syntax highlighting
+        }
 
         // Create CodeMirror instance
         const initialContent = this.node.textContent;
@@ -64,7 +71,7 @@ export class GoCodeBlockNodeView {
             state: EditorState.create({
                 doc: initialContent,
                 extensions: [
-                    go(), // Go language grammar
+                    goExtension,  // Go language support (empty if unavailable)
                     syntaxHighlighting(defaultHighlightStyle), // Apply syntax highlighting theme
                     goTheme,
                     EditorView.lineWrapping,


### PR DESCRIPTION
## Problem
Go code blocks crashed with `TypeError: can't access property Symbol.iterator, K is undefined`, breaking syntax highlighting in the editor.

## Root Cause
Version conflict: `@lezer/common` 1.5.0 at root incompatible with `@lezer/go` expecting 1.4.0 APIs.

## Fix
- Pin `@lezer/common` to 1.4.0 in package resolutions
- Upgrade `@lezer/highlight` from 1.2.1 to 1.2.3 (fixes highlighting bugs)
- Add defensive error handling in `go-code-block.ts`

## Verification
Manually tested - syntax highlighting now works correctly in browser.

Fixes #75