### PR TITLE
Fix DRY violation: use canonical ats.IndividualClaim

### DIFF
--- a/ats/ax/classification/classifier.go
+++ b/ats/ax/classification/classifier.go
@@ -3,6 +3,7 @@ package classification
 import (
 	"time"
 
+	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/types"
 )
 
@@ -29,7 +30,7 @@ func NewSmartClassifier(config TemporalConfig) *SmartClassifier {
 }
 
 // ClassifyConflicts performs smart classification on a set of claims
-func (sc *SmartClassifier) ClassifyConflicts(claimGroups map[string][]IndividualClaim) ClassificationResult {
+func (sc *SmartClassifier) ClassifyConflicts(claimGroups map[string][]ats.IndividualClaim) ClassificationResult {
 	var conflicts []AdvancedConflict
 	autoResolved := 0
 	reviewRequired := 0
@@ -60,18 +61,8 @@ func (sc *SmartClassifier) ClassifyConflicts(claimGroups map[string][]Individual
 	}
 }
 
-// IndividualClaim represents a single claim from cartesian expansion
-type IndividualClaim struct {
-	Subject   string
-	Predicate string
-	Context   string
-	Actor     string
-	Timestamp time.Time
-	SourceAs  types.As
-}
-
 // classifySingleConflict classifies a single conflict situation
-func (sc *SmartClassifier) classifySingleConflict(claimKey string, claims []IndividualClaim) AdvancedConflict {
+func (sc *SmartClassifier) classifySingleConflict(claimKey string, claims []ats.IndividualClaim) AdvancedConflict {
 	// Convert to ClaimWithTiming for analysis
 	claimsWithTiming := make([]ClaimWithTiming, len(claims))
 	for i, claim := range claims {
@@ -120,7 +111,7 @@ func (sc *SmartClassifier) classifySingleConflict(claimKey string, claims []Indi
 }
 
 // determineResolutionType determines the type of resolution needed
-func (sc *SmartClassifier) determineResolutionType(claims []IndividualClaim) ResolutionType {
+func (sc *SmartClassifier) determineResolutionType(claims []ats.IndividualClaim) ResolutionType {
 	// Check for same actor evolution
 	if sc.isSameActorEvolution(claims) {
 		return ResolutionEvolution
@@ -146,7 +137,7 @@ func (sc *SmartClassifier) determineResolutionType(claims []IndividualClaim) Res
 }
 
 // isSameActorEvolution checks if claims represent evolution by same actor
-func (sc *SmartClassifier) isSameActorEvolution(claims []IndividualClaim) bool {
+func (sc *SmartClassifier) isSameActorEvolution(claims []ats.IndividualClaim) bool {
 	if len(claims) < 2 {
 		return false
 	}
@@ -186,7 +177,7 @@ func (sc *SmartClassifier) isSameActorEvolution(claims []IndividualClaim) bool {
 }
 
 // isSimultaneousVerification checks if claims are simultaneous verification
-func (sc *SmartClassifier) isSimultaneousVerification(claims []IndividualClaim) bool {
+func (sc *SmartClassifier) isSimultaneousVerification(claims []ats.IndividualClaim) bool {
 	if len(claims) < 2 {
 		return false
 	}
@@ -211,7 +202,7 @@ func (sc *SmartClassifier) isSimultaneousVerification(claims []IndividualClaim) 
 }
 
 // isDifferentContexts checks if claims are about different contexts
-func (sc *SmartClassifier) isDifferentContexts(claims []IndividualClaim) bool {
+func (sc *SmartClassifier) isDifferentContexts(claims []ats.IndividualClaim) bool {
 	contexts := make(map[string]bool)
 	for _, claim := range claims {
 		contexts[claim.Context] = true
@@ -220,7 +211,7 @@ func (sc *SmartClassifier) isDifferentContexts(claims []IndividualClaim) bool {
 }
 
 // hasHumanSupersession checks if human operator overrides other actors
-func (sc *SmartClassifier) hasHumanSupersession(claims []IndividualClaim) bool {
+func (sc *SmartClassifier) hasHumanSupersession(claims []ats.IndividualClaim) bool {
 	hasHuman := false
 	hasNonHuman := false
 
@@ -256,7 +247,7 @@ func (sc *SmartClassifier) determineStrategy(resType ResolutionType, confidence 
 }
 
 // analyzeTemporalPattern analyzes temporal patterns in claims
-func (sc *SmartClassifier) analyzeTemporalPattern(claims []IndividualClaim) string {
+func (sc *SmartClassifier) analyzeTemporalPattern(claims []ats.IndividualClaim) string {
 	var timings []ClaimTiming
 	for _, claim := range claims {
 		timings = append(timings, ClaimTiming{
@@ -271,7 +262,7 @@ func (sc *SmartClassifier) analyzeTemporalPattern(claims []IndividualClaim) stri
 }
 
 // createActorHierarchy creates a hierarchy of actors by credibility
-func (sc *SmartClassifier) createActorHierarchy(claims []IndividualClaim) []ActorRanking {
+func (sc *SmartClassifier) createActorHierarchy(claims []ats.IndividualClaim) []ActorRanking {
 	var actors []string
 	for _, claim := range claims {
 		actors = append(actors, claim.Actor)
@@ -293,7 +284,7 @@ func (sc *SmartClassifier) createActorHierarchy(claims []IndividualClaim) []Acto
 }
 
 // getUniqueSourceAttestations extracts unique source attestations
-func (sc *SmartClassifier) getUniqueSourceAttestations(claims []IndividualClaim) []types.As {
+func (sc *SmartClassifier) getUniqueSourceAttestations(claims []ats.IndividualClaim) []types.As {
 	seen := make(map[string]bool)
 	var attestations []types.As
 

--- a/ats/ax/classification/classifier_test.go
+++ b/ats/ax/classification/classifier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/types"
 )
 
@@ -17,7 +18,7 @@ func TestSmartClassifier_EvolutionDetection(t *testing.T) {
 	classifier := NewSmartClassifier(config)
 
 	// NEO's progression from awakening to The One - classic evolution pattern
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "NEO",
 			Predicate: "programmer",
@@ -57,7 +58,7 @@ func TestSmartClassifier_SimultaneousVerification(t *testing.T) {
 
 	now := time.Now()
 	// TRINITY's pilot skills verified by multiple independent sources
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "TRINITY",
 			Predicate: "pilot",
@@ -96,7 +97,7 @@ func TestSmartClassifier_HumanSupersession(t *testing.T) {
 	classifier := NewSmartClassifier(config)
 
 	// Morpheus (human) overrides automated Matrix classification
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "TANK",
 			Predicate: "operator",
@@ -135,7 +136,7 @@ func TestSmartClassifier_DifferentContexts(t *testing.T) {
 	classifier := NewSmartClassifier(config)
 
 	// NIOBE holds different roles in different contexts - both valid
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "NIOBE",
 			Predicate: "captain",
@@ -175,7 +176,7 @@ func TestSmartClassifier_RequiresReview(t *testing.T) {
 
 	// CYPHER's loyalty: demonstrates why decentralized verification matters
 	// - untrusted sources create ambiguity that requires human judgment
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "CYPHER",
 			Predicate: "resistance_member",
@@ -211,7 +212,7 @@ func TestSmartClassifier_ConfidenceScoring(t *testing.T) {
 	classifier := NewSmartClassifier(config)
 
 	// High confidence: LINK's skills verified by multiple trusted sources
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "LINK",
 			Predicate: "operator",
@@ -237,7 +238,7 @@ func TestSmartClassifier_ConfidenceScoring(t *testing.T) {
 	}
 
 	// Low confidence: old data from unverified Matrix surveillance
-	lowConfidenceClaims := []IndividualClaim{
+	lowConfidenceClaims := []ats.IndividualClaim{
 		{
 			Subject:   "DOZER",
 			Predicate: "engineer",
@@ -260,7 +261,7 @@ func TestSmartClassifier_ActorHierarchy(t *testing.T) {
 	classifier := NewSmartClassifier(config)
 
 	// ZEE's profession assessment from different actor types
-	claims := []IndividualClaim{
+	claims := []ats.IndividualClaim{
 		{
 			Subject:   "ZEE",
 			Predicate: "engineer",
@@ -330,7 +331,7 @@ func TestSmartClassifier_ClassifyConflicts(t *testing.T) {
 	classifier := NewSmartClassifier(config)
 
 	// Multiple conflict scenarios from The Attestation Chronicles
-	claimGroups := map[string][]IndividualClaim{
+	claimGroups := map[string][]ats.IndividualClaim{
 		"NEO|profession|MATRIX": {
 			{
 				Subject:   "NEO",


### PR DESCRIPTION
Remove duplicate IndividualClaim struct from classification package
and use the canonical definition from ats package. This eliminates
unnecessary type conversions in executor.go and reduces code by 41 lines.