### PR TITLE
Migrate pulse package to use QNTX errors package

### DIFF
--- a/pulse/async/error.go
+++ b/pulse/async/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/sym"
 	"go.uber.org/zap"
 )
@@ -117,11 +118,11 @@ func RetryableError(queue *Queue, job *Job, operation string, err error, log *za
 				"operation", operation,
 			)
 		}
-		return fmt.Errorf("retriable: %w", err)
+		return errors.Wrap(err, "retriable")
 	}
 	log.Warnw(sym.Pulse+" Max retries exceeded",
 		"max_retries", MaxRetries,
 		"operation", operation,
 	)
-	return fmt.Errorf("%s after %d retries: %w", operation, MaxRetries, err)
+	return errors.Wrapf(err, "%s after %d retries", operation, MaxRetries)
 }

--- a/pulse/async/handler.go
+++ b/pulse/async/handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"github.com/teranos/QNTX/errors"
 )
 
 // JobHandler defines the interface for executing a specific job type.
@@ -115,7 +117,7 @@ func NewRegistryExecutor(registry *HandlerRegistry, fallback JobExecutor) *Regis
 // Execute implements JobExecutor by dispatching to registered handlers.
 func (e *RegistryExecutor) Execute(ctx context.Context, job *Job) error {
 	if job.HandlerName == "" {
-		return fmt.Errorf("job missing handler_name")
+		return errors.New("job missing handler_name")
 	}
 
 	handler := e.registry.Get(job.HandlerName)
@@ -128,5 +130,5 @@ func (e *RegistryExecutor) Execute(ctx context.Context, job *Job) error {
 		return e.fallback.Execute(ctx, job)
 	}
 
-	return fmt.Errorf("no handler registered for handler name: %s", job.HandlerName)
+	return errors.Newf("no handler registered for handler name: %s", job.HandlerName)
 }

--- a/pulse/async/job.go
+++ b/pulse/async/job.go
@@ -3,9 +3,9 @@ package async
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/vanity-id"
 )
 
@@ -105,7 +105,7 @@ func NewChildJobWithPayload(handlerName string, source string, payload json.RawM
 	// Format: JB + random(2) + handler(5) + random(2) + process(7) + random(2) + source(5) + random(4) + actor(3)
 	jobID, err := id.GenerateJobASID(handlerName, source, actor)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate job ASID: %w", err)
+		return nil, errors.Wrap(err, "failed to generate job ASID")
 	}
 
 	now := time.Now()
@@ -203,7 +203,7 @@ func MarshalPulseState(state *PulseState) (string, error) {
 	}
 	data, err := json.Marshal(state)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal pulse state: %w", err)
+		return "", errors.Wrap(err, "failed to marshal pulse state")
 	}
 	return string(data), nil
 }
@@ -215,7 +215,7 @@ func UnmarshalPulseState(data string) (*PulseState, error) {
 	}
 	var state PulseState
 	if err := json.Unmarshal([]byte(data), &state); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal pulse state: %w", err)
+		return nil, errors.Wrap(err, "failed to unmarshal pulse state")
 	}
 	return &state, nil
 }

--- a/pulse/async/scan.go
+++ b/pulse/async/scan.go
@@ -2,7 +2,8 @@ package async
 
 import (
 	"database/sql"
-	"fmt"
+
+	"github.com/teranos/QNTX/errors"
 )
 
 // JobScanArgs holds all the variables needed for scanning a job from a database row.
@@ -63,7 +64,7 @@ func ProcessJobScanArgs(job *Job, args *JobScanArgs) error {
 	if args.PulseStateJSON.Valid {
 		pulseState, err := UnmarshalPulseState(args.PulseStateJSON.String)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal pulse state for job %s: %w", job.ID, err)
+			return errors.Wrapf(err, "failed to unmarshal pulse state for job %s", job.ID)
 		}
 		job.PulseState = pulseState
 	}

--- a/pulse/budget/limiter.go
+++ b/pulse/budget/limiter.go
@@ -2,9 +2,10 @@ package budget
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
+
+	"github.com/teranos/QNTX/errors"
 )
 
 // Limiter enforces max calls per time window using sliding window algorithm
@@ -44,7 +45,7 @@ func (r *Limiter) Allow() error {
 
 	// Check if we're at the limit
 	if len(r.callTimes) >= r.maxCallsPerMinute {
-		return fmt.Errorf("rate limit exceeded: %d calls per minute (limit: %d)",
+		return errors.Newf("rate limit exceeded: %d calls per minute (limit: %d)",
 			len(r.callTimes), r.maxCallsPerMinute)
 	}
 

--- a/pulse/budget/store.go
+++ b/pulse/budget/store.go
@@ -5,6 +5,8 @@ package budget
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/teranos/QNTX/errors"
 )
 
 // Store handles budget queries against ai_model_usage table
@@ -31,7 +33,7 @@ func (s *Store) getActualSpend(window string, period string) (totalCost float64,
 
 	err = s.db.QueryRow(query).Scan(&totalCost, &opCount)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to query %s spend: %w", period, err)
+		return 0, 0, errors.Wrapf(err, "failed to query %s spend", period)
 	}
 
 	return totalCost, opCount, nil

--- a/pulse/schedule/store.go
+++ b/pulse/schedule/store.go
@@ -3,8 +3,9 @@ package schedule
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
+
+	"github.com/teranos/QNTX/errors"
 )
 
 const (
@@ -87,7 +88,7 @@ func (s *Store) CreateJob(job *Job) error {
 	)
 
 	if err != nil {
-		return fmt.Errorf("failed to create scheduled job: %w", err)
+		return errors.Wrap(err, "failed to create scheduled job")
 	}
 
 	return nil
@@ -128,31 +129,31 @@ func (s *Store) GetJob(id string) (*Job, error) {
 
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, fmt.Errorf("scheduled job not found: %s", id)
+			return nil, errors.Newf("scheduled job not found: %s", id)
 		}
-		return nil, fmt.Errorf("failed to get scheduled job: %w", err)
+		return nil, errors.Wrap(err, "failed to get scheduled job")
 	}
 
 	// Parse timestamps (return error if parsing fails - indicates data corruption or schema mismatch)
 	job.NextRunAt, err = time.Parse(time.RFC3339, nextRunAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse next_run_at for job %s: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to parse next_run_at for job %s", id)
 	}
 
 	job.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse created_at for job %s: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to parse created_at for job %s", id)
 	}
 
 	job.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse updated_at for job %s: %w", id, err)
+		return nil, errors.Wrapf(err, "failed to parse updated_at for job %s", id)
 	}
 
 	if lastRunAt.Valid {
 		t, err := time.Parse(time.RFC3339, lastRunAt.String)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse last_run_at for job %s: %w", id, err)
+			return nil, errors.Wrapf(err, "failed to parse last_run_at for job %s", id)
 		}
 		job.LastRunAt = &t
 	}
@@ -229,23 +230,23 @@ func (s *Store) ListJobsDue(now time.Time) ([]*Job, error) {
 		// Parse timestamps (return error if parsing fails - indicates data corruption or schema mismatch)
 		job.NextRunAt, err = time.Parse(time.RFC3339, nextRunAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse next_run_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse next_run_at for job %s", job.ID)
 		}
 
 		job.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse created_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse created_at for job %s", job.ID)
 		}
 
 		job.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse updated_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse updated_at for job %s", job.ID)
 		}
 
 		if lastRunAt.Valid {
 			t, err := time.Parse(time.RFC3339, lastRunAt.String)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse last_run_at for job %s: %w", job.ID, err)
+				return nil, errors.Wrapf(err, "failed to parse last_run_at for job %s", job.ID)
 			}
 			job.LastRunAt = &t
 		}
@@ -326,23 +327,23 @@ func (s *Store) ListJobsDueContext(ctx context.Context, now time.Time) ([]*Job, 
 		// Parse timestamps (return error if parsing fails - indicates data corruption or schema mismatch)
 		job.NextRunAt, err = time.Parse(time.RFC3339, nextRunAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse next_run_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse next_run_at for job %s", job.ID)
 		}
 
 		job.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse created_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse created_at for job %s", job.ID)
 		}
 
 		job.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse updated_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse updated_at for job %s", job.ID)
 		}
 
 		if lastRunAt.Valid {
 			t, err := time.Parse(time.RFC3339, lastRunAt.String)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse last_run_at for job %s: %w", job.ID, err)
+				return nil, errors.Wrapf(err, "failed to parse last_run_at for job %s", job.ID)
 			}
 			job.LastRunAt = &t
 		}
@@ -423,23 +424,23 @@ func (s *Store) ListAllScheduledJobs() ([]*Job, error) {
 		// Parse timestamps
 		job.NextRunAt, err = time.Parse(time.RFC3339, nextRunAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse next_run_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse next_run_at for job %s", job.ID)
 		}
 
 		job.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse created_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse created_at for job %s", job.ID)
 		}
 
 		job.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse updated_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse updated_at for job %s", job.ID)
 		}
 
 		if lastRunAt.Valid {
 			t, err := time.Parse(time.RFC3339, lastRunAt.String)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse last_run_at for job %s: %w", job.ID, err)
+				return nil, errors.Wrapf(err, "failed to parse last_run_at for job %s", job.ID)
 			}
 			job.LastRunAt = &t
 		}
@@ -479,16 +480,16 @@ func (s *Store) UpdateJobState(jobID string, newState string) error {
 
 	result, err := s.db.Exec(query, newState, time.Now().UTC().Format(time.RFC3339), jobID)
 	if err != nil {
-		return fmt.Errorf("failed to update scheduled job state: %w", err)
+		return errors.Wrap(err, "failed to update scheduled job state")
 	}
 
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
+		return errors.Wrap(err, "failed to get rows affected")
 	}
 
 	if rows == 0 {
-		return fmt.Errorf("scheduled job not found: %s", jobID)
+		return errors.Newf("scheduled job not found: %s", jobID)
 	}
 
 	return nil
@@ -505,16 +506,16 @@ func (s *Store) UpdateJobInterval(jobID string, newInterval int) error {
 
 	result, err := s.db.Exec(query, newInterval, time.Now().UTC().Format(time.RFC3339), jobID)
 	if err != nil {
-		return fmt.Errorf("failed to update scheduled job interval: %w", err)
+		return errors.Wrap(err, "failed to update scheduled job interval")
 	}
 
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
+		return errors.Wrap(err, "failed to get rows affected")
 	}
 
 	if rows == 0 {
-		return fmt.Errorf("scheduled job not found: %s", jobID)
+		return errors.Newf("scheduled job not found: %s", jobID)
 	}
 
 	return nil
@@ -539,16 +540,16 @@ func (s *Store) UpdateJobAfterExecution(jobID string, lastRun time.Time, executi
 		jobID)
 
 	if err != nil {
-		return fmt.Errorf("failed to update scheduled job: %w", err)
+		return errors.Wrap(err, "failed to update scheduled job")
 	}
 
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
+		return errors.Wrap(err, "failed to get rows affected")
 	}
 
 	if rows == 0 {
-		return fmt.Errorf("scheduled job not found: %s", jobID)
+		return errors.Newf("scheduled job not found: %s", jobID)
 	}
 
 	return nil
@@ -598,29 +599,29 @@ func (s *Store) GetNextScheduledJob() (*Job, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get next scheduled job: %w", err)
+		return nil, errors.Wrap(err, "failed to get next scheduled job")
 	}
 
 	// Parse timestamps (return error if parsing fails - indicates data corruption or schema mismatch)
 	job.NextRunAt, err = time.Parse(time.RFC3339, nextRunAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse next_run_at for job %s: %w", job.ID, err)
+		return nil, errors.Wrapf(err, "failed to parse next_run_at for job %s", job.ID)
 	}
 
 	job.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse created_at for job %s: %w", job.ID, err)
+		return nil, errors.Wrapf(err, "failed to parse created_at for job %s", job.ID)
 	}
 
 	job.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse updated_at for job %s: %w", job.ID, err)
+		return nil, errors.Wrapf(err, "failed to parse updated_at for job %s", job.ID)
 	}
 
 	if lastRunAt.Valid {
 		t, err := time.Parse(time.RFC3339, lastRunAt.String)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse last_run_at for job %s: %w", job.ID, err)
+			return nil, errors.Wrapf(err, "failed to parse last_run_at for job %s", job.ID)
 		}
 		job.LastRunAt = &t
 	}

--- a/pulse/schedule/ticker.go
+++ b/pulse/schedule/ticker.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/internal/util"
 	"github.com/teranos/QNTX/pulse/async"
 	"github.com/teranos/QNTX/sym"
@@ -200,7 +201,7 @@ func (t *Ticker) checkScheduledJobs(now time.Time) error {
 	// Query for active jobs that are due to run (with context for graceful cancellation)
 	jobs, err := t.store.ListJobsDueContext(t.ctx, now)
 	if err != nil {
-		return fmt.Errorf("failed to list scheduled jobs: %w", err)
+		return errors.Wrap(err, "failed to list scheduled jobs")
 	}
 
 	if len(jobs) == 0 {
@@ -310,7 +311,7 @@ func (t *Ticker) executeScheduledJob(scheduled *Job, now time.Time) error {
 
 		// Update the scheduled job with next run time
 		if err := t.store.UpdateJobAfterExecution(scheduled.ID, now, asyncJobID, nextRun); err != nil {
-			return fmt.Errorf("failed to update scheduled job: %w", err)
+			return errors.Wrap(err, "failed to update scheduled job")
 		}
 	}
 
@@ -382,7 +383,7 @@ func (t *Ticker) enqueueAsyncJob(scheduled *Job) (string, error) {
 	// Require pre-computed handler - jobs should be created by the application
 	// with handler_name and payload populated
 	if scheduled.HandlerName == "" {
-		return "", fmt.Errorf("scheduled job %s missing handler_name (job may need re-creation)", scheduled.ID)
+		return "", errors.Newf("scheduled job %s missing handler_name (job may need re-creation)", scheduled.ID)
 	}
 
 	handlerName := scheduled.HandlerName
@@ -392,7 +393,7 @@ func (t *Ticker) enqueueAsyncJob(scheduled *Job) (string, error) {
 	// Check for existing active job with same source URL (deduplication)
 	existingJob, err := t.queue.FindActiveJobBySourceAndHandler(sourceURL, handlerName)
 	if err != nil {
-		return "", fmt.Errorf("failed to check for duplicate job: %w", err)
+		return "", errors.Wrap(err, "failed to check for duplicate job")
 	}
 
 	if existingJob != nil {
@@ -415,12 +416,12 @@ func (t *Ticker) enqueueAsyncJob(scheduled *Job) (string, error) {
 		fmt.Sprintf("pulse:%s", scheduled.ID),
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to create async job: %w", err)
+		return "", errors.Wrap(err, "failed to create async job")
 	}
 
 	// Enqueue the job
 	if err := t.queue.Enqueue(job); err != nil {
-		return "", fmt.Errorf("failed to enqueue job: %w", err)
+		return "", errors.Wrap(err, "failed to enqueue job")
 	}
 
 	t.logger.Debugw(sym.Pulse+" Enqueued async job",


### PR DESCRIPTION
Replace standard library errors and fmt.Errorf with
github.com/teranos/QNTX/errors for consistent error handling:

- errors.Wrap(err, "msg") for wrapping errors
- errors.Wrapf(err, "fmt", args) for formatted wrapping
- errors.New("msg") for new errors
- errors.Newf("fmt", args) for formatted new errors

Updated files:
- pulse/async: error.go, handler.go, job.go, queue.go, scan.go, store.go, worker.go
- pulse/schedule: execution_store.go, store.go, ticker.go
- pulse/budget: limiter.go, store.go, tracker.go