### PR TITLE
Add GitHub Releases workflow (Phase 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - 'feat/cross-compilation-releases'  # Testing branch - remove before merge
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Implements Phase 2 of distribution strategy: GitHub Releases for downloadable binaries.

## Changes

**New workflow: `.github/workflows/release.yml`**
- Triggered on version tags (`v*`)
- Creates GitHub Release with changelog and installation instructions
- Builds QNTX binaries for Linux (amd64, arm64) using Nix
- Packages binaries as `.tar.gz` with SHA256 checksums
- Uploads to GitHub Releases for easy download

## Installation After Merge

Users will be able to download pre-built binaries:

```bash
# Download and extract
curl -LO https://github.com/teranos/QNTX/releases/download/v0.17.3/qntx-0.17.3-linux-amd64.tar.gz
tar -xzf qntx-0.17.3-linux-amd64.tar.gz
sudo mv qntx /usr/local/bin/
```

Or continue using Nix:
```bash
nix profile install github:teranos/QNTX
```

## Testing Plan

After merge:
1. Tag v0.17.3 (or next version)
2. Both `nix-image.yml` and `release.yml` will trigger
3. Verify binaries appear in GitHub Release
4. Test download and execution

## Future Enhancements

- macOS binaries (Intel + Apple Silicon)
- Windows binaries  
- Homebrew tap (uses GitHub Release binaries)
- winget manifest
- APT/RPM repositories

See `docs/distribution-strategy.md` for full roadmap.