### PR TITLE
Use logger for plugin health websocket updates

### DIFF
--- a/web/ts/logger.ts
+++ b/web/ts/logger.ts
@@ -17,7 +17,7 @@
  *   log.warn('⚠', 'Rate limit approaching');
  *   log.error('⊔', 'Database connection failed', error);
  *
- * TODO: Migrate remaining 43 files from console.* to log.*:
+ * TODO: Migrate remaining 42 files from console.* to log.*:
  *   - system-drawer.ts (3)
  *   - codemirror-editor.ts (5)
  *   - ai-provider-panel.ts (9)
@@ -56,7 +56,6 @@
  *   - websocket-handlers/system-capabilities.ts (1)
  *   - graph/renderer.ts (3)
  *   - storage.ts (6)
- *   - websocket-handlers/plugin-health.ts (1)
  *   - graph/focus.ts (9)
  *   - graph/focus/dimensions.ts (1)
  *   - graph/focus/physics.ts (2)

--- a/web/ts/websocket-handlers/plugin-health.ts
+++ b/web/ts/websocket-handlers/plugin-health.ts
@@ -7,6 +7,7 @@
  */
 
 import { toast } from '../toast';
+import { log, SEG } from '../logger';
 import type { PluginHealthMessage } from '../../types/websocket';
 
 // Track unhealthy plugins for indicator
@@ -16,7 +17,7 @@ const unhealthyPlugins = new Set<string>();
  * Handle plugin health message - display toast and update indicator
  */
 export function handlePluginHealth(data: PluginHealthMessage): void {
-    console.log('Plugin health update:', data.name, data.state, data.healthy ? 'healthy' : 'unhealthy');
+    log.debug(SEG.WS, 'Plugin health update:', data.name, data.state, data.healthy ? 'healthy' : 'unhealthy');
 
     // Update unhealthy set
     if (!data.healthy) {


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `console.log` usage with the centralized logging utility to standardize logging behavior.
- Tag websocket logs with the `SEG.WS` symbol for consistent visual context in logs.
- Keep runtime behavior unchanged while moving to the leveled logger.
- Reflect the migration in the manual logger TODO list.

### Description
- Import `log` and `SEG` in `web/ts/websocket-handlers/plugin-health.ts` and replace the `console.log` call with `log.debug(SEG.WS, ...)`.
- Update the `web/ts/logger.ts` TODO comment to decrement the remaining files count and remove the `websocket-handlers/plugin-health.ts` entry.
- No other functional changes were made to `handlePluginHealth` or its related helpers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696181d78eb08331a725359c3586c99a)