### PR TITLE
Make Pulse domain-agnostic by removing ats/ix dependency

### DIFF
--- a/ats/ix/progress_domain_agnostic_test.go
+++ b/ats/ix/progress_domain_agnostic_test.go
@@ -137,6 +137,10 @@ func (m *MedicalProgressEmitter) EmitStage(stage string, message string) {
 	m.base.EmitStage(stage, message)
 }
 
+func (m *MedicalProgressEmitter) EmitProgress(count int, metadata map[string]interface{}) {
+	m.base.EmitProgress(count, metadata)
+}
+
 func (m *MedicalProgressEmitter) EmitAttestations(count int, entities []ix.AttestationEntity) {
 	m.base.EmitAttestations(count, entities)
 }
@@ -193,6 +197,10 @@ func (f *FinancialProgressEmitter) EmitTransactionValidated(txnID string, amount
 
 func (f *FinancialProgressEmitter) EmitStage(stage string, message string) {
 	f.base.EmitStage(stage, message)
+}
+
+func (f *FinancialProgressEmitter) EmitProgress(count int, metadata map[string]interface{}) {
+	f.base.EmitProgress(count, metadata)
 }
 
 func (f *FinancialProgressEmitter) EmitAttestations(count int, entities []ix.AttestationEntity) {

--- a/ats/storage/ix_integration_test.go
+++ b/ats/storage/ix_integration_test.go
@@ -60,6 +60,10 @@ func (m *mockEmitter) EmitComplete(summary map[string]interface{}) {
 	m.completeCalls = append(m.completeCalls, summary)
 }
 
+func (m *mockEmitter) EmitProgress(count int, metadata map[string]interface{}) {
+	// Not tracked in mock for now
+}
+
 func (m *mockEmitter) EmitAttestations(count int, entities []ix.AttestationEntity) {
 	// Not tracked in mock for now
 }

--- a/pulse/progress.go
+++ b/pulse/progress.go
@@ -1,0 +1,66 @@
+package pulse
+
+// ProgressEmitter defines the domain-agnostic interface for emitting progress updates
+// during long-running operations. This interface lives in the infrastructure layer (pulse)
+// and should NOT contain any domain-specific methods.
+//
+// Domain packages can:
+// 1. Use these methods directly for generic progress reporting
+// 2. Create wrapper emitters that add domain-specific convenience methods
+//    (see ats/ix/progress_domain_agnostic_test.go for examples)
+type ProgressEmitter interface {
+	// EmitStage announces the start of a processing stage
+	EmitStage(stage string, message string)
+
+	// EmitProgress announces batch progress with count and optional metadata.
+	// This is the generic replacement for domain-specific methods like EmitAttestations.
+	// Domains can pass entity data as metadata maps.
+	EmitProgress(count int, metadata map[string]interface{})
+
+	// EmitComplete announces successful completion with summary
+	EmitComplete(summary map[string]interface{})
+
+	// EmitError announces an error during processing
+	EmitError(stage string, err error)
+
+	// EmitInfo emits general informational message
+	EmitInfo(message string)
+}
+
+// ProgressEntity represents a generic entity for progress tracking.
+// This is domain-agnostic - any domain can use it for their entities.
+type ProgressEntity struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// JobBroadcaster is an optional interface that ProgressEmitter implementations
+// can implement to support job tracking and broadcasting to UI clients.
+type JobBroadcaster interface {
+	// BroadcastJobUpdate sends a job update to all connected clients
+	// The job parameter should be of type *async.Job but is interface{} to avoid import cycles
+	BroadcastJobUpdate(job interface{})
+}
+
+// TaskTracker is an optional interface that ProgressEmitter implementations
+// can implement to support fine-grained task tracking (e.g., individual items being processed).
+// This enables UI visualizations like progress squares.
+type TaskTracker interface {
+	// AddTask registers a new task that will be tracked
+	// taskID: unique identifier (e.g., item ID, entity ID)
+	// taskName: display name (e.g., "Entity-A", "Item-123")
+	AddTask(taskID string, taskName string)
+
+	// UpdateTaskStatus updates a task's completion status
+	// taskID: the task to update
+	// completed: true if task finished successfully, false if failed
+	// result: optional result summary (e.g., "Processed: 15 items")
+	UpdateTaskStatus(taskID string, completed bool, result string)
+}
+
+// LLMStreamBroadcaster is an optional interface for broadcasting LLM streaming events.
+type LLMStreamBroadcaster interface {
+	// BroadcastLLMStream forwards LLM streaming events to clients.
+	BroadcastLLMStream(jobID, taskID, content string, done bool, err error, model, stage string)
+}


### PR DESCRIPTION
Infrastructure packages should not depend on domain packages. This change
inverts the dependency so that ats/ix depends on pulse, not vice versa.

Changes:
- Add pulse/progress.go with domain-agnostic ProgressEmitter interface
- Remove EmitCandidateMatch from JobProgressEmitter (domain-specific)
- Replace EmitAttestations with generic EmitProgress in pulse/async
- Update ats/ix to extend pulse.ProgressEmitter with domain-specific methods
- Domain wrappers can add convenience methods via the wrapper pattern

The ats/ix package now properly extends the pulse interface with
domain-specific methods like EmitAttestations, while pulse remains
completely domain-agnostic.