### PR TITLE
Update gRPC package to use QNTX errors package

### DIFF
--- a/plugin/grpc/atsstore_server.go
+++ b/plugin/grpc/atsstore_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"go.uber.org/zap"
 )
@@ -34,7 +35,7 @@ func NewATSStoreServer(store *storage.SQLStore, authToken string, logger *zap.Su
 // validateAuth checks the authentication token
 func (s *ATSStoreServer) validateAuth(token string) error {
 	if subtle.ConstantTimeCompare([]byte(token), []byte(s.authToken)) != 1 {
-		return fmt.Errorf("invalid authentication token")
+		return errors.New("invalid authentication token")
 	}
 	return nil
 }
@@ -177,7 +178,7 @@ func protoToAttestation(proto *protocol.Attestation) (*types.As, error) {
 	var attributes map[string]interface{}
 	if proto.AttributesJson != "" {
 		if err := json.Unmarshal([]byte(proto.AttributesJson), &attributes); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal attributes: %w", err)
+			return nil, errors.Wrap(err, "failed to unmarshal attributes")
 		}
 	}
 
@@ -199,7 +200,7 @@ func attestationToProto(as *types.As) (*protocol.Attestation, error) {
 	if len(as.Attributes) > 0 {
 		bytes, err := json.Marshal(as.Attributes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal attributes: %w", err)
+			return nil, errors.Wrap(err, "failed to marshal attributes")
 		}
 		attributesJSON = string(bytes)
 	}
@@ -221,7 +222,7 @@ func protoToCommand(proto *protocol.AttestationCommand) (*types.AsCommand, error
 	var attributes map[string]interface{}
 	if proto.AttributesJson != "" {
 		if err := json.Unmarshal([]byte(proto.AttributesJson), &attributes); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal attributes: %w", err)
+			return nil, errors.Wrap(err, "failed to unmarshal attributes")
 		}
 	}
 

--- a/plugin/grpc/client.go
+++ b/plugin/grpc/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"go.uber.org/zap"
@@ -45,7 +46,7 @@ func NewExternalDomainProxy(addr string, logger *zap.SugaredLogger) (*ExternalDo
 		grpc.WithBlock(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to plugin at %s: %w", addr, err)
+		return nil, errors.Wrapf(err, "failed to connect to plugin at %s", addr)
 	}
 
 	client := protocol.NewDomainPluginServiceClient(conn)
@@ -61,7 +62,7 @@ func NewExternalDomainProxy(addr string, logger *zap.SugaredLogger) (*ExternalDo
 	metaResp, err := client.Metadata(ctx, &protocol.Empty{})
 	if err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("failed to get plugin metadata from %s: %w", addr, err)
+		return nil, errors.Wrapf(err, "failed to get plugin metadata from %s", addr)
 	}
 
 	proxy.metadata = plugin.Metadata{
@@ -174,7 +175,7 @@ func (c *ExternalDomainProxy) Initialize(ctx context.Context, services plugin.Se
 
 	_, err := c.client.Initialize(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to initialize remote plugin %s at %s: %w", c.metadata.Name, c.addr, err)
+		return errors.Wrapf(err, "failed to initialize remote plugin %s at %s", c.metadata.Name, c.addr)
 	}
 
 	c.logger.Infow("Remote plugin initialized",
@@ -189,7 +190,7 @@ func (c *ExternalDomainProxy) Initialize(ctx context.Context, services plugin.Se
 func (c *ExternalDomainProxy) Shutdown(ctx context.Context) error {
 	_, err := c.client.Shutdown(ctx, &protocol.Empty{})
 	if err != nil {
-		return fmt.Errorf("failed to shutdown remote plugin %s at %s: %w", c.metadata.Name, c.addr, err)
+		return errors.Wrapf(err, "failed to shutdown remote plugin %s at %s", c.metadata.Name, c.addr)
 	}
 	return c.conn.Close()
 }

--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin"
 	"go.uber.org/zap"
 )
@@ -77,8 +78,8 @@ func (m *PluginManager) LoadPlugins(ctx context.Context, configs []PluginConfig)
 		}
 
 		if err := m.loadPlugin(ctx, config); err != nil {
-			return fmt.Errorf("failed to load plugin %s (binary=%s, address=%s): %w",
-				config.Name, config.Binary, config.Address, err)
+			return errors.Wrapf(err, "failed to load plugin %s (binary=%s, address=%s)",
+				config.Name, config.Binary, config.Address)
 		}
 	}
 	return nil
@@ -91,7 +92,7 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 
 	// Check if already loaded
 	if _, exists := m.plugins[config.Name]; exists {
-		return fmt.Errorf("plugin already loaded: %s", config.Name)
+		return errors.Newf("plugin already loaded: %s", config.Name)
 	}
 
 	var addr string
@@ -110,16 +111,16 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 		var err error
 		process, err = m.launchPlugin(ctx, config, port)
 		if err != nil {
-			return fmt.Errorf("failed to launch plugin %s (binary=%s, port=%d): %w",
-				config.Name, config.Binary, port, err)
+			return errors.Wrapf(err, "failed to launch plugin %s (binary=%s, port=%d)",
+				config.Name, config.Binary, port)
 		}
 		m.logger.Infow("Launched plugin process", "name", config.Name, "port", port, "pid", process.Pid)
 
 		// Wait for plugin to be ready
 		if err := m.waitForPlugin(ctx, addr, 30*time.Second); err != nil {
 			process.Kill()
-			return fmt.Errorf("plugin %s failed to start (binary=%s, addr=%s, pid=%d): %w",
-				config.Name, config.Binary, addr, process.Pid, err)
+			return errors.Wrapf(err, "plugin %s failed to start (binary=%s, addr=%s, pid=%d)",
+				config.Name, config.Binary, addr, process.Pid)
 		}
 	} else if config.Binary != "" {
 		// Binary specified but auto_start is false
@@ -129,7 +130,7 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 		)
 		return nil
 	} else {
-		return fmt.Errorf("plugin %s: either address or binary must be specified", config.Name)
+		return errors.Newf("plugin %s: either address or binary must be specified", config.Name)
 	}
 
 	// Connect to the plugin
@@ -138,7 +139,7 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 		if process != nil {
 			process.Kill()
 		}
-		return fmt.Errorf("failed to connect to plugin %s at %s: %w", config.Name, addr, err)
+		return errors.Wrapf(err, "failed to connect to plugin %s at %s", config.Name, addr)
 	}
 
 	m.plugins[config.Name] = &managedPlugin{
@@ -186,14 +187,14 @@ func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, p
 	if !filepath.IsAbs(binary) {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get home directory for plugin %s: %w", config.Name, err)
+			return nil, errors.Wrapf(err, "failed to get home directory for plugin %s", config.Name)
 		}
 		binary = filepath.Join(home, ".qntx", "plugins", binary)
 	}
 
 	// Check if binary exists
 	if _, err := os.Stat(binary); os.IsNotExist(err) {
-		return nil, fmt.Errorf("plugin binary not found for %s: %s", config.Name, binary)
+		return nil, errors.Newf("plugin binary not found for %s: %s", config.Name, binary)
 	}
 
 	// Build command arguments
@@ -212,8 +213,8 @@ func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, p
 	cmd.Stderr = &pluginLogger{logger: m.logger, name: config.Name, level: "error"}
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to start plugin %s (binary=%s, args=%v): %w",
-			config.Name, binary, args, err)
+		return nil, errors.Wrapf(err, "failed to start plugin %s (binary=%s, args=%v)",
+			config.Name, binary, args)
 	}
 
 	return cmd.Process, nil
@@ -240,7 +241,7 @@ func (m *PluginManager) waitForPlugin(ctx context.Context, addr string, timeout 
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	return fmt.Errorf("timeout waiting for plugin at %s", addr)
+	return errors.Newf("timeout waiting for plugin at %s", addr)
 }
 
 // GetPlugin returns a connected plugin as a DomainPlugin.
@@ -311,7 +312,7 @@ func (m *PluginManager) Shutdown(ctx context.Context) error {
 	m.plugins = make(map[string]*managedPlugin)
 
 	if len(errs) > 0 {
-		return fmt.Errorf("shutdown errors: %v", errs)
+		return errors.Newf("shutdown errors: %v", errs)
 	}
 	return nil
 }

--- a/plugin/grpc/loader.go
+++ b/plugin/grpc/loader.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-getter"
 	"github.com/teranos/QNTX/am"
+	"github.com/teranos/QNTX/errors"
 	"go.uber.org/zap"
 )
 
@@ -50,7 +51,7 @@ func LoadPluginsFromConfig(ctx context.Context, cfg *am.Config, logger *zap.Suga
 	// Load discovered plugins
 	if len(pluginConfigs) > 0 {
 		if err := manager.LoadPlugins(ctx, pluginConfigs); err != nil {
-			return nil, fmt.Errorf("failed to load plugins: %w", err)
+			return nil, errors.Wrap(err, "failed to load plugins")
 		}
 
 		// Configure WebSocket settings from am.Config
@@ -140,7 +141,7 @@ func discoverPlugin(name string, searchPaths []string, logger *zap.SugaredLogger
 		}
 	}
 
-	return PluginConfig{}, fmt.Errorf("plugin binary not found in search paths: %s", strings.Join(expandedPaths, ", "))
+	return PluginConfig{}, errors.Newf("plugin binary not found in search paths: %s", strings.Join(expandedPaths, ", "))
 }
 
 // expandAndValidatePath safely expands and validates a path using go-getter.
@@ -150,13 +151,13 @@ func expandAndValidatePath(path string) (string, error) {
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
+			return "", errors.Wrap(err, "failed to get home directory")
 		}
 		path = filepath.Join(home, path[2:])
 	} else if path == "~" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
+			return "", errors.Wrap(err, "failed to get home directory")
 		}
 		return home, nil
 	}
@@ -170,13 +171,13 @@ func expandAndValidatePath(path string) (string, error) {
 	// Use go-getter's detection to safely handle paths
 	detected, err := getter.Detect(path, pwd, getter.Detectors)
 	if err != nil {
-		return "", fmt.Errorf("invalid path: %w", err)
+		return "", errors.Wrap(err, "invalid path")
 	}
 
 	// Parse the detected URL/path
 	u, err := url.Parse(detected)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse path: %w", err)
+		return "", errors.Wrap(err, "failed to parse path")
 	}
 
 	// For file:// URLs, extract the path
@@ -188,10 +189,10 @@ func expandAndValidatePath(path string) (string, error) {
 	if u.Scheme == "" {
 		abs, err := filepath.Abs(path)
 		if err != nil {
-			return "", fmt.Errorf("failed to make absolute path: %w", err)
+			return "", errors.Wrap(err, "failed to make absolute path")
 		}
 		return abs, nil
 	}
 
-	return "", fmt.Errorf("unsupported path scheme: %s (expected file:// or local path)", u.Scheme)
+	return "", errors.Newf("unsupported path scheme: %s (expected file:// or local path)", u.Scheme)
 }

--- a/plugin/grpc/queue_server.go
+++ b/plugin/grpc/queue_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"github.com/teranos/QNTX/pulse/async"
 	"go.uber.org/zap"
@@ -31,7 +32,7 @@ func NewQueueServer(queue *async.Queue, authToken string, logger *zap.SugaredLog
 // validateAuth checks the authentication token
 func (s *QueueServer) validateAuth(token string) error {
 	if subtle.ConstantTimeCompare([]byte(token), []byte(s.authToken)) != 1 {
-		return fmt.Errorf("invalid authentication token")
+		return errors.New("invalid authentication token")
 	}
 	return nil
 }

--- a/plugin/grpc/remote_atsstore.go
+++ b/plugin/grpc/remote_atsstore.go
@@ -3,11 +3,11 @@ package grpc
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -60,7 +60,7 @@ func (r *RemoteATSStore) GenerateAndCreateAttestation(cmd *types.AsCommand) (*ty
 	if cmd.Attributes != nil {
 		attributesJSON, err := json.Marshal(cmd.Attributes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal attributes: %w", err)
+			return nil, errors.Wrap(err, "failed to marshal attributes")
 		}
 		protoCmd.AttributesJson = string(attributesJSON)
 	}
@@ -80,7 +80,7 @@ func (r *RemoteATSStore) GenerateAndCreateAttestation(cmd *types.AsCommand) (*ty
 	}
 
 	if !resp.Success {
-		return nil, fmt.Errorf("failed to generate attestation: %s", resp.Error)
+		return nil, errors.Newf("failed to generate attestation: %s", resp.Error)
 	}
 
 	// Convert response to types.As
@@ -180,17 +180,17 @@ func (r *RemoteATSStore) GetAttestations(filter ats.AttestationFilter) ([]*types
 // Use GenerateAndCreateAttestation instead.
 func (r *RemoteATSStore) CreateAttestation(a *types.As) error {
 	r.logger.Warn("CreateAttestation not supported for remote plugins - use GenerateAndCreateAttestation")
-	return fmt.Errorf("CreateAttestation not supported for remote plugins")
+	return errors.New("CreateAttestation not supported for remote plugins")
 }
 
 // GetAttestation is not implemented for remote plugins.
 func (r *RemoteATSStore) GetAttestation(asid string) (*types.As, error) {
 	r.logger.Warn("GetAttestation not supported for remote plugins yet")
-	return nil, fmt.Errorf("GetAttestation not supported for remote plugins yet")
+	return nil, errors.New("GetAttestation not supported for remote plugins yet")
 }
 
 // DeleteAttestation is not implemented for remote plugins.
 func (r *RemoteATSStore) DeleteAttestation(asid string) error {
 	r.logger.Warn("DeleteAttestation not supported for remote plugins")
-	return fmt.Errorf("DeleteAttestation not supported for remote plugins")
+	return errors.New("DeleteAttestation not supported for remote plugins")
 }

--- a/plugin/grpc/services_manager.go
+++ b/plugin/grpc/services_manager.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"net"
 
 	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"github.com/teranos/QNTX/pulse/async"
 	"go.uber.org/zap"
@@ -41,13 +41,13 @@ func (m *ServicesManager) Start(ctx context.Context, store *storage.SQLStore, qu
 	// Generate authentication token
 	authToken, err := generateAuthToken()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate auth token: %w", err)
+		return nil, errors.Wrap(err, "failed to generate auth token")
 	}
 
 	// Start ATSStore service
 	atsStoreAddr, err := m.startATSStoreService(ctx, store, authToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start ATS store service: %w", err)
+		return nil, errors.Wrap(err, "failed to start ATS store service")
 	}
 
 	// Start Queue service
@@ -57,7 +57,7 @@ func (m *ServicesManager) Start(ctx context.Context, store *storage.SQLStore, qu
 		if m.atsStoreServer != nil {
 			m.atsStoreServer.Stop()
 		}
-		return nil, fmt.Errorf("failed to start queue service: %w", err)
+		return nil, errors.Wrap(err, "failed to start queue service")
 	}
 
 	m.endpoints = ServiceEndpoints{
@@ -79,7 +79,7 @@ func (m *ServicesManager) startATSStoreService(ctx context.Context, store *stora
 	// Listen on dynamic port
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return "", fmt.Errorf("failed to listen: %w", err)
+		return "", errors.Wrap(err, "failed to listen")
 	}
 
 	// Create gRPC server
@@ -112,7 +112,7 @@ func (m *ServicesManager) startQueueService(ctx context.Context, queue *async.Qu
 	// Listen on dynamic port
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return "", fmt.Errorf("failed to listen: %w", err)
+		return "", errors.Wrap(err, "failed to listen")
 	}
 
 	// Create gRPC server

--- a/plugin/grpc/websocket_keepalive.go
+++ b/plugin/grpc/websocket_keepalive.go
@@ -2,12 +2,12 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"go.uber.org/zap"
 )
@@ -381,7 +381,7 @@ func (h *KeepaliveHandler) ConnectWithRetry(ctx context.Context, connect func() 
 		}
 	}
 
-	return fmt.Errorf("failed after %d reconnect attempts: %w", h.config.ReconnectAttempts, lastErr)
+	return errors.Wrapf(lastErr, "failed after %d reconnect attempts", h.config.ReconnectAttempts)
 }
 
 // HandleMessage processes incoming WebSocket messages for keepalive-related types
@@ -399,7 +399,7 @@ func (h *KeepaliveHandler) HandleMessage(msg *protocol.WebSocketMessage) (*proto
 	case protocol.WebSocketMessage_ERROR:
 		errMsg := string(msg.Data)
 		h.logger.Errorw("WebSocket error received", "error", errMsg)
-		return nil, fmt.Errorf("websocket error: %s", errMsg)
+		return nil, errors.Newf("websocket error: %s", errMsg)
 
 	default:
 		// Not a keepalive message, let caller handle it


### PR DESCRIPTION
Replace fmt.Errorf with QNTX errors package (wrapping cockroachdb/errors)
for consistent error handling with stack traces across the codebase.

Changes:
- Replace fmt.Errorf("msg: %w", err) with errors.Wrap(err, "msg")
- Replace fmt.Errorf("msg %s: %w", arg, err) with errors.Wrapf(err, "msg %s", arg)
- Replace fmt.Errorf("msg") with errors.New("msg")
- Replace fmt.Errorf("msg %s", arg) with errors.Newf("msg %s", arg)

Files updated:
- plugin/grpc/server.go
- plugin/grpc/client.go
- plugin/grpc/discovery.go
- plugin/grpc/loader.go
- plugin/grpc/services_manager.go
- plugin/grpc/remote_atsstore.go
- plugin/grpc/remote_queue.go
- plugin/grpc/atsstore_server.go
- plugin/grpc/queue_server.go
- plugin/grpc/websocket_keepalive.go