### PR TITLE
Extract magic values from pulse/async to make graceful shutdown configurable

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -54,8 +54,8 @@ Infrastructure and lifecycle markers:
 | Symbol | Name | Purpose |
 |--------|------|---------|
 | `꩜` | Pulse | Async operations, always prefix Pulse-related logs. See [API](api/pulse-jobs.md) |
-| `✿` | PulseOpen | Graceful startup with orphaned job recovery |
-| `❀` | PulseClose | Graceful shutdown with checkpoint preservation |
+| `✿` | PulseOpen | Graceful startup with orphaned job recovery. See [Opening & Closing](development/grace.md) |
+| `❀` | PulseClose | Graceful shutdown with checkpoint preservation. See [Opening & Closing](development/grace.md) |
 | `⊔` | DB | Database/storage layer |
 | `▣` | Prose | Documentation and prose content |
 

--- a/docs/development/grace.md
+++ b/docs/development/grace.md
@@ -15,7 +15,7 @@ _(Formerly codename: GRACE - Graceful Async Cancellation Engine)_
 - **Plugin shutdown**: Plugins receive shutdown signal via gRPC, complete in-flight work
 - **Task-level atomicity**: Jobs complete current task before checkpointing
 - **Signal handling**: Application catches signals, triggers shutdown
-- **Worker timeout**: 30 seconds for clean checkpoint and exit
+- **Worker timeout**: 20 seconds for clean checkpoint and exit (configurable via `WorkerPoolConfig.WorkerStopTimeout`)
 - **Job re-queuing**: Cancelled jobs transition to `queued` status with checkpoint intact
 
 ### ✿ Opening (Graceful Start)
@@ -165,12 +165,12 @@ When a parent job completes or fails:
 
 **Location**: `pulse/async/error.go:RetryableError()`
 
-Failed tasks can be retried automatically (max 3 attempts total):
+Failed tasks can be retried automatically (max 2 retries = 3 total attempts):
 
 1. Task fails with retryable error (AI failure, network error, timeout)
 2. System increments `retry_count` and re-queues job
 3. Logs retry attempt: `꩜ Retry 1/2: operation failed | job:JB_abc123`
-4. After max retries, logs: `꩜ Max retries exceeded (2): operation failed | job:JB_abc123`
+4. After max retries exceeded, logs: `꩜ Max retries exceeded (2): operation failed | job:JB_abc123`
 
 **Database tracking**: Each retry attempt updates the job record with retry count and error details, providing full audit trail.
 
@@ -195,7 +195,7 @@ Applications using Pulse should propagate shutdown signals:
 ctx, cancel := context.WithCancel(context.Background())
 defer cancel()
 
-workerPool := async.NewWorkerPool(ctx, db, queue, executor, config)
+workerPool := async.NewWorkerPool(ctx, db, cfg, poolCfg, logger)
 workerPool.Start()
 
 // Handle shutdown signals
@@ -204,12 +204,9 @@ signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 <-sigChan
 log.Println("Shutdown signal received, stopping workers...")
-cancel() // Triggers graceful shutdown
 
-// Wait for workers to finish (with timeout)
-shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
-defer shutdownCancel()
-workerPool.StopWithContext(shutdownCtx)
+// Stop() cancels context and waits for workers with timeout (default 20s, configurable via poolCfg.WorkerStopTimeout)
+workerPool.Stop()
 ```
 
 ### Handler Context Checks
@@ -245,9 +242,13 @@ func (h *MyHandler) Execute(ctx context.Context, job *async.Job) error {
 
 ```go
 type WorkerPoolConfig struct {
-    Workers       int           // Number of concurrent workers
-    PollInterval  time.Duration // How often to check for jobs
-    ShutdownTimeout time.Duration // Max time to wait for graceful shutdown
+    Workers              int           // Number of concurrent workers
+    PollInterval         *time.Duration // Poll interval: nil = gradual ramp-up (default), 0 = no polling, positive = fixed interval
+    PauseOnBudget        bool          // Pause jobs when budget exceeded
+    GracefulStartPhase   time.Duration // Duration of each graceful start phase (default: 5min, test: 10s)
+    WorkerStopTimeout    time.Duration // Max time to wait for workers to checkpoint and exit (default: 20s)
+    MaxConsecutiveErrors int           // Threshold for applying exponential backoff (default: 5)
+    MaxBackoff           time.Duration // Maximum exponential backoff duration (default: 30s)
 }
 ```
 
@@ -258,9 +259,12 @@ For faster testing, use shorter intervals:
 ```go
 pollInterval := 100 * time.Millisecond
 config := async.WorkerPoolConfig{
-    Workers:         1,
-    PollInterval:    &pollInterval,
-    ShutdownTimeout: 2 * time.Second,
+    Workers:              1,
+    PollInterval:         &pollInterval,
+    GracefulStartPhase:   10 * time.Second,
+    WorkerStopTimeout:    2 * time.Second,
+    MaxConsecutiveErrors: 3,
+    MaxBackoff:           5 * time.Second,
 }
 ```
 

--- a/pulse/async/grace_test.go
+++ b/pulse/async/grace_test.go
@@ -201,7 +201,7 @@ func TestGRACEWorkerShutdownTimeout(t *testing.T) {
 	select {
 	case <-stopDone:
 		t.Log("✓ Worker pool stopped cleanly")
-	case <-time.After(35 * time.Second): // 30s timeout + 5s buffer
+	case <-time.After(25 * time.Second): // 20s timeout + 5s buffer
 		t.Error("Worker pool shutdown exceeded timeout")
 	}
 }

--- a/pulse/async/worker.go
+++ b/pulse/async/worker.go
@@ -18,6 +18,18 @@ const (
 	// MaxOrphanedJobsToRecover limits how many orphaned jobs we'll attempt to recover
 	// on startup to prevent overwhelming the system after a crash
 	MaxOrphanedJobsToRecover = 1000
+
+	// DefaultWorkerStopTimeout is the default time to wait for workers to checkpoint and exit
+	// during graceful shutdown. Can be overridden via WorkerPoolConfig.
+	DefaultWorkerStopTimeout = 20 * time.Second
+
+	// DefaultMaxConsecutiveErrors is the threshold for applying exponential backoff
+	// when workers encounter repeated errors
+	DefaultMaxConsecutiveErrors = 5
+
+	// DefaultMaxBackoff is the maximum duration for exponential backoff
+	// when workers encounter consecutive errors
+	DefaultMaxBackoff = 30 * time.Second
 )
 
 // BudgetTracker interface defines budget tracking operations
@@ -86,19 +98,25 @@ type WorkerPool struct {
 
 // WorkerPoolConfig contains configuration for the worker pool
 type WorkerPoolConfig struct {
-	Workers            int            `json:"workers"`              // Number of concurrent workers
-	PollInterval       *time.Duration `json:"poll_interval"`        // Poll interval: nil = gradual ramp-up (default), 0 = no polling, positive = fixed interval
-	PauseOnBudget      bool           `json:"pause_on_budget"`      // Pause jobs when budget exceeded
-	GracefulStartPhase time.Duration  `json:"graceful_start_phase"` // Duration of each graceful start phase (default: 5min, test: 10s)
+	Workers            int            `json:"workers"`                // Number of concurrent workers
+	PollInterval       *time.Duration `json:"poll_interval"`          // Poll interval: nil = gradual ramp-up (default), 0 = no polling, positive = fixed interval
+	PauseOnBudget      bool           `json:"pause_on_budget"`        // Pause jobs when budget exceeded
+	GracefulStartPhase time.Duration  `json:"graceful_start_phase"`   // Duration of each graceful start phase (default: 5min, test: 10s)
+	WorkerStopTimeout  time.Duration  `json:"worker_stop_timeout"`    // Max time to wait for workers to checkpoint and exit (default: 20s)
+	MaxConsecutiveErrors int          `json:"max_consecutive_errors"` // Threshold for applying exponential backoff (default: 5)
+	MaxBackoff         time.Duration  `json:"max_backoff"`            // Maximum exponential backoff duration (default: 30s)
 }
 
 // DefaultWorkerPoolConfig returns sensible defaults
 func DefaultWorkerPoolConfig() WorkerPoolConfig {
 	return WorkerPoolConfig{
-		Workers:            1,               // Single worker to avoid race conditions initially
-		PollInterval:       nil,             // nil = gradual ramp-up (production default)
-		PauseOnBudget:      true,            // Pause when budget exceeded
-		GracefulStartPhase: 5 * time.Minute, // 5min per phase = 15min total graceful start
+		Workers:              1,                           // Single worker to avoid race conditions initially
+		PollInterval:         nil,                         // nil = gradual ramp-up (production default)
+		PauseOnBudget:        true,                        // Pause when budget exceeded
+		GracefulStartPhase:   5 * time.Minute,             // 5min per phase = 15min total graceful start
+		WorkerStopTimeout:    DefaultWorkerStopTimeout,    // 20s for checkpoint completion
+		MaxConsecutiveErrors: DefaultMaxConsecutiveErrors, // 5 errors before backoff
+		MaxBackoff:           DefaultMaxBackoff,           // 30s maximum backoff
 	}
 }
 
@@ -303,18 +321,21 @@ func (wp *WorkerPool) gradualRecovery(jobs []*Job) {
 
 // Stop gracefully stops the worker pool
 // ❀ Closing: Workers checkpoint and exit cleanly on context cancellation
-// Uses a 30-second timeout to allow jobs to checkpoint without blocking indefinitely
+// Uses a configurable timeout (default 20s) to allow jobs to checkpoint without blocking indefinitely
 func (wp *WorkerPool) Stop() {
 	wp.cancel()
 
-	// Wait for workers to checkpoint and exit (with generous timeout)
+	// Wait for workers to checkpoint and exit (with configurable timeout)
 	done := make(chan struct{})
 	go func() {
 		wp.wg.Wait()
 		close(done)
 	}()
 
-	timeout := 30 * time.Second // Generous timeout for checkpoint completion
+	timeout := wp.poolConfig.WorkerStopTimeout
+	if timeout == 0 {
+		timeout = DefaultWorkerStopTimeout
+	}
 	select {
 	case <-done:
 		wp.logger.Pulse("❀ WorkerPool.Stop() complete - all workers exited cleanly")
@@ -335,9 +356,15 @@ func (wp *WorkerPool) worker(id int) {
 
 	// Error backoff state
 	errorCount := 0
-	const maxConsecutiveErrors = 5
+	maxConsecutiveErrors := wp.poolConfig.MaxConsecutiveErrors
+	if maxConsecutiveErrors == 0 {
+		maxConsecutiveErrors = DefaultMaxConsecutiveErrors
+	}
 	backoffDuration := time.Second
-	const maxBackoff = 30 * time.Second
+	maxBackoff := wp.poolConfig.MaxBackoff
+	if maxBackoff == 0 {
+		maxBackoff = DefaultMaxBackoff
+	}
 
 	for {
 		select {

--- a/server/types.go
+++ b/server/types.go
@@ -13,7 +13,7 @@ const (
 	MaxClientMessageQueueSize = 256
 	// ShutdownTimeout is how long to wait for graceful shutdown
 	// Set to 60s to accommodate:
-	// - WorkerPool.Stop() can take up to 30s for checkpoint completion
+	// - WorkerPool.Stop() can take up to 20s for checkpoint completion (configurable via WorkerPoolConfig.WorkerStopTimeout)
 	// - Additional time for other goroutines (WebSocket, config watcher, etc.)
 	ShutdownTimeout = 60 * time.Second
 )


### PR DESCRIPTION
Make critical Pulse/Async magic values configurable to enable:
- Dynamic tuning per deployment environment
- Testing with shorter timeouts
- Production optimization based on actual workload

Changes:
- Lower default worker stop timeout from 30s to 20s
- Extract worker error backoff policy (max consecutive errors, max backoff)
- Add WorkerPoolConfig fields for all timing/policy values
- Update grace.md to document new configuration options
- Link GLOSSARY symbols (✿/❀) to grace documentation
- Fix grace.md example code (remove non-existent StopWithContext)
- Clarify retry logic documentation (2 retries = 3 total attempts)
- Update test timeout expectations (20s + 5s buffer)

Configuration now exposed:
- WorkerStopTimeout: 20s (was hardcoded 30s)
- MaxConsecutiveErrors: 5 (was hardcoded)
- MaxBackoff: 30s (was hardcoded)

All GRACE tests passing (20.3s).

https://claude.ai/code/session_019yAFwuuS6vXwZ4pW7rvvcQ