### PR TITLE
Rename container to qntx-code-plugin for clarity

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -18,8 +18,8 @@ jobs:
         image:
           - name: ci-image
             registry: ghcr.io/teranos/qntx
-          - name: qntx-code-image
-            registry: ghcr.io/teranos/qntx-code
+          - name: qntx-code-plugin-image
+            registry: ghcr.io/teranos/qntx-code-plugin
 
     steps:
       - name: Checkout repository
@@ -55,7 +55,7 @@ jobs:
           nix build .#qntx --print-out-paths --no-link | cachix push qntx
 
       - name: Build and cache qntx-code plugin binary
-        if: matrix.image.name == 'qntx-code-image'
+        if: matrix.image.name == 'qntx-code-plugin-image'
         run: |
           nix build .#qntx-code --print-build-logs
           nix build .#qntx-code --print-out-paths --no-link | cachix push qntx
@@ -129,8 +129,8 @@ jobs:
         image:
           - name: ci-image
             registry: ghcr.io/teranos/qntx
-          - name: qntx-code-image
-            registry: ghcr.io/teranos/qntx-code
+          - name: qntx-code-plugin-image
+            registry: ghcr.io/teranos/qntx-code-plugin
 
     steps:
       - name: Log in to GHCR

--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
 
         # Helper function to build qntx-code plugin image for specific architecture
         mkCodeImage = arch: pkgs.dockerTools.buildLayeredImage {
-          name = "ghcr.io/teranos/qntx-code";
+          name = "ghcr.io/teranos/qntx-code-plugin";
           tag = "latest";
           architecture = arch;
 
@@ -223,9 +223,9 @@
           ci-image-arm64 = mkCiImage "arm64";
 
           # qntx-code plugin Docker images (minimal runtime)
-          qntx-code-image = codeImage;
-          qntx-code-image-amd64 = mkCodeImage "amd64";
-          qntx-code-image-arm64 = mkCodeImage "arm64";
+          qntx-code-plugin-image = codeImage;
+          qntx-code-plugin-image-amd64 = mkCodeImage "amd64";
+          qntx-code-plugin-image-arm64 = mkCodeImage "arm64";
 
           # Default: CLI binary for easy installation
           default = qntx;
@@ -250,7 +250,7 @@
           qntx-build = qntx; # Ensure QNTX builds
           qntx-code-build = qntx-code; # Ensure qntx-code plugin builds
           ci-image = ciImage; # Ensure CI image builds
-          qntx-code-image = codeImage; # Ensure qntx-code image builds
+          qntx-code-plugin-image = codeImage; # Ensure qntx-code plugin image builds
         };
       }
     );


### PR DESCRIPTION
## Summary

Renames the container image from `qntx-code` to `qntx-code-plugin` to make it more distinct and obvious what it contains.

## Changes

- **Image name:** `ghcr.io/teranos/qntx-code` → `ghcr.io/teranos/qntx-code-plugin`
- **Package names:** `qntx-code-image-*` → `qntx-code-plugin-image-*`
- **Workflow matrix:** Updated both build-push and create-manifest jobs

## Rationale

The `-plugin` suffix makes it immediately clear that this is a plugin container, distinguishing it from:
- `qntx` (main CLI)
- `qntx-code` (the plugin binary itself)
- `qntx-code-plugin` (the containerized plugin)