### PR TITLE
Add WebSocket PING/PONG keepalive messages

### DIFF
--- a/am/am.go
+++ b/am/am.go
@@ -150,8 +150,22 @@ type AxConfig struct {
 
 // PluginConfig configures the domain plugin system
 type PluginConfig struct {
-	Enabled []string `mapstructure:"enabled"` // Whitelist of enabled plugins (e.g., ["code"])
-	Paths   []string `mapstructure:"paths"`   // Plugin search paths (e.g., ["~/.qntx/plugins", "./plugins"])
+	Enabled   []string              `mapstructure:"enabled"`   // Whitelist of enabled plugins (e.g., ["code"])
+	Paths     []string              `mapstructure:"paths"`     // Plugin search paths (e.g., ["~/.qntx/plugins", "./plugins"])
+	WebSocket PluginWebSocketConfig `mapstructure:"websocket"` // WebSocket configuration
+}
+
+// PluginWebSocketConfig configures WebSocket keepalive behavior
+type PluginWebSocketConfig struct {
+	Keepalive PluginKeepaliveConfig `mapstructure:"keepalive"`
+}
+
+// PluginKeepaliveConfig configures WebSocket keepalive behavior
+type PluginKeepaliveConfig struct {
+	Enabled           bool `mapstructure:"enabled"`            // Enable keepalive (default: true)
+	PingIntervalSecs  int  `mapstructure:"ping_interval_secs"` // Seconds between PING messages (default: 30)
+	PongTimeoutSecs   int  `mapstructure:"pong_timeout_secs"`  // Seconds to wait for PONG (default: 60)
+	ReconnectAttempts int  `mapstructure:"reconnect_attempts"` // Number of reconnect attempts (default: 3)
 }
 
 // File system constants

--- a/am/defaults.go
+++ b/am/defaults.go
@@ -80,6 +80,10 @@ func SetDefaults(v *viper.Viper) {
 		"~/.qntx/plugins", // User-level plugins
 		"./plugins",       // Project-level plugins
 	})
+	v.SetDefault("plugin.websocket.keepalive.enabled", true)
+	v.SetDefault("plugin.websocket.keepalive.ping_interval_secs", 30)
+	v.SetDefault("plugin.websocket.keepalive.pong_timeout_secs", 60)
+	v.SetDefault("plugin.websocket.keepalive.reconnect_attempts", 3)
 }
 
 // BindSensitiveEnvVars explicitly binds sensitive configuration to environment variables

--- a/plugin/grpc/protocol/domain.pb.go
+++ b/plugin/grpc/protocol/domain.pb.go
@@ -31,6 +31,9 @@ const (
 	WebSocketMessage_CONNECT WebSocketMessage_Type = 0
 	WebSocketMessage_DATA    WebSocketMessage_Type = 1
 	WebSocketMessage_CLOSE   WebSocketMessage_Type = 2
+	WebSocketMessage_PING    WebSocketMessage_Type = 3
+	WebSocketMessage_PONG    WebSocketMessage_Type = 4
+	WebSocketMessage_ERROR   WebSocketMessage_Type = 5
 )
 
 // Enum value maps for WebSocketMessage_Type.
@@ -39,11 +42,17 @@ var (
 		0: "CONNECT",
 		1: "DATA",
 		2: "CLOSE",
+		3: "PING",
+		4: "PONG",
+		5: "ERROR",
 	}
 	WebSocketMessage_Type_value = map[string]int32{
 		"CONNECT": 0,
 		"DATA":    1,
 		"CLOSE":   2,
+		"PING":    3,
+		"PONG":    4,
+		"ERROR":   5,
 	}
 )
 
@@ -419,8 +428,10 @@ type WebSocketMessage struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Type WebSocketMessage_Type `protobuf:"varint,1,opt,name=type,proto3,enum=protocol.WebSocketMessage_Type" json:"type,omitempty"`
-	Data []byte                `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	Type      WebSocketMessage_Type `protobuf:"varint,1,opt,name=type,proto3,enum=protocol.WebSocketMessage_Type" json:"type,omitempty"`
+	Data      []byte                `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	Headers   map[string]string     `protobuf:"bytes,3,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Timestamp int64                 `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 }
 
 func (x *WebSocketMessage) Reset() {
@@ -467,6 +478,20 @@ func (x *WebSocketMessage) GetData() []byte {
 		return x.Data
 	}
 	return nil
+}
+
+func (x *WebSocketMessage) GetHeaders() map[string]string {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+func (x *WebSocketMessage) GetTimestamp() int64 {
+	if x != nil {
+		return x.Timestamp
+	}
+	return 0
 }
 
 type HealthResponse struct {

--- a/plugin/grpc/protocol/domain.proto
+++ b/plugin/grpc/protocol/domain.proto
@@ -80,10 +80,15 @@ message WebSocketMessage {
     CONNECT = 0;
     DATA = 1;
     CLOSE = 2;
+    PING = 3;   // Client/Server can send for keepalive
+    PONG = 4;   // Response to PING
+    ERROR = 5;  // Error notification
   }
 
   Type type = 1;
   bytes data = 2;
+  map<string, string> headers = 3;  // Optional headers/metadata
+  int64 timestamp = 4;              // For latency measurement (Unix timestamp in nanoseconds)
 }
 
 message HealthResponse {

--- a/plugin/grpc/server.go
+++ b/plugin/grpc/server.go
@@ -200,8 +200,9 @@ func (s *PluginServer) HandleWebSocket(stream protocol.DomainPluginService_Handl
 			// This demonstrates bidirectional streaming working correctly
 			// Real plugins would process the data and respond appropriately
 			echoMsg := &protocol.WebSocketMessage{
-				Type: protocol.WebSocketMessage_DATA,
-				Data: msg.Data,
+				Type:      protocol.WebSocketMessage_DATA,
+				Data:      msg.Data,
+				Timestamp: msg.Timestamp,
 			}
 
 			if err := stream.Send(echoMsg); err != nil {
@@ -209,12 +210,33 @@ func (s *PluginServer) HandleWebSocket(stream protocol.DomainPluginService_Handl
 				return err
 			}
 
+		case protocol.WebSocketMessage_PING:
+			s.logger.Debug("WebSocket PING received, sending PONG")
+			// Respond with PONG, echoing back the timestamp for latency measurement
+			pongMsg := &protocol.WebSocketMessage{
+				Type:      protocol.WebSocketMessage_PONG,
+				Timestamp: msg.Timestamp,
+			}
+			if err := stream.Send(pongMsg); err != nil {
+				s.logger.Errorw("Failed to send PONG message", "error", err)
+				return err
+			}
+
+		case protocol.WebSocketMessage_PONG:
+			s.logger.Debug("WebSocket PONG received")
+			// PONG received, connection is alive
+			// Client-side keepalive handler processes latency
+
+		case protocol.WebSocketMessage_ERROR:
+			s.logger.Errorw("WebSocket ERROR received", "error", string(msg.Data))
+			// Log the error and continue, let the connection decide if it should close
+
 		case protocol.WebSocketMessage_CLOSE:
 			s.logger.Info("WebSocket CLOSE message received")
 			// Send CLOSE acknowledgment
 			closeMsg := &protocol.WebSocketMessage{
-				Type: protocol.WebSocketMessage_CLOSE,
-				Data: []byte{},
+				Type:      protocol.WebSocketMessage_CLOSE,
+				Timestamp: msg.Timestamp,
 			}
 			if err := stream.Send(closeMsg); err != nil {
 				s.logger.Errorw("Failed to send CLOSE message", "error", err)

--- a/plugin/grpc/websocket_keepalive.go
+++ b/plugin/grpc/websocket_keepalive.go
@@ -1,0 +1,408 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/teranos/QNTX/plugin/grpc/protocol"
+	"go.uber.org/zap"
+)
+
+// Default keepalive configuration values
+const (
+	DefaultPingInterval      = 30 * time.Second
+	DefaultPongTimeout       = 60 * time.Second
+	DefaultReconnectAttempts = 3
+	DefaultReconnectBaseWait = time.Second
+)
+
+// KeepaliveConfig contains configuration for WebSocket keepalive behavior
+type KeepaliveConfig struct {
+	// Enabled determines if keepalive is active
+	Enabled bool
+
+	// PingInterval is how often to send PING messages
+	PingInterval time.Duration
+
+	// PongTimeout is how long to wait for PONG before considering connection dead
+	PongTimeout time.Duration
+
+	// ReconnectAttempts is the number of reconnect attempts on connection loss
+	ReconnectAttempts int
+
+	// ReconnectBaseWait is the base wait time for exponential backoff reconnection
+	ReconnectBaseWait time.Duration
+}
+
+// DefaultKeepaliveConfig returns the default keepalive configuration
+func DefaultKeepaliveConfig() KeepaliveConfig {
+	return KeepaliveConfig{
+		Enabled:           true,
+		PingInterval:      DefaultPingInterval,
+		PongTimeout:       DefaultPongTimeout,
+		ReconnectAttempts: DefaultReconnectAttempts,
+		ReconnectBaseWait: DefaultReconnectBaseWait,
+	}
+}
+
+// NewKeepaliveConfigFromSettings creates a KeepaliveConfig from configuration values.
+// This is useful for creating config from am.PluginKeepaliveConfig settings.
+// Pass 0 for any value to use defaults.
+func NewKeepaliveConfigFromSettings(enabled bool, pingIntervalSecs, pongTimeoutSecs, reconnectAttempts int) KeepaliveConfig {
+	config := DefaultKeepaliveConfig()
+	config.Enabled = enabled
+
+	if pingIntervalSecs > 0 {
+		config.PingInterval = time.Duration(pingIntervalSecs) * time.Second
+	}
+	if pongTimeoutSecs > 0 {
+		config.PongTimeout = time.Duration(pongTimeoutSecs) * time.Second
+	}
+	if reconnectAttempts > 0 {
+		config.ReconnectAttempts = reconnectAttempts
+	}
+
+	return config
+}
+
+// KeepaliveMetrics tracks connection health metrics
+type KeepaliveMetrics struct {
+	// mu protects the metrics
+	mu sync.RWMutex
+
+	// latencies stores recent ping/pong latencies for averaging
+	latencies []time.Duration
+
+	// maxLatencySamples is the maximum number of latency samples to keep
+	maxLatencySamples int
+
+	// totalPings is the total number of pings sent
+	totalPings uint64
+
+	// totalPongs is the total number of pongs received
+	totalPongs uint64
+
+	// reconnectCount is the number of reconnection attempts
+	reconnectCount uint64
+
+	// connectionUptime tracks when the connection was established
+	connectionStart time.Time
+
+	// lastPingTime is when the last ping was sent
+	lastPingTime time.Time
+
+	// lastPongTime is when the last pong was received
+	lastPongTime time.Time
+}
+
+// NewKeepaliveMetrics creates a new KeepaliveMetrics instance
+func NewKeepaliveMetrics() *KeepaliveMetrics {
+	return &KeepaliveMetrics{
+		latencies:         make([]time.Duration, 0, 100),
+		maxLatencySamples: 100,
+		connectionStart:   time.Now(),
+	}
+}
+
+// RecordPing records that a ping was sent
+func (m *KeepaliveMetrics) RecordPing() {
+	atomic.AddUint64(&m.totalPings, 1)
+	m.mu.Lock()
+	m.lastPingTime = time.Now()
+	m.mu.Unlock()
+}
+
+// RecordPong records that a pong was received with latency
+func (m *KeepaliveMetrics) RecordPong(latency time.Duration) {
+	atomic.AddUint64(&m.totalPongs, 1)
+	m.mu.Lock()
+	m.lastPongTime = time.Now()
+	m.latencies = append(m.latencies, latency)
+	if len(m.latencies) > m.maxLatencySamples {
+		m.latencies = m.latencies[1:]
+	}
+	m.mu.Unlock()
+}
+
+// RecordReconnect records a reconnection attempt
+func (m *KeepaliveMetrics) RecordReconnect() {
+	atomic.AddUint64(&m.reconnectCount, 1)
+}
+
+// ResetConnectionStart resets the connection start time
+func (m *KeepaliveMetrics) ResetConnectionStart() {
+	m.mu.Lock()
+	m.connectionStart = time.Now()
+	m.mu.Unlock()
+}
+
+// GetAverageLatency returns the average ping/pong latency
+func (m *KeepaliveMetrics) GetAverageLatency() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.latencies) == 0 {
+		return 0
+	}
+
+	var total time.Duration
+	for _, l := range m.latencies {
+		total += l
+	}
+	return total / time.Duration(len(m.latencies))
+}
+
+// GetConnectionUptime returns how long the connection has been up
+func (m *KeepaliveMetrics) GetConnectionUptime() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return time.Since(m.connectionStart)
+}
+
+// GetTotalPings returns the total number of pings sent
+func (m *KeepaliveMetrics) GetTotalPings() uint64 {
+	return atomic.LoadUint64(&m.totalPings)
+}
+
+// GetTotalPongs returns the total number of pongs received
+func (m *KeepaliveMetrics) GetTotalPongs() uint64 {
+	return atomic.LoadUint64(&m.totalPongs)
+}
+
+// GetReconnectCount returns the number of reconnection attempts
+func (m *KeepaliveMetrics) GetReconnectCount() uint64 {
+	return atomic.LoadUint64(&m.reconnectCount)
+}
+
+// GetLastPingTime returns when the last ping was sent
+func (m *KeepaliveMetrics) GetLastPingTime() time.Time {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.lastPingTime
+}
+
+// GetLastPongTime returns when the last pong was received
+func (m *KeepaliveMetrics) GetLastPongTime() time.Time {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.lastPongTime
+}
+
+// KeepaliveHandler manages the keepalive mechanism for a WebSocket connection
+type KeepaliveHandler struct {
+	config  KeepaliveConfig
+	metrics *KeepaliveMetrics
+	logger  *zap.SugaredLogger
+
+	// mu protects state changes
+	mu sync.Mutex
+
+	// lastPong tracks when the last PONG was received
+	lastPong time.Time
+
+	// running indicates if the keepalive loop is active
+	running bool
+
+	// cancel is used to stop the keepalive loop
+	cancel context.CancelFunc
+}
+
+// NewKeepaliveHandler creates a new KeepaliveHandler with the given configuration
+func NewKeepaliveHandler(config KeepaliveConfig, logger *zap.SugaredLogger) *KeepaliveHandler {
+	return &KeepaliveHandler{
+		config:   config,
+		metrics:  NewKeepaliveMetrics(),
+		logger:   logger,
+		lastPong: time.Now(),
+	}
+}
+
+// Metrics returns the keepalive metrics
+func (h *KeepaliveHandler) Metrics() *KeepaliveMetrics {
+	return h.metrics
+}
+
+// Start begins the keepalive loop, sending periodic PINGs
+// sendPing is called to send a PING message and should return an error if sending fails
+func (h *KeepaliveHandler) Start(ctx context.Context, sendPing func(timestamp int64) error) {
+	if !h.config.Enabled {
+		h.logger.Debug("Keepalive disabled, not starting")
+		return
+	}
+
+	h.mu.Lock()
+	if h.running {
+		h.mu.Unlock()
+		return
+	}
+
+	ctx, h.cancel = context.WithCancel(ctx)
+	h.running = true
+	h.lastPong = time.Now()
+	h.mu.Unlock()
+
+	h.logger.Infow("Starting keepalive handler",
+		"ping_interval", h.config.PingInterval,
+		"pong_timeout", h.config.PongTimeout,
+	)
+
+	go h.keepaliveLoop(ctx, sendPing)
+}
+
+// Stop stops the keepalive loop
+func (h *KeepaliveHandler) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.running {
+		return
+	}
+
+	h.logger.Debug("Stopping keepalive handler")
+	if h.cancel != nil {
+		h.cancel()
+	}
+	h.running = false
+}
+
+// IsRunning returns whether the keepalive loop is active
+func (h *KeepaliveHandler) IsRunning() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.running
+}
+
+// HandlePong processes a PONG message
+func (h *KeepaliveHandler) HandlePong(msg *protocol.WebSocketMessage) {
+	h.mu.Lock()
+	h.lastPong = time.Now()
+	h.mu.Unlock()
+
+	// Calculate latency if timestamp is present
+	if msg.Timestamp > 0 {
+		sentTime := time.Unix(0, msg.Timestamp)
+		latency := time.Since(sentTime)
+		h.metrics.RecordPong(latency)
+		h.logger.Debugw("PONG received", "latency", latency)
+	} else {
+		h.metrics.RecordPong(0)
+		h.logger.Debug("PONG received (no timestamp)")
+	}
+}
+
+// HandlePing processes a PING message and returns a PONG response
+func (h *KeepaliveHandler) HandlePing(msg *protocol.WebSocketMessage) *protocol.WebSocketMessage {
+	h.logger.Debug("PING received, sending PONG")
+	return &protocol.WebSocketMessage{
+		Type:      protocol.WebSocketMessage_PONG,
+		Timestamp: msg.Timestamp, // Echo back the timestamp for latency calculation
+	}
+}
+
+// CheckTimeout returns true if the connection should be considered dead
+func (h *KeepaliveHandler) CheckTimeout() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if time.Since(h.lastPong) > h.config.PongTimeout {
+		return true
+	}
+	return false
+}
+
+// keepaliveLoop runs the periodic PING sending
+func (h *KeepaliveHandler) keepaliveLoop(ctx context.Context, sendPing func(timestamp int64) error) {
+	ticker := time.NewTicker(h.config.PingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logger.Debug("Keepalive loop stopped")
+			return
+
+		case <-ticker.C:
+			// Check for pong timeout
+			if h.CheckTimeout() {
+				h.logger.Warn("WebSocket pong timeout, connection may be stale")
+				// Continue sending pings in case the connection recovers
+			}
+
+			// Send PING with current timestamp
+			timestamp := time.Now().UnixNano()
+			h.metrics.RecordPing()
+
+			if err := sendPing(timestamp); err != nil {
+				h.logger.Warnw("Failed to send PING", "error", err)
+				// Don't return, keep trying
+			} else {
+				h.logger.Debug("PING sent")
+			}
+		}
+	}
+}
+
+// ConnectWithRetry attempts to establish a connection with exponential backoff
+func (h *KeepaliveHandler) ConnectWithRetry(ctx context.Context, connect func() error) error {
+	var lastErr error
+
+	for attempt := 0; attempt < h.config.ReconnectAttempts; attempt++ {
+		h.metrics.RecordReconnect()
+
+		if err := connect(); err == nil {
+			h.metrics.ResetConnectionStart()
+			h.logger.Infow("Connection established",
+				"attempt", attempt+1,
+				"total_attempts", h.config.ReconnectAttempts,
+			)
+			return nil
+		} else {
+			lastErr = err
+			h.logger.Warnw("Connection attempt failed",
+				"attempt", attempt+1,
+				"total_attempts", h.config.ReconnectAttempts,
+				"error", err,
+			)
+		}
+
+		// Calculate backoff with exponential increase
+		backoff := h.config.ReconnectBaseWait * time.Duration(math.Pow(2, float64(attempt)))
+
+		// Wait with context cancellation support
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+			// Continue to next attempt
+		}
+	}
+
+	return fmt.Errorf("failed after %d reconnect attempts: %w", h.config.ReconnectAttempts, lastErr)
+}
+
+// HandleMessage processes incoming WebSocket messages for keepalive-related types
+// Returns the PONG response for PING messages, nil for other types
+// Returns an error for ERROR message types
+func (h *KeepaliveHandler) HandleMessage(msg *protocol.WebSocketMessage) (*protocol.WebSocketMessage, error) {
+	switch msg.Type {
+	case protocol.WebSocketMessage_PING:
+		return h.HandlePing(msg), nil
+
+	case protocol.WebSocketMessage_PONG:
+		h.HandlePong(msg)
+		return nil, nil
+
+	case protocol.WebSocketMessage_ERROR:
+		errMsg := string(msg.Data)
+		h.logger.Errorw("WebSocket error received", "error", errMsg)
+		return nil, fmt.Errorf("websocket error: %s", errMsg)
+
+	default:
+		// Not a keepalive message, let caller handle it
+		return nil, nil
+	}
+}

--- a/plugin/grpc/websocket_keepalive_test.go
+++ b/plugin/grpc/websocket_keepalive_test.go
@@ -1,0 +1,651 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teranos/QNTX/plugin/grpc/protocol"
+	"go.uber.org/zap/zaptest"
+)
+
+// =============================================================================
+// KeepaliveConfig Tests
+// =============================================================================
+
+func TestDefaultKeepaliveConfig(t *testing.T) {
+	config := DefaultKeepaliveConfig()
+
+	assert.True(t, config.Enabled)
+	assert.Equal(t, DefaultPingInterval, config.PingInterval)
+	assert.Equal(t, DefaultPongTimeout, config.PongTimeout)
+	assert.Equal(t, DefaultReconnectAttempts, config.ReconnectAttempts)
+	assert.Equal(t, DefaultReconnectBaseWait, config.ReconnectBaseWait)
+}
+
+func TestNewKeepaliveConfigFromSettings(t *testing.T) {
+	tests := []struct {
+		name              string
+		enabled           bool
+		pingIntervalSecs  int
+		pongTimeoutSecs   int
+		reconnectAttempts int
+		wantPingInterval  time.Duration
+		wantPongTimeout   time.Duration
+		wantReconnect     int
+	}{
+		{
+			name:              "all defaults (zeros)",
+			enabled:           true,
+			pingIntervalSecs:  0,
+			pongTimeoutSecs:   0,
+			reconnectAttempts: 0,
+			wantPingInterval:  DefaultPingInterval,
+			wantPongTimeout:   DefaultPongTimeout,
+			wantReconnect:     DefaultReconnectAttempts,
+		},
+		{
+			name:              "custom values",
+			enabled:           false,
+			pingIntervalSecs:  15,
+			pongTimeoutSecs:   45,
+			reconnectAttempts: 5,
+			wantPingInterval:  15 * time.Second,
+			wantPongTimeout:   45 * time.Second,
+			wantReconnect:     5,
+		},
+		{
+			name:              "mixed custom and defaults",
+			enabled:           true,
+			pingIntervalSecs:  20,
+			pongTimeoutSecs:   0,
+			reconnectAttempts: 0,
+			wantPingInterval:  20 * time.Second,
+			wantPongTimeout:   DefaultPongTimeout,
+			wantReconnect:     DefaultReconnectAttempts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := NewKeepaliveConfigFromSettings(
+				tt.enabled,
+				tt.pingIntervalSecs,
+				tt.pongTimeoutSecs,
+				tt.reconnectAttempts,
+			)
+
+			assert.Equal(t, tt.enabled, config.Enabled)
+			assert.Equal(t, tt.wantPingInterval, config.PingInterval)
+			assert.Equal(t, tt.wantPongTimeout, config.PongTimeout)
+			assert.Equal(t, tt.wantReconnect, config.ReconnectAttempts)
+		})
+	}
+}
+
+// =============================================================================
+// KeepaliveMetrics Tests
+// =============================================================================
+
+func TestKeepaliveMetrics_RecordPing(t *testing.T) {
+	metrics := NewKeepaliveMetrics()
+
+	assert.Equal(t, uint64(0), metrics.GetTotalPings())
+
+	metrics.RecordPing()
+	assert.Equal(t, uint64(1), metrics.GetTotalPings())
+
+	metrics.RecordPing()
+	metrics.RecordPing()
+	assert.Equal(t, uint64(3), metrics.GetTotalPings())
+
+	// Verify last ping time is updated
+	assert.False(t, metrics.GetLastPingTime().IsZero())
+}
+
+func TestKeepaliveMetrics_RecordPong(t *testing.T) {
+	metrics := NewKeepaliveMetrics()
+
+	assert.Equal(t, uint64(0), metrics.GetTotalPongs())
+	assert.Equal(t, time.Duration(0), metrics.GetAverageLatency())
+
+	metrics.RecordPong(100 * time.Millisecond)
+	assert.Equal(t, uint64(1), metrics.GetTotalPongs())
+	assert.Equal(t, 100*time.Millisecond, metrics.GetAverageLatency())
+
+	metrics.RecordPong(200 * time.Millisecond)
+	assert.Equal(t, uint64(2), metrics.GetTotalPongs())
+	assert.Equal(t, 150*time.Millisecond, metrics.GetAverageLatency())
+
+	// Verify last pong time is updated
+	assert.False(t, metrics.GetLastPongTime().IsZero())
+}
+
+func TestKeepaliveMetrics_RecordReconnect(t *testing.T) {
+	metrics := NewKeepaliveMetrics()
+
+	assert.Equal(t, uint64(0), metrics.GetReconnectCount())
+
+	metrics.RecordReconnect()
+	assert.Equal(t, uint64(1), metrics.GetReconnectCount())
+}
+
+func TestKeepaliveMetrics_ConnectionUptime(t *testing.T) {
+	metrics := NewKeepaliveMetrics()
+
+	// Initial uptime should be very small
+	time.Sleep(10 * time.Millisecond)
+	uptime := metrics.GetConnectionUptime()
+	assert.True(t, uptime >= 10*time.Millisecond)
+
+	// Reset and verify
+	time.Sleep(5 * time.Millisecond)
+	metrics.ResetConnectionStart()
+	time.Sleep(5 * time.Millisecond)
+	newUptime := metrics.GetConnectionUptime()
+	assert.True(t, newUptime < uptime)
+}
+
+func TestKeepaliveMetrics_LatencySampleLimit(t *testing.T) {
+	metrics := NewKeepaliveMetrics()
+
+	// Add more samples than the limit
+	for i := 0; i < 150; i++ {
+		metrics.RecordPong(time.Duration(i) * time.Millisecond)
+	}
+
+	// Should still work and not panic
+	assert.Equal(t, uint64(150), metrics.GetTotalPongs())
+
+	// Average should be based on last 100 samples (50-149)
+	// Average of 50..149 = (50+149)/2 = 99.5ms
+	avg := metrics.GetAverageLatency()
+	assert.True(t, avg > 90*time.Millisecond && avg < 110*time.Millisecond)
+}
+
+func TestKeepaliveMetrics_ConcurrentAccess(t *testing.T) {
+	metrics := NewKeepaliveMetrics()
+	var wg sync.WaitGroup
+
+	// Concurrent pings
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			metrics.RecordPing()
+		}()
+	}
+
+	// Concurrent pongs
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(latency time.Duration) {
+			defer wg.Done()
+			metrics.RecordPong(latency)
+		}(time.Duration(i) * time.Millisecond)
+	}
+
+	// Concurrent reads
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = metrics.GetTotalPings()
+			_ = metrics.GetTotalPongs()
+			_ = metrics.GetAverageLatency()
+			_ = metrics.GetConnectionUptime()
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, uint64(100), metrics.GetTotalPings())
+	assert.Equal(t, uint64(100), metrics.GetTotalPongs())
+}
+
+// =============================================================================
+// KeepaliveHandler Tests
+// =============================================================================
+
+func TestKeepaliveHandler_StartStop(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		Enabled:      true,
+		PingInterval: 50 * time.Millisecond,
+		PongTimeout:  100 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	var pingCount int32
+	sendPing := func(timestamp int64) error {
+		atomic.AddInt32(&pingCount, 1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start keepalive
+	handler.Start(ctx, sendPing)
+	assert.True(t, handler.IsRunning())
+
+	// Wait for a few pings
+	time.Sleep(150 * time.Millisecond)
+
+	// Stop keepalive
+	handler.Stop()
+	assert.False(t, handler.IsRunning())
+
+	// Verify some pings were sent
+	assert.True(t, atomic.LoadInt32(&pingCount) >= 2)
+}
+
+func TestKeepaliveHandler_DisabledDoesNotStart(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		Enabled:      false,
+		PingInterval: 10 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	var pingCount int32
+	sendPing := func(timestamp int64) error {
+		atomic.AddInt32(&pingCount, 1)
+		return nil
+	}
+
+	handler.Start(context.Background(), sendPing)
+
+	// Should not be running
+	assert.False(t, handler.IsRunning())
+
+	time.Sleep(50 * time.Millisecond)
+
+	// No pings should have been sent
+	assert.Equal(t, int32(0), atomic.LoadInt32(&pingCount))
+}
+
+func TestKeepaliveHandler_HandlePing(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	handler := NewKeepaliveHandler(DefaultKeepaliveConfig(), logger)
+
+	timestamp := time.Now().UnixNano()
+	pingMsg := &protocol.WebSocketMessage{
+		Type:      protocol.WebSocketMessage_PING,
+		Timestamp: timestamp,
+	}
+
+	pongMsg := handler.HandlePing(pingMsg)
+
+	require.NotNil(t, pongMsg)
+	assert.Equal(t, protocol.WebSocketMessage_PONG, pongMsg.Type)
+	assert.Equal(t, timestamp, pongMsg.Timestamp)
+}
+
+func TestKeepaliveHandler_HandlePong(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	handler := NewKeepaliveHandler(DefaultKeepaliveConfig(), logger)
+
+	// Send a pong with timestamp from 100ms ago
+	sentTime := time.Now().Add(-100 * time.Millisecond)
+	pongMsg := &protocol.WebSocketMessage{
+		Type:      protocol.WebSocketMessage_PONG,
+		Timestamp: sentTime.UnixNano(),
+	}
+
+	handler.HandlePong(pongMsg)
+
+	// Verify metrics recorded
+	metrics := handler.Metrics()
+	assert.Equal(t, uint64(1), metrics.GetTotalPongs())
+
+	// Latency should be approximately 100ms
+	latency := metrics.GetAverageLatency()
+	assert.True(t, latency >= 90*time.Millisecond && latency <= 200*time.Millisecond)
+}
+
+func TestKeepaliveHandler_HandlePongWithoutTimestamp(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	handler := NewKeepaliveHandler(DefaultKeepaliveConfig(), logger)
+
+	pongMsg := &protocol.WebSocketMessage{
+		Type:      protocol.WebSocketMessage_PONG,
+		Timestamp: 0, // No timestamp
+	}
+
+	handler.HandlePong(pongMsg)
+
+	// Should still record pong
+	metrics := handler.Metrics()
+	assert.Equal(t, uint64(1), metrics.GetTotalPongs())
+	assert.Equal(t, time.Duration(0), metrics.GetAverageLatency())
+}
+
+func TestKeepaliveHandler_HandleMessage(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	handler := NewKeepaliveHandler(DefaultKeepaliveConfig(), logger)
+
+	tests := []struct {
+		name        string
+		msg         *protocol.WebSocketMessage
+		wantReply   bool
+		wantErr     bool
+		wantErrMsg  string
+		checkMetric func(t *testing.T, m *KeepaliveMetrics)
+	}{
+		{
+			name: "PING returns PONG",
+			msg: &protocol.WebSocketMessage{
+				Type:      protocol.WebSocketMessage_PING,
+				Timestamp: time.Now().UnixNano(),
+			},
+			wantReply: true,
+			wantErr:   false,
+		},
+		{
+			name: "PONG updates metrics",
+			msg: &protocol.WebSocketMessage{
+				Type:      protocol.WebSocketMessage_PONG,
+				Timestamp: time.Now().Add(-50 * time.Millisecond).UnixNano(),
+			},
+			wantReply: false,
+			wantErr:   false,
+			checkMetric: func(t *testing.T, m *KeepaliveMetrics) {
+				assert.True(t, m.GetTotalPongs() > 0)
+			},
+		},
+		{
+			name: "ERROR returns error",
+			msg: &protocol.WebSocketMessage{
+				Type: protocol.WebSocketMessage_ERROR,
+				Data: []byte("connection reset"),
+			},
+			wantReply:  false,
+			wantErr:    true,
+			wantErrMsg: "websocket error: connection reset",
+		},
+		{
+			name: "DATA is ignored",
+			msg: &protocol.WebSocketMessage{
+				Type: protocol.WebSocketMessage_DATA,
+				Data: []byte("hello"),
+			},
+			wantReply: false,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reply, err := handler.HandleMessage(tt.msg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.wantReply {
+				require.NotNil(t, reply)
+				assert.Equal(t, protocol.WebSocketMessage_PONG, reply.Type)
+			} else {
+				assert.Nil(t, reply)
+			}
+
+			if tt.checkMetric != nil {
+				tt.checkMetric(t, handler.Metrics())
+			}
+		})
+	}
+}
+
+func TestKeepaliveHandler_CheckTimeout(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		Enabled:     true,
+		PongTimeout: 50 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	// Initially not timed out
+	assert.False(t, handler.CheckTimeout())
+
+	// Wait past timeout
+	time.Sleep(60 * time.Millisecond)
+	assert.True(t, handler.CheckTimeout())
+
+	// Simulate receiving a pong
+	handler.HandlePong(&protocol.WebSocketMessage{
+		Type:      protocol.WebSocketMessage_PONG,
+		Timestamp: time.Now().UnixNano(),
+	})
+
+	// Should not be timed out anymore
+	assert.False(t, handler.CheckTimeout())
+}
+
+func TestKeepaliveHandler_ConnectWithRetry_Success(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		ReconnectAttempts: 3,
+		ReconnectBaseWait: 10 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	var attempts int32
+	connect := func() error {
+		atomic.AddInt32(&attempts, 1)
+		return nil // Success on first attempt
+	}
+
+	err := handler.ConnectWithRetry(context.Background(), connect)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+	assert.Equal(t, uint64(1), handler.Metrics().GetReconnectCount())
+}
+
+func TestKeepaliveHandler_ConnectWithRetry_SuccessAfterFailures(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		ReconnectAttempts: 5,
+		ReconnectBaseWait: 5 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	var attempts int32
+	connect := func() error {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			return errors.New("connection failed")
+		}
+		return nil // Success on third attempt
+	}
+
+	err := handler.ConnectWithRetry(context.Background(), connect)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestKeepaliveHandler_ConnectWithRetry_AllFail(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		ReconnectAttempts: 3,
+		ReconnectBaseWait: 5 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	var attempts int32
+	connect := func() error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("connection failed")
+	}
+
+	err := handler.ConnectWithRetry(context.Background(), connect)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after 3 reconnect attempts")
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestKeepaliveHandler_ConnectWithRetry_ContextCanceled(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		ReconnectAttempts: 10,
+		ReconnectBaseWait: 100 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var attempts int32
+	connect := func() error {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 2 {
+			cancel() // Cancel after second attempt
+		}
+		return errors.New("connection failed")
+	}
+
+	err := handler.ConnectWithRetry(ctx, connect)
+	require.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+
+	// Should have stopped after context was canceled
+	assert.True(t, atomic.LoadInt32(&attempts) <= 3)
+}
+
+func TestKeepaliveHandler_MultipleStartStopCycles(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		Enabled:      true,
+		PingInterval: 20 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	sendPing := func(timestamp int64) error {
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// Multiple start/stop cycles
+	for i := 0; i < 3; i++ {
+		handler.Start(ctx, sendPing)
+		assert.True(t, handler.IsRunning())
+
+		time.Sleep(30 * time.Millisecond)
+
+		handler.Stop()
+		assert.False(t, handler.IsRunning())
+	}
+}
+
+func TestKeepaliveHandler_DoubleStartIgnored(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		Enabled:      true,
+		PingInterval: 50 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	var pingCount int32
+	sendPing := func(timestamp int64) error {
+		atomic.AddInt32(&pingCount, 1)
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// Start twice
+	handler.Start(ctx, sendPing)
+	handler.Start(ctx, sendPing)
+
+	time.Sleep(75 * time.Millisecond)
+
+	handler.Stop()
+
+	// Should only have one set of pings (not doubled)
+	count := atomic.LoadInt32(&pingCount)
+	assert.True(t, count >= 1 && count <= 3)
+}
+
+func TestKeepaliveHandler_DoubleStopSafe(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	handler := NewKeepaliveHandler(DefaultKeepaliveConfig(), logger)
+
+	sendPing := func(timestamp int64) error {
+		return nil
+	}
+
+	handler.Start(context.Background(), sendPing)
+	handler.Stop()
+	handler.Stop() // Should not panic
+
+	assert.False(t, handler.IsRunning())
+}
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+func TestKeepaliveHandler_Integration_PingPongFlow(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	config := KeepaliveConfig{
+		Enabled:      true,
+		PingInterval: 20 * time.Millisecond,
+		PongTimeout:  100 * time.Millisecond,
+	}
+
+	handler := NewKeepaliveHandler(config, logger)
+
+	// Channel to receive pings
+	pingCh := make(chan int64, 10)
+
+	sendPing := func(timestamp int64) error {
+		pingCh <- timestamp
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handler.Start(ctx, sendPing)
+
+	// Simulate receiving pongs for sent pings
+	go func() {
+		for timestamp := range pingCh {
+			// Small delay to simulate network latency
+			time.Sleep(5 * time.Millisecond)
+			handler.HandlePong(&protocol.WebSocketMessage{
+				Type:      protocol.WebSocketMessage_PONG,
+				Timestamp: timestamp,
+			})
+		}
+	}()
+
+	// Let it run for a bit
+	time.Sleep(100 * time.Millisecond)
+
+	handler.Stop()
+	close(pingCh)
+
+	// Verify metrics
+	metrics := handler.Metrics()
+	assert.True(t, metrics.GetTotalPings() >= 3)
+	assert.True(t, metrics.GetTotalPongs() >= 2)
+	assert.True(t, metrics.GetAverageLatency() > 0)
+}


### PR DESCRIPTION
Implement keepalive functionality for WebSocket connections to detect stale connections and maintain long-lived sessions:

- Extend protocol with PING, PONG, ERROR message types and timestamp field
- Add KeepaliveHandler with configurable ping interval and pong timeout
- Implement auto-reconnect with exponential backoff
- Add connection health metrics (latency, uptime, ping/pong counts)
- Add configuration in am package for keepalive settings
- Include comprehensive tests for keepalive mechanism

Configuration options (in am.toml):
  plugin.websocket.keepalive.enabled = true plugin.websocket.keepalive.ping_interval_secs = 30 plugin.websocket.keepalive.pong_timeout_secs = 60 plugin.websocket.keepalive.reconnect_attempts = 3