### PR TITLE
Add Nix binary distribution via Cachix

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -34,11 +34,25 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v14
+        with:
+          name: qntx
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Validate Nix flake
         run: nix flake check
 
+      - name: Build and cache QNTX CLI binary
+        run: |
+          nix build .#qntx --print-build-logs
+          nix build .#qntx --print-out-paths --no-link | cachix push qntx
+
       - name: Build CI image with Nix
         run: nix build .#ci-image-${{ matrix.arch }}
+
+      - name: Cache CI image
+        run: nix build .#ci-image-${{ matrix.arch }} --print-out-paths --no-link | cachix push qntx
 
       - name: Load image into Docker
         run: docker load < result

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Data → Graph → Knowledge → Intelligence → Action
 
 QNTX provides a **domain-agnostic foundation** for building knowledge systems. At its core is the **[Attestation Type System (ATS)](ats/README.md)**
 
+## Installation
+
+See [Installation Guide](docs/installation.md) for all installation methods including Nix, Docker, and building from source.
+
 ## Segments
 
 - **꩜** pulse - continuous compute (heartbeat)

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -1,0 +1,413 @@
+# QNTX Distribution Strategy
+
+## Current State
+
+### What We Build
+- ✅ Docker images (amd64, arm64) → GHCR
+- ✅ Go CLI binary (local builds only)
+- ⚠️  Tauri apps (macOS, Windows, Android, iOS) → Only CI checks, no releases
+
+### What We Distribute
+- Docker images: `ghcr.io/teranos/qntx:latest` and `ghcr.io/teranos/qntx:{version}`
+- **Nothing else publicly available**
+
+## Distribution Channels
+
+### 1. GitHub Releases (Quick Win - High Priority)
+
+**What:** Attach binaries to git tags automatically
+
+**Platforms to distribute:**
+- CLI binaries (Linux amd64/arm64, macOS Intel/ARM, Windows x64)
+- Desktop apps (macOS .dmg, Windows .msi/.exe)
+- Android APK (sideload)
+
+**Implementation:**
+- Add release workflow triggered on `v*` tags
+- Use `goreleaser` for CLI multi-platform builds
+- Use Tauri's built-in release action for desktop apps
+- Upload artifacts to GitHub Release
+
+**Benefits:**
+- Immediate download links for all platforms
+- Changelog integration
+- Version history
+- Zero infrastructure cost
+
+**Effort:** Medium (1-2 days)
+
+---
+
+### 2. Homebrew (High Priority - macOS/Linux)
+
+**What:** Package manager for macOS and Linux
+
+**Command:**
+```bash
+brew install teranos/tap/qntx
+```
+
+**Requirements:**
+- Create homebrew-tap repository (`teranos/homebrew-tap`)
+- Formula pointing to GitHub Release binaries
+- Auto-update formula on new releases
+
+**Benefits:**
+- Primary distribution method for developers
+- Automatic updates via `brew upgrade`
+- High discoverability
+
+**Effort:** Low (few hours after GitHub Releases exist)
+
+---
+
+### 3. Container Registries (Already Done ✓)
+
+**Current:**
+- ✅ GitHub Container Registry (ghcr.io)
+
+**Could Add:**
+- Docker Hub (wider discoverability)
+- Quay.io (Red Hat ecosystem)
+
+**Multi-arch manifests:** ✅ Already implemented
+
+---
+
+### 4. Package Managers by Platform
+
+#### macOS
+- ✅ Homebrew (priority)
+- MacPorts (lower priority)
+- Mac App Store (requires Apple Developer account + annual fee)
+
+#### Windows
+- **winget** (High priority - official Windows package manager)
+  - Submit manifest to `microsoft/winget-pkgs`
+  - Free, official, widely adopted
+- **Scoop** (Medium priority - developer-focused)
+  - Add bucket with JSON manifest
+- **Chocolatey** (Lower priority - enterprise-focused)
+  - Requires moderation for community repo
+
+#### Linux
+- **APT repository** (Debian/Ubuntu)
+  - Host .deb packages on GitHub Pages or Cloudflare Pages
+  - One-time setup, auto-update via CI
+- **RPM repository** (Fedora/RHEL)
+  - Similar to APT
+- **Snap Store** (Cross-distro)
+  - Canonical's universal package format
+  - Automatic updates, sandboxed
+- **Flatpak** (Desktop apps)
+  - For Tauri desktop app
+  - Flathub distribution
+
+---
+
+### 5. Mobile App Stores
+
+#### Android
+**Options:**
+1. **Google Play Store** (Recommended)
+   - Widest reach
+   - Requires $25 one-time fee
+   - Review process (1-3 days typically)
+
+2. **F-Droid** (Open source alternative)
+   - Free, no developer account needed
+   - Longer review process
+   - Trusted by privacy-conscious users
+
+3. **GitHub Releases** (Sideloading)
+   - Immediate, free
+   - Lower discoverability
+   - Users must enable "unknown sources"
+
+**Recommendation:** Start with GitHub Releases (APK), add Play Store when ready for wider distribution.
+
+#### iOS
+- **App Store** (Only official option)
+  - Requires Apple Developer account ($99/year)
+  - Strict review process
+  - TestFlight for beta distribution
+
+---
+
+### 6. Language-Specific Package Managers
+
+**Not Recommended** (QNTX is a platform, not a library):
+- ❌ npm - Not applicable (QNTX is not a Node library)
+- ❌ PyPI - Python plugin exists but QNTX itself isn't a Python package
+- ❌ crates.io - Not distributing Rust library
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Foundation (Week 1)
+**Goal:** Make QNTX downloadable
+
+1. **GitHub Releases workflow**
+   - Multi-platform CLI builds (goreleaser)
+   - Tauri desktop app builds (macOS .dmg, Windows .msi)
+   - Android APK build
+   - Auto-create release on version tags
+
+2. **Update README**
+   - Installation instructions
+   - Download links
+   - Platform support matrix
+
+**Deliverable:** Users can download QNTX for their platform from GitHub
+
+---
+
+### Phase 2: Package Managers (Week 2-3)
+**Goal:** Native installation experience
+
+1. **Homebrew tap**
+   - Create `teranos/homebrew-tap`
+   - Auto-update formula on releases
+   - Test on macOS and Linux
+
+2. **winget manifest**
+   - Submit to microsoft/winget-pkgs
+   - Waiting period for approval (~1 week)
+
+**Deliverable:**
+```bash
+brew install teranos/tap/qntx        # macOS/Linux
+winget install Teranos.QNTX          # Windows
+```
+
+---
+
+### Phase 3: Linux Distribution (Week 4)
+**Goal:** Native package managers for Linux
+
+1. **APT repository** (Debian/Ubuntu)
+   - Host on GitHub Pages
+   - Auto-publish .deb on releases
+   - Add to sources.list
+
+2. **Snap package**
+   - Create snapcraft.yaml
+   - Publish to Snap Store
+   - Automatic updates
+
+**Deliverable:**
+```bash
+sudo apt install qntx               # Debian/Ubuntu
+snap install qntx                   # Any Linux
+```
+
+---
+
+### Phase 4: Mobile (Month 2)
+**Goal:** Official app store presence
+
+1. **Google Play Store**
+   - Developer account setup
+   - App listing (screenshots, description)
+   - Submit Android APK/AAB
+   - Production release
+
+2. **iOS App Store** (if budget allows)
+   - Apple Developer account ($99/year)
+   - App listing
+   - TestFlight beta
+   - Production release
+
+---
+
+## Technical Implementation Details
+
+### CLI Binary Distribution
+
+**Using goreleaser:**
+
+`.goreleaser.yml`:
+```yaml
+builds:
+  - main: ./cmd/qntx
+    binary: qntx
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -X github.com/teranos/QNTX/internal/version.Version={{.Version}}
+      - -X github.com/teranos/QNTX/internal/version.CommitHash={{.Commit}}
+
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
+release:
+  github:
+    owner: teranos
+    name: QNTX
+```
+
+**GitHub workflow:**
+```yaml
+- uses: goreleaser/goreleaser-action@v5
+  with:
+    version: latest
+    args: release --clean
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+---
+
+### Tauri App Distribution
+
+**Add to existing workflows:**
+
+```yaml
+- name: Build Tauri app
+  uses: tauri-apps/tauri-action@v0
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    tagName: ${{ github.ref_name }}
+    releaseName: 'QNTX ${{ github.ref_name }}'
+    releaseBody: 'See CHANGELOG.md for details'
+    releaseDraft: false
+    prerelease: false
+```
+
+Tauri automatically:
+- Builds platform-specific installers
+- Uploads to GitHub Releases
+- Generates update manifests (for auto-update)
+
+---
+
+### Homebrew Formula
+
+**`homebrew-tap/Formula/qntx.rb`:**
+```ruby
+class Qntx < Formula
+  desc "Continuous Intelligence Platform"
+  homepage "https://github.com/teranos/QNTX"
+  version "0.16.14"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/teranos/QNTX/releases/download/v0.16.14/qntx_Darwin_arm64.tar.gz"
+      sha256 "..."
+    else
+      url "https://github.com/teranos/QNTX/releases/download/v0.16.14/qntx_Darwin_x86_64.tar.gz"
+      sha256 "..."
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/teranos/QNTX/releases/download/v0.16.14/qntx_Linux_arm64.tar.gz"
+      sha256 "..."
+    else
+      url "https://github.com/teranos/QNTX/releases/download/v0.16.14/qntx_Linux_x86_64.tar.gz"
+      sha256 "..."
+    end
+  end
+
+  def install
+    bin.install "qntx"
+  end
+end
+```
+
+Auto-update with `brew bump-formula-pr`.
+
+---
+
+### winget Manifest
+
+**`microsoft/winget-pkgs/manifests/t/Teranos/QNTX/0.16.14/`:**
+
+```yaml
+PackageIdentifier: Teranos.QNTX
+PackageVersion: 0.16.14
+PackageLocale: en-US
+Publisher: Teranos
+PackageName: QNTX
+License: MIT
+ShortDescription: Continuous Intelligence Platform
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/teranos/QNTX/releases/download/v0.16.14/qntx_Windows_x64.msi
+    InstallerSha256: ...
+```
+
+---
+
+## Cost Analysis
+
+| Channel | Setup Cost | Ongoing Cost | Effort |
+|---------|-----------|--------------|--------|
+| GitHub Releases | Free | Free | Medium |
+| Homebrew | Free | Free | Low |
+| winget | Free | Free | Low |
+| Docker (GHCR) | Free | Free | Done ✓ |
+| Snap Store | Free | Free | Medium |
+| Google Play | $25 once | Free | Medium |
+| Apple App Store | Free (have account?) | $99/year | High |
+| F-Droid | Free | Free | Medium |
+
+**Total upfront:** $25-124 (depending on iOS)
+**Annual:** $0-99 (depending on iOS)
+
+---
+
+## Metrics to Track
+
+Post-distribution, monitor:
+- Download counts by platform (GitHub Releases API)
+- Package manager installs (Homebrew analytics, winget telemetry)
+- Docker pulls (GHCR stats)
+- App store downloads/ratings
+- Platform distribution (which OS/arch is most popular)
+
+---
+
+## Recommended Priority
+
+1. **GitHub Releases** (CLI + desktop apps) - Week 1
+2. **Homebrew** - Week 2
+3. **winget** - Week 2
+4. **Docker** - Already done ✓
+5. **Snap/APT** - Week 3-4
+6. **Google Play** - Month 2
+7. **iOS App Store** - When budget allows
+
+---
+
+## Next Steps
+
+1. Create `.goreleaser.yml` for CLI builds
+2. Add release workflow (`.github/workflows/release.yml`)
+3. Update Tauri workflows to build on tags (not just check)
+4. Create release (tag v0.16.15 to test)
+5. Document installation methods in README
+6. Create homebrew-tap repository
+7. Submit winget manifest
+
+---
+
+## Questions to Answer
+
+- Do we want auto-update for desktop apps? (Tauri supports this)
+- Should Docker images be pushed to Docker Hub in addition to GHCR?
+- Do we want nightly/beta releases in addition to stable?
+- What's our iOS distribution timeline? (requires Apple Developer account)
+- Should we create a downloads page on a website? (or just README)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,271 @@
+# Installing QNTX
+
+QNTX is available through multiple installation methods. Choose the one that best fits your workflow.
+
+## Nix (Recommended)
+
+QNTX uses Nix for reproducible builds and fast binary distribution via Cachix.
+
+### Install
+
+```bash
+# Install QNTX CLI
+nix profile install github:teranos/QNTX
+
+# Verify installation
+qntx --version
+```
+
+### Run Without Installing
+
+```bash
+# Run directly from GitHub
+nix run github:teranos/QNTX -- --help
+
+# Use in a temporary shell
+nix shell github:teranos/QNTX
+```
+
+### Specific Version
+
+```bash
+# Install specific version
+nix profile install github:teranos/QNTX/v0.16.14
+
+# Run specific version
+nix run github:teranos/QNTX/v0.16.14
+```
+
+### Binary Cache
+
+The first time you use QNTX via Nix, you'll see:
+
+```
+do you want to allow configuration setting 'extra-substituters' to be set to 'https://qntx.cachix.org' (y/N)?
+```
+
+**Accept this** (type `y`) for instant binary downloads instead of building from source.
+
+The cache is configured in `flake.nix` and uses:
+- Substituter: `https://qntx.cachix.org`
+- Public key: `qntx.cachix.org-1:sL1EkSS5871D3ycLjHzuD+/zNddU9G38HGt3qQotAtg=`
+
+---
+
+## Docker
+
+Multi-architecture images (amd64, arm64) are available on GitHub Container Registry.
+
+### Pull and Run
+
+```bash
+# Latest version (auto-detects architecture)
+docker pull ghcr.io/teranos/qntx:latest
+docker run ghcr.io/teranos/qntx:latest qntx --help
+
+# Specific version
+docker pull ghcr.io/teranos/qntx:0.16.14
+docker run ghcr.io/teranos/qntx:0.16.14 qntx --version
+```
+
+### Interactive Use
+
+```bash
+# Start container with shell
+docker run -it ghcr.io/teranos/qntx:latest /bin/bash
+
+# Inside container
+qntx --help
+```
+
+### With Persistent Data
+
+```bash
+# Mount local directory for persistent storage
+docker run -v $(pwd)/data:/data ghcr.io/teranos/qntx:latest qntx --help
+```
+
+---
+
+## From Source
+
+Build QNTX from source using Go and optionally Rust for fuzzy matching optimization.
+
+### Prerequisites
+
+- Go 1.24+ (required)
+- Rust toolchain (optional, for fuzzy matching)
+- Git
+
+### Build
+
+```bash
+# Clone repository
+git clone https://github.com/teranos/QNTX.git
+cd QNTX
+
+# Build with Rust fuzzy optimization (recommended)
+make cli
+
+# Or build without Rust (pure Go)
+make cli-nocgo
+
+# Binary created at ./bin/qntx
+./bin/qntx --version
+```
+
+### Install Locally
+
+```bash
+# After building
+sudo mv ./bin/qntx /usr/local/bin/
+
+# Verify
+qntx --version
+```
+
+---
+
+## Package Managers (Coming Soon)
+
+The following package managers are planned:
+
+### Homebrew (macOS/Linux)
+```bash
+# Not yet available
+brew install teranos/tap/qntx
+```
+
+### winget (Windows)
+```bash
+# Not yet available
+winget install Teranos.QNTX
+```
+
+### APT (Debian/Ubuntu)
+```bash
+# Not yet available
+sudo apt install qntx
+```
+
+---
+
+## Verification
+
+After installation, verify QNTX is working:
+
+```bash
+# Check version
+qntx --version
+
+# View help
+qntx --help
+
+# Check configuration
+qntx am show
+```
+
+---
+
+## Platform Support
+
+| Platform | Architecture | Method | Status |
+|----------|-------------|---------|---------|
+| Linux | amd64 | Nix, Docker, Source | ✅ |
+| Linux | arm64 | Nix, Docker, Source | ✅ |
+| macOS | Intel (x64) | Nix, Source | ✅ |
+| macOS | Apple Silicon (ARM) | Nix, Source | ✅ |
+| Windows | x64 | Source | ✅ |
+| Android | ARM | Docker | ✅ (via Tauri) |
+| iOS | ARM | Source | ⚠️ (experimental) |
+
+---
+
+## Uninstallation
+
+### Nix
+
+```bash
+# List installed packages
+nix profile list
+
+# Remove QNTX (replace <index> with actual index from list)
+nix profile remove <index>
+```
+
+### Docker
+
+```bash
+# Remove image
+docker rmi ghcr.io/teranos/qntx:latest
+
+# Remove all QNTX images
+docker images | grep qntx | awk '{print $3}' | xargs docker rmi
+```
+
+### Source Install
+
+```bash
+# Remove binary
+sudo rm /usr/local/bin/qntx
+```
+
+---
+
+## Troubleshooting
+
+### Nix: "experimental features" error
+
+Enable flakes in your Nix configuration:
+
+```bash
+mkdir -p ~/.config/nix
+echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+### Nix: Slow downloads
+
+If you declined the binary cache prompt, re-run with:
+
+```bash
+nix profile install github:teranos/QNTX --accept-flake-config
+```
+
+### Docker: Architecture mismatch
+
+Explicitly specify architecture:
+
+```bash
+docker pull --platform linux/amd64 ghcr.io/teranos/qntx:latest
+# or
+docker pull --platform linux/arm64 ghcr.io/teranos/qntx:latest
+```
+
+### Build from source: Missing Rust
+
+If `make cli` fails due to missing Rust:
+
+```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Or use pure Go build
+make cli-nocgo
+```
+
+---
+
+## Next Steps
+
+After installing QNTX:
+
+1. **Configuration**: See [Configuration Guide](../am/README.md)
+2. **Development**: See [Nix Development Guide](./nix-development.md)
+3. **Segments**: Explore QNTX components in the [main README](../README.md#segments)
+
+---
+
+## Getting Help
+
+- GitHub Issues: https://github.com/teranos/QNTX/issues
+- Documentation: https://github.com/teranos/QNTX/tree/main/docs

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,12 @@
     };
   };
 
+  # Binary cache configuration
+  nixConfig = {
+    extra-substituters = ["https://qntx.cachix.org"];
+    extra-trusted-public-keys = ["qntx.cachix.org-1:sL1EkSS5871D3ycLjHzuD+/zNddU9G38HGt3qQotAtg="];
+  };
+
   outputs = { self, nixpkgs, flake-utils, pre-commit-hooks }:
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -134,10 +140,16 @@
       in
       {
         packages = {
+          # QNTX CLI binary
+          qntx = qntx;
+
+          # Docker images
           ci-image = ciImage;
           ci-image-amd64 = mkCiImage "amd64";
           ci-image-arm64 = mkCiImage "arm64";
-          default = ciImage;
+
+          # Default: CLI binary for easy installation
+          default = qntx;
         };
 
         # Development shell with same tools


### PR DESCRIPTION
## Summary

Implements Phase 1 of the distribution strategy: Nix-first distribution with binary caching.

Users can now install QNTX instantly via Nix with pre-built binaries:

```bash
nix profile install github:teranos/QNTX
```

## Changes

### Binary Distribution
- **flake.nix**: Exposed `qntx` CLI binary in packages (previously only Docker images)
- **flake.nix**: Changed default package from `ci-image` to `qntx` for easy installation
- **flake.nix**: Added nixConfig with qntx.cachix.org binary cache

### CI Integration
- **nix-image.yml**: Added cachix-action setup with CACHIX_AUTH_TOKEN
- **nix-image.yml**: Build and push QNTX CLI to cache (instant downloads for users)
- **nix-image.yml**: Push CI images to cache (faster CI runs)

### Documentation
- **docs/installation.md**: Comprehensive installation guide
  - Nix installation (with cachix)
  - Docker usage
  - Building from source
  - Platform support matrix
  - Troubleshooting
- **docs/distribution-strategy.md**: Strategic roadmap for future distribution channels
- **README.md**: Added link to installation guide

## Installation Methods

### Nix (Recommended - New!)
```bash
nix profile install github:teranos/QNTX  # Installs with binary cache
nix run github:teranos/QNTX              # Run without installing
```

### Docker (Existing)
```bash
docker pull ghcr.io/teranos/qntx:latest
```

### Source (Existing)
```bash
make cli
```

## Binary Cache

Configured cachix cache:
- Name: `qntx`
- URL: https://qntx.cachix.org
- Public key: `qntx.cachix.org-1:sL1EkSS5871D3ycLjHzuD+/zNddU9G38HGt3qQotAtg=`

When users first install via Nix, they'll be prompted to trust the cache. Accepting gives instant binary downloads instead of 10+ minute builds.

## Testing

After merge, test with:
```bash
# Fresh install (will use binary cache)
nix profile install github:teranos/QNTX

# Verify
qntx --version
```

## Next Steps (Future PRs)

- Phase 2: Cross-compilation + GitHub Releases (traditional downloads)
- Phase 3: Homebrew tap
- Phase 4: winget, apt, snap

See docs/distribution-strategy.md for full roadmap.