### PR TITLE
Add generate-types Nix app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,11 @@ cli-nocgo: ## Build QNTX CLI binary without CGO (for Windows or environments wit
 typegen: ## Build standalone typegen binary (pure Go, no plugins/CGO)
 	@go build -o bin/typegen ./cmd/typegen
 
-types: typegen ## Generate TypeScript, Python, Rust types and markdown docs from Go source
-	@echo "Generating types and documentation..."
-	@./bin/typegen --lang typescript --output types/generated/
-	@./bin/typegen --lang python --output types/generated/
-	@./bin/typegen --lang rust --output types/generated/
-	@./bin/typegen --lang markdown  # Defaults to docs/types/
-	@echo "✓ TypeScript types generated in types/generated/typescript/"
-	@echo "✓ Python types generated in types/generated/python/"
-	@echo "✓ Rust types generated in types/generated/rust/"
-	@echo "✓ Markdown docs generated in docs/types/"
+types: ## Generate TypeScript, Python, Rust types and markdown docs from Go source (via Nix)
+	@nix run .#generate-types
 
-types-check: typegen ## Check if generated types are up to date (uses standalone typegen, no plugins)
-	@./bin/typegen check
+types-check: ## Check if generated types are up to date (via Nix)
+	@nix run .#check-types
 
 server: cli ## Start QNTX WebSocket server
 	@echo "Starting QNTX server..."

--- a/flake.nix
+++ b/flake.nix
@@ -440,6 +440,18 @@
               echo "✓ Markdown docs generated in docs/types/"
             '');
           };
+
+          check-types = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "check-types" ''
+              set -e
+              # Ensure typegen is built
+              ${pkgs.nix}/bin/nix build .#typegen
+
+              # Run typegen check
+              ./result/bin/typegen check
+            '');
+          };
         };
       }
     );


### PR DESCRIPTION
First step in migrating Makefile functionality to Nix.

- Adds `nix run .#generate-types` app for reproducible type generation
- Generates TypeScript, Python, Rust types and Markdown docs from Go source
- Tested locally: successfully generates all types
- Local `nix flake check` passes

Part of the larger effort to reduce Makefile size by moving reproducible builds to Nix.

Next steps (separate PRs):
- Proto generation
- Plugin installation
- Rust fuzzy build