### PR TITLE
Enable parallel builds in CI with --max-jobs auto

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,7 @@ jobs:
           nix run nixpkgs#nixpkgs-fmt -- --check *.nix
 
       - name: Run flake checks
-        run: nix flake check --show-trace
+        run: nix flake check --max-jobs auto --show-trace
 
       - name: Push to Cachix
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Problem

CI was building packages sequentially within each platform job, not utilizing available CPU cores.

## Solution

Add `--max-jobs auto` to `nix flake check` to enable Nix's built-in parallelization.

## Expected Impact

On GitHub Actions standard runners (2 cores), this should allow Nix to build independent packages concurrently, potentially reducing CI time.

## Testing

Will compare CI time before/after to measure actual speedup.