### PR TITLE
Add generate-proto Nix app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,12 +172,8 @@ desktop-build: desktop-prepare ## Build production desktop app (requires: cargo 
 		cp web/src-tauri/bin/qntx-$$TARGET target/release/bundle/macos/QNTX.app/Contents/MacOS/
 	@echo "✓ Desktop app built in target/release/bundle/"
 
-proto: ## Generate Go code from protobuf definitions
-	@echo "Generating gRPC code from proto files..."
-	@protoc --go_out=. --go_opt=paths=source_relative \
-		--go-grpc_out=. --go-grpc_opt=paths=source_relative \
-		plugin/grpc/protocol/domain.proto
-	@echo "✓ Proto files generated in plugin/grpc/protocol/"
+proto: ## Generate Go code from protobuf definitions (via Nix)
+	@nix run .#generate-proto
 
 plugins: ## Build and install all external plugin binaries to ~/.qntx/plugins/
 	@echo "Building external plugins..."

--- a/flake.nix
+++ b/flake.nix
@@ -452,6 +452,24 @@
               ./result/bin/typegen check
             '');
           };
+
+          generate-proto = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "generate-proto" ''
+              set -e
+              echo "Generating gRPC code from proto files..."
+
+              # Use protoc from nixpkgs with Go plugins
+              ${pkgs.protobuf}/bin/protoc \
+                --plugin=${pkgs.protoc-gen-go}/bin/protoc-gen-go \
+                --plugin=${pkgs.protoc-gen-go-grpc}/bin/protoc-gen-go-grpc \
+                --go_out=. --go_opt=paths=source_relative \
+                --go-grpc_out=. --go-grpc_opt=paths=source_relative \
+                plugin/grpc/protocol/domain.proto
+
+              echo "✓ Proto files generated in plugin/grpc/protocol/"
+            '');
+          };
         };
       }
     );


### PR DESCRIPTION
## Summary

Migrates proto generation from Makefile to Nix for reproducibility.

## Changes

- Added `generate-proto` Nix app with protoc + Go plugins (protoc-gen-go, protoc-gen-go-grpc)
- Updated `make proto` to call `nix run .#generate-proto`
- Reduces Makefile from 6 lines to 2 lines

## Testing

- `nix run .#generate-proto` - generates proto files successfully
- `make proto` - works via Nix app

## Part of Makefile-to-Nix migration series

- PR #235: Type generation ✓ merged
- This PR: Proto generation
- Next: Plugin installation
- Final: Rust fuzzy build