### PR TITLE
Standardize test imports from vitest to bun:test

### DIFF
--- a/web/ts/graph-renderer.test.ts
+++ b/web/ts/graph-renderer.test.ts
@@ -4,7 +4,7 @@
  * Basic tests for node visibility filtering
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { filterVisibleNodes } from './graph-renderer';
 
 describe('Graph Visibility', () => {

--- a/web/ts/hixtory-panel.test.ts
+++ b/web/ts/hixtory-panel.test.ts
@@ -2,7 +2,7 @@
  * Tests for hixtory panel core functionality
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'bun:test';
 import type { JobUpdateData } from '../types/websocket';
 
 describe('Hixtory Panel - handleJobUpdate', () => {

--- a/web/ts/legenda.test.ts
+++ b/web/ts/legenda.test.ts
@@ -4,7 +4,7 @@
  * Basic tests for node type state management
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'bun:test';
 import { hiddenNodeTypes } from './legenda';
 
 describe('Legenda State Management', () => {

--- a/web/ts/pulse/document-link.test.ts
+++ b/web/ts/pulse/document-link.test.ts
@@ -6,7 +6,7 @@
  * allowing users to navigate back to the source document.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 
 describe('Prose Document Linking', () => {
   it('should include document path when creating job from prose document', () => {

--- a/web/ts/pulse/inline-error.test.ts
+++ b/web/ts/pulse/inline-error.test.ts
@@ -4,7 +4,7 @@
  * Verifies that scheduling errors are displayed inline (not as toasts)
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Window } from 'happy-dom';
 
 // Set up DOM environment

--- a/web/ts/pulse/scheduling-controls.test.ts
+++ b/web/ts/pulse/scheduling-controls.test.ts
@@ -4,7 +4,7 @@
  * Tests UI state and interactions for scheduling controls
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { Window } from 'happy-dom';
 import { createSchedulingControls } from './scheduling-controls';
 import type { ScheduledJob } from './types';
@@ -15,17 +15,27 @@ globalThis.document = window.document as unknown as Document;
 globalThis.window = window as unknown as Window & typeof globalThis;
 
 // Mock API functions
-vi.mock('./api', () => ({
-  createScheduledJob: vi.fn(),
-  updateScheduledJob: vi.fn(),
-  pauseScheduledJob: vi.fn(),
-  resumeScheduledJob: vi.fn(),
-  deleteScheduledJob: vi.fn(),
+const mockCreateScheduledJob = mock(() => Promise.resolve());
+const mockUpdateScheduledJob = mock(() => Promise.resolve());
+const mockPauseScheduledJob = mock(() => Promise.resolve());
+const mockResumeScheduledJob = mock(() => Promise.resolve());
+const mockDeleteScheduledJob = mock(() => Promise.resolve());
+
+mock.module('./api', () => ({
+  createScheduledJob: mockCreateScheduledJob,
+  updateScheduledJob: mockUpdateScheduledJob,
+  pauseScheduledJob: mockPauseScheduledJob,
+  resumeScheduledJob: mockResumeScheduledJob,
+  deleteScheduledJob: mockDeleteScheduledJob,
 }));
 
 describe('Scheduling Controls UI', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockCreateScheduledJob.mockClear();
+    mockUpdateScheduledJob.mockClear();
+    mockPauseScheduledJob.mockClear();
+    mockResumeScheduledJob.mockClear();
+    mockDeleteScheduledJob.mockClear();
   });
 
   describe('Empty ATS Code Prevention', () => {
@@ -186,7 +196,7 @@ describe('Scheduling Controls UI', () => {
   describe('ATS Code Callback Pattern', () => {
     it('should call function to get fresh ATS code when needed', () => {
       let currentCode = 'ix https://example.com/api/data';
-      const getCode = vi.fn(() => currentCode);
+      const getCode = mock(() => currentCode);
 
       const controls = createSchedulingControls({
         atsCode: getCode,

--- a/web/ts/pulse/types.test.ts
+++ b/web/ts/pulse/types.test.ts
@@ -4,7 +4,7 @@
  * Covers interval formatting/parsing and type validation
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { formatInterval, parseInterval } from './types';
 
 describe('Pulse Type Utilities', () => {

--- a/web/ts/pulse/validation.test.ts
+++ b/web/ts/pulse/validation.test.ts
@@ -4,7 +4,7 @@
  * Ensures job state integrity and valid transitions
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import type { ScheduledJob, ScheduledJobState } from './types';
 
 // Validation utilities


### PR DESCRIPTION
Replace vitest imports with bun:test across all 8 test files that were
using the vitest compatibility shim. This makes the test framework
explicit and consistent with the project's actual test runner.

- Simple import replacement in 7 files
- Full mock.module() conversion in scheduling-controls.test.ts