### PR TITLE
Update server package to use QNTX errors package

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/pulse/async"
 	"github.com/teranos/QNTX/sym"
 )
@@ -373,7 +374,7 @@ func (s *QNTXServer) getDaemonState() (enabled bool, err error) {
 	query := "SELECT enabled FROM daemon_config WHERE id = 1"
 	err = s.db.QueryRow(query).Scan(&enabled)
 	if err != nil {
-		return false, fmt.Errorf("failed to get daemon state: %w", err)
+		return false, errors.Wrap(err, "failed to get daemon state")
 	}
 	return enabled, nil
 }
@@ -389,7 +390,7 @@ func (s *QNTXServer) setDaemonState(enabled bool) error {
 	`
 	_, err := s.db.Exec(query, enabled)
 	if err != nil {
-		return fmt.Errorf("failed to set daemon state: %w", err)
+		return errors.Wrap(err, "failed to set daemon state")
 	}
 	return nil
 }
@@ -397,7 +398,7 @@ func (s *QNTXServer) setDaemonState(enabled bool) error {
 // startDaemon starts the daemon and updates state
 func (s *QNTXServer) startDaemon() error {
 	if s.daemon == nil {
-		return fmt.Errorf("daemon not initialized")
+		return errors.New("daemon not initialized")
 	}
 
 	s.daemon.Start()
@@ -416,7 +417,7 @@ func (s *QNTXServer) startDaemon() error {
 // stopDaemon stops the daemon and updates state
 func (s *QNTXServer) stopDaemon() error {
 	if s.daemon == nil {
-		return fmt.Errorf("daemon not initialized")
+		return errors.New("daemon not initialized")
 	}
 
 	if s.ticker != nil {

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,6 +1,6 @@
 package server
 
-import "errors"
+import "github.com/teranos/QNTX/errors"
 
 // Sentinel errors for common cases
 var (

--- a/server/init.go
+++ b/server/init.go
@@ -10,6 +10,7 @@ import (
 	appcfg "github.com/teranos/QNTX/am"
 	"github.com/teranos/QNTX/ats/lsp"
 	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/graph"
 	"github.com/teranos/QNTX/logger"
 	"github.com/teranos/QNTX/plugin"
@@ -41,40 +42,40 @@ func NewQNTXServer(db *sql.DB, dbPath string, verbosity int) (*QNTXServer, error
 func NewQNTXServerWithInitialQuery(db *sql.DB, dbPath string, verbosity int, initialQuery string) (*QNTXServer, error) {
 	// Defensive: Validate critical inputs
 	if db == nil {
-		return nil, fmt.Errorf("database connection cannot be nil")
+		return nil, errors.New("database connection cannot be nil")
 	}
 	if verbosity < 0 || verbosity > 4 {
-		return nil, fmt.Errorf("verbosity must be 0-4, got %d", verbosity)
+		return nil, errors.Newf("verbosity must be 0-4, got %d", verbosity)
 	}
 
 	// Create logger with multi-output (console, WebSocket, file)
 	serverLogger, wsCore, wsTransport, err := createGraphLogger(verbosity)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create logger: %w", err)
+		return nil, errors.Wrap(err, "failed to create logger")
 	}
 	// Defensive: Verify logger components
 	if serverLogger == nil || wsCore == nil || wsTransport == nil {
-		return nil, fmt.Errorf("logger creation returned nil components")
+		return nil, errors.New("logger creation returned nil components")
 	}
 
 	// Create all server dependencies (builder, services, trackers, daemon)
 	deps, err := createServerDependencies(db, verbosity, wsCore, wsTransport, serverLogger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create server dependencies: %w", err)
+		return nil, errors.Wrap(err, "failed to create server dependencies")
 	}
 
 	// Defensive: Validate critical dependencies (nil daemon is allowed)
 	if deps.builder == nil {
-		return nil, fmt.Errorf("graph builder creation failed")
+		return nil, errors.New("graph builder creation failed")
 	}
 	if deps.langService == nil {
-		return nil, fmt.Errorf("language service creation failed")
+		return nil, errors.New("language service creation failed")
 	}
 	if deps.usageTracker == nil {
-		return nil, fmt.Errorf("usage tracker creation failed")
+		return nil, errors.New("usage tracker creation failed")
 	}
 	if deps.budgetTracker == nil {
-		return nil, fmt.Errorf("budget tracker creation failed")
+		return nil, errors.New("budget tracker creation failed")
 	}
 
 	// Create cancellation context for lifecycle management
@@ -249,7 +250,7 @@ func createServerDependencies(db *sql.DB, verbosity int, wsCore *wslogs.WebSocke
 	// Create builder with server logger
 	builder, err := graph.NewAxGraphBuilder(db, verbosity, serverLogger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create graph builder: %w", err)
+		return nil, errors.Wrap(err, "failed to create graph builder")
 	}
 	serverLogger.Debugw("Graph builder created", "duration_ms", time.Since(start).Milliseconds())
 
@@ -257,7 +258,7 @@ func createServerDependencies(db *sql.DB, verbosity int, wsCore *wslogs.WebSocke
 	langStart := time.Now()
 	symbolIndex, err := storage.NewSymbolIndex(db)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create symbol index: %w", err)
+		return nil, errors.Wrap(err, "failed to create symbol index")
 	}
 	langService := lsp.NewService(symbolIndex)
 	serverLogger.Debugw("Language service created", "duration_ms", time.Since(langStart).Milliseconds())

--- a/server/lifecycle.go
+++ b/server/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/sym"
 )
 
@@ -91,7 +92,7 @@ func (s *QNTXServer) Start(port int, openBrowserFunc func(url string)) error {
 	// Find an available port
 	actualPort, err := findAvailablePort(port)
 	if err != nil {
-		return fmt.Errorf("failed to find available port: %w", err)
+		return errors.Wrap(err, "failed to find available port")
 	}
 
 	if actualPort != port {

--- a/server/lsp_handler.go
+++ b/server/lsp_handler.go
@@ -2,13 +2,13 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
 
 	"github.com/gorilla/websocket"
 	"github.com/teranos/QNTX/ats/lsp"
 	"github.com/teranos/QNTX/ats/parser"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/internal/util"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -136,7 +136,7 @@ func (h *GLSPHandler) TextDocumentDidOpen(ctx *glsp.Context, params *protocol.Di
 				"current_count", len(h.documents),
 				"max_allowed", maxDocumentsPerClient,
 			)
-			return fmt.Errorf("document cache limit reached (%d documents open)", maxDocumentsPerClient)
+			return errors.Newf("document cache limit reached (%d documents open)", maxDocumentsPerClient)
 		}
 	}
 

--- a/server/response.go
+++ b/server/response.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/teranos/QNTX/errors"
 )
 
 // writeJSON writes a JSON response with the given status code
@@ -11,7 +13,7 @@ func writeJSON(w http.ResponseWriter, status int, data interface{}) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		return fmt.Errorf("failed to encode JSON: %w", err)
+		return errors.Wrap(err, "failed to encode JSON")
 	}
 	return nil
 }

--- a/server/util.go
+++ b/server/util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	appcfg "github.com/teranos/QNTX/am"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/logger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -93,7 +94,7 @@ func findAvailablePort(requestedPort int) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("no available ports found (tried %d, %d, %d, and range 56787-56796)", requestedPort, appcfg.DefaultGraphPort, appcfg.FallbackGraphPort)
+	return 0, errors.Newf("no available ports found (tried %d, %d, %d, and range 56787-56796)", requestedPort, appcfg.DefaultGraphPort, appcfg.FallbackGraphPort)
 }
 
 // createFileCore creates a zap core for file logging without colors
@@ -101,12 +102,12 @@ func createFileCore(path string, verbosity int) (zapcore.Core, error) {
 	// Ensure directory exists (os.OpenFile doesn't create intermediate directories)
 	dir := "tmp"
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create log directory: %w", err)
+		return nil, errors.Wrap(err, "failed to create log directory")
 	}
 
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open log file %s: %w", path, err)
+		return nil, errors.Wrapf(err, "failed to open log file %s", path)
 	}
 
 	// Create encoder config for plain file output (no colors)


### PR DESCRIPTION
Replace standard library errors and fmt.Errorf with the QNTX errors
package (github.com/teranos/QNTX/errors) which wraps cockroachdb/errors
for production-grade error handling with stack traces and rich context.

Changes:
- errors.go: Use QNTX errors for sentinel errors
- ats_parser.go: Replace fmt.Errorf with errors.New/Newf/Wrap
- broadcast.go: Replace fmt.Errorf with errors.New/Wrap
- init.go: Replace fmt.Errorf with errors.New/Newf/Wrap
- lifecycle.go: Replace fmt.Errorf with errors.Wrap
- lsp_handler.go: Replace fmt.Errorf with errors.Newf
- prose_handler.go: Replace fmt.Errorf with errors.Newf/Wrap
- response.go: Replace fmt.Errorf with errors.Wrap
- util.go: Replace fmt.Errorf with errors.Newf/Wrap/Wrapf