### PR TITLE
Replace console.* with shared logger in system-drawer

### DIFF
--- a/web/ts/system-drawer.ts
+++ b/web/ts/system-drawer.ts
@@ -4,6 +4,7 @@ import { MAX_LOGS, appState } from './config.ts';
 import { sendMessage } from './websocket.ts';
 import { CSS } from './css-classes.ts';
 import { formatTimestamp } from './html-utils.ts';
+import { log, SEG } from './logger.ts';
 import type { LogsMessage, LogEntry } from '../types/websocket';
 
 // Make this a module
@@ -19,14 +20,14 @@ const LOG_LEVEL_MAP: Record<string, string> = {
 
 // Log handling - accepts the full WebSocket message type
 export function handleLogBatch(data: LogsMessage): void {
-    console.log('📋 handleLogBatch called:', data);
+    log.info(SEG.WS, '📋 handleLogBatch called:', data);
 
     if (!data.data || !data.data.messages) {
-        console.warn('⚠️  No data.data.messages in log batch:', data);
+        log.warn(SEG.WS, '⚠️  No data.data.messages in log batch:', data);
         return;
     }
 
-    console.log(`📝 Processing ${data.data.messages.length} log messages`);
+    log.info(SEG.WS, `📝 Processing ${data.data.messages.length} log messages`);
 
     data.data.messages.forEach(msg => {
         appendLog(msg);


### PR DESCRIPTION
### Motivation
- Centralize UI logging by using the existing shared logger instead of ad-hoc `console.*` calls.
- Ensure WebSocket log handling messages carry a consistent SEG context (`SEG.WS`).
- Preserve existing log message content and types while improving consistency with other modules.

### Description
- Import `log` and `SEG` from `./logger.ts` into `web/ts/system-drawer.ts`.
- Replace `console.log('📋 handleLogBatch called:', ...)` with `log.info(SEG.WS, ...)` inside `handleLogBatch`.
- Replace the missing-data `console.warn(...)` with `log.warn(SEG.WS, ...)` and the processing message with `log.info(SEG.WS, ...)`.
- No other behavioral changes were made; DOM handling and types remain unchanged.

### Testing
- No automated tests were run for this change.
- A commit was created and the modified file was staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69617c79e7d083318246f636299b6c1e)