### PR TITLE
Remove redundant builds from CI workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,18 +39,6 @@ jobs:
       - name: Run flake checks
         run: nix flake check --show-trace
 
-      - name: Build QNTX CLI
-        run: nix build .#qntx --print-build-logs
-
-      - name: Build qntx-code plugin
-        run: nix build .#qntx-code --print-build-logs
-
-      - name: Build qntx-python plugin
-        run: nix build .#qntx-python --print-build-logs
-
-      - name: Build documentation site
-        run: nix build .#docs-site --print-build-logs
-
       - name: Push to Cachix
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
## Problem

CI was building all packages twice:
1. First via `nix flake check` (which builds qntx, qntx-code, qntx-python, docs-site, typegen via checks attribute)
2. Again via individual build steps

This was doubling CI time (~11-12 minutes per platform).

## Solution

Remove redundant individual build steps. The Cachix push steps still work correctly - `nix build` reuses already-built paths from the Nix store (populated by flake check).

## Expected Impact

CI time should roughly halve (from ~11-12 minutes to ~6-7 minutes per platform).