### PR TITLE
Remove unused Tauri dependencies from CI image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,20 +96,8 @@
             pkgs.rustfmt
             pkgs.clippy
 
-            # Tauri system dependencies (from NixOS Wiki)
-            pkgs.webkitgtk_4_1
-            pkgs.gtk3
-            pkgs.at-spi2-atk
-            pkgs.cairo
-            pkgs.gdk-pixbuf
-            pkgs.glib
-            pkgs.harfbuzz
-            pkgs.librsvg
-            pkgs.libsoup_3
-            pkgs.pango
-            pkgs.gobject-introspection
+            # System dependencies
             pkgs.openssl
-            pkgs.libayatana-appindicator
             pkgs.patchelf
 
             # Build tools and utilities
@@ -142,7 +130,7 @@
           config = {
             Env = [
               "PATH=${pkgs.lib.makeBinPath [ qntx pkgs.go pkgs.git pkgs.rustc pkgs.cargo pkgs.rustfmt pkgs.clippy pkgs.pkg-config pkgs.gcc pkgs.gnumake pkgs.coreutils pkgs.diffutils pkgs.findutils pkgs.bash ]}"
-              "PKG_CONFIG_PATH=${pkgs.lib.makeSearchPathOutput "dev" "lib/pkgconfig" [ pkgs.glib pkgs.gtk3 pkgs.at-spi2-atk pkgs.cairo pkgs.gdk-pixbuf pkgs.harfbuzz pkgs.librsvg pkgs.libsoup_3 pkgs.pango pkgs.gobject-introspection pkgs.webkitgtk_4_1 pkgs.openssl ]}:${pkgs.lib.concatMapStringsSep ":" (p: "${p}/lib/pkgconfig") [ pkgs.libayatana-appindicator ]}"
+              "PKG_CONFIG_PATH=${pkgs.lib.makeSearchPathOutput "dev" "lib/pkgconfig" [ pkgs.openssl ]}"
               "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
               "LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc ]}"
             ];


### PR DESCRIPTION
## Problem

CI builds failing with:
```
error: Package 'webkitgtk-2.50.4+abi=4.1' is marked as broken
```

## Root Cause

The CI image included full Tauri system dependencies (webkitgtk, gtk3, cairo, etc.) but these are never used:
- Tauri workflows use platform-native runners (not Docker)
- CI image is only used for Go/Rust tests and type generation

## Solution

Remove all Tauri-specific dependencies from CI image:
- ❌ Removed: webkitgtk, gtk3, cairo, glib, pango, librsvg, etc. (13 packages)
- ✅ Kept: openssl (needed for HTTPS), patchelf (useful for binaries)

## Benefits

- Fixes broken builds
- Reduces image size significantly  
- Faster builds (fewer dependencies to fetch)
- Clearer purpose (Go/Rust dev environment, not Tauri)