### PR TITLE
Centralize window-tray state in uiState

### DIFF
--- a/web/ts/state/ui.ts
+++ b/web/ts/state/ui.ts
@@ -75,6 +75,9 @@ export interface UIStateData {
     // Graph session (query, verbosity, transform)
     graphSession: GraphSessionState;
 
+    // Minimized window IDs (for window tray)
+    minimizedWindows: string[];
+
     // Timestamp for state versioning
     lastUpdated: number;
 }
@@ -99,6 +102,7 @@ interface PersistedUIState {
     activeModality: string;
     usageView: 'week' | 'month';
     graphSession: GraphSessionState;
+    minimizedWindows: string[];
 }
 
 // ============================================================================
@@ -130,6 +134,7 @@ function createDefaultState(): UIStateData {
         },
         usageView: 'week',
         graphSession: {},
+        minimizedWindows: [],
         lastUpdated: Date.now(),
     };
 }
@@ -326,6 +331,48 @@ class UIState {
     }
 
     // ========================================================================
+    // Minimized Windows Management
+    // ========================================================================
+
+    /**
+     * Get minimized window IDs
+     */
+    getMinimizedWindows(): string[] {
+        return this.state.minimizedWindows;
+    }
+
+    /**
+     * Add a window to the minimized list
+     */
+    addMinimizedWindow(id: string): void {
+        if (this.state.minimizedWindows.includes(id)) return;
+        const updated = [...this.state.minimizedWindows, id];
+        this.update('minimizedWindows', updated);
+    }
+
+    /**
+     * Remove a window from the minimized list
+     */
+    removeMinimizedWindow(id: string): void {
+        const updated = this.state.minimizedWindows.filter(wid => wid !== id);
+        this.update('minimizedWindows', updated);
+    }
+
+    /**
+     * Check if a window is minimized
+     */
+    isWindowMinimized(id: string): boolean {
+        return this.state.minimizedWindows.includes(id);
+    }
+
+    /**
+     * Clear all minimized windows
+     */
+    clearMinimizedWindows(): void {
+        this.update('minimizedWindows', []);
+    }
+
+    // ========================================================================
     // Subscription (Pub/Sub)
     // ========================================================================
 
@@ -432,6 +479,7 @@ class UIState {
             activeModality: this.state.activeModality,
             usageView: this.state.usageView,
             graphSession: this.state.graphSession,
+            minimizedWindows: this.state.minimizedWindows,
             // Don't persist: panels (should start closed), budgetWarnings (session-only)
         };
     }
@@ -461,6 +509,7 @@ class UIState {
             activeModality: persisted.activeModality ?? defaultState.activeModality,
             usageView: persisted.usageView ?? defaultState.usageView,
             graphSession: persisted.graphSession ?? defaultState.graphSession,
+            minimizedWindows: persisted.minimizedWindows ?? defaultState.minimizedWindows,
         };
     }
 


### PR DESCRIPTION
## Summary
Refactors window-tray to use centralized state management instead of raw localStorage access.

## Changes
- **state/ui.ts**: Added `minimizedWindows: string[]` to UIStateData with accessor methods
- **window-tray.ts**: Replaced direct localStorage calls with `uiState` methods
- **Tests**: Updated to verify state through `uiState` instead of localStorage

## Why
The window-tray was using raw localStorage operations while the rest of the app uses the centralized `state/ui.ts` + `state/storage.ts` layer. This created:
- Parallel persistence patterns (inconsistent)
- No centralized observability (can't subscribe to tray changes)
- Different error handling approaches

## Benefits
✅ Single source of truth for all UI state
✅ Centralized observability (can subscribe to `minimizedWindows`)
✅ Consistent error handling through `storage.ts`
✅ Automatic timestamping and versioning
✅ Easier to extend (e.g., "restore all windows" feature)

## Testing
- All 14 window-tray DOM tests pass
- Full web test suite passes (298 tests)
- TypeScript compiles without errors