### PR TITLE
Make README badges clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [꩜](pulse/README.md)  ⌬   [≡](am/README.md)  [⨳](ats/ix/README.md)  [⋈](ats/ax/README.md)  +  =  ✦  ⟶
 
-![Go Tests](https://github.com/teranos/QNTX/actions/workflows/go.yml/badge.svg)
-![TypeGen Check](https://github.com/teranos/QNTX/actions/workflows/typegen.yml/badge.svg)
-![Nix Image](https://github.com/teranos/QNTX/actions/workflows/nix-image.yml/badge.svg)
+[![Go Tests](https://github.com/teranos/QNTX/actions/workflows/go.yml/badge.svg)](https://github.com/teranos/QNTX/actions/workflows/go.yml)
+[![TypeGen Check](https://github.com/teranos/QNTX/actions/workflows/typegen.yml/badge.svg)](https://github.com/teranos/QNTX/actions/workflows/typegen.yml)
+[![Nix Image](https://github.com/teranos/QNTX/actions/workflows/nix-image.yml/badge.svg)](https://github.com/teranos/QNTX/actions/workflows/nix-image.yml)
 
 **QNTX** = A modular Continuous Intelligence Platform operated as a graph of attestations. It automates data ingestion, enrichment, and reasoning to create a continuously self-improving knowledge graph.
 


### PR DESCRIPTION
Links each CI status badge to its respective workflow page.

## Changes
- Wrapped Go Tests badge with link to go.yml workflow
- Wrapped TypeGen Check badge with link to typegen.yml workflow
- Wrapped Nix Image badge with link to nix-image.yml workflow

Now clicking on badges takes you directly to the CI pipeline history and current status.