### PR TITLE
Backend coupling analysis: 5 actionable suggestions to reduce high fan-out

### DIFF
--- a/ats/ax/rich_search_matcher.go
+++ b/ats/ax/rich_search_matcher.go
@@ -1,0 +1,51 @@
+package ax
+
+import (
+	"github.com/teranos/QNTX/ats"
+	"github.com/teranos/QNTX/ats/ax/fuzzy-ax/fuzzyax"
+)
+
+// FuzzyRichSearchMatcher implements ats.RichSearchMatcher using the Rust fuzzy engine.
+// Each call to MatchWords creates a short-lived engine, indexes the vocabulary, and
+// finds matches — callers don't manage engine lifecycle.
+type FuzzyRichSearchMatcher struct{}
+
+// NewFuzzyRichSearchMatcher creates a RichSearchMatcher backed by the Rust fuzzy engine.
+// Returns nil if the Rust backend is not available.
+func NewFuzzyRichSearchMatcher() ats.RichSearchMatcher {
+	if DetectBackend() != MatcherBackendRust {
+		return nil
+	}
+	return &FuzzyRichSearchMatcher{}
+}
+
+// MatchWords finds fuzzy matches for each query word against the vocabulary.
+func (m *FuzzyRichSearchMatcher) MatchWords(vocabulary []string, queryWords []string, limit int, minScore float64) (map[string][]ats.WordMatch, error) {
+	engine, err := fuzzyax.NewFuzzyEngine()
+	if err != nil {
+		return nil, err
+	}
+	defer engine.Close()
+
+	if _, err := engine.RebuildIndex(vocabulary, nil); err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]ats.WordMatch, len(queryWords))
+	for _, qw := range queryWords {
+		matches, _, err := engine.FindMatches(qw, fuzzyax.VocabPredicates, limit, minScore)
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			result[qw] = append(result[qw], ats.WordMatch{
+				Value: match.Value,
+				Score: match.Score,
+			})
+		}
+	}
+	return result, nil
+}
+
+// Ensure FuzzyRichSearchMatcher implements ats.RichSearchMatcher
+var _ ats.RichSearchMatcher = (*FuzzyRichSearchMatcher)(nil)

--- a/ats/interfaces.go
+++ b/ats/interfaces.go
@@ -112,6 +112,20 @@ func (n *NoOpQueryExpander) GetNaturalLanguagePredicates() []string {
 	return []string{}
 }
 
+// WordMatch represents a single fuzzy match result from a RichSearchMatcher.
+type WordMatch struct {
+	Value string
+	Score float64
+}
+
+// RichSearchMatcher performs fuzzy word matching for rich text search.
+// Implementations handle engine lifecycle (creation, indexing, cleanup) internally.
+type RichSearchMatcher interface {
+	// MatchWords finds fuzzy matches for each query word against the given vocabulary.
+	// Returns a map from query word to its fuzzy matches.
+	MatchWords(vocabulary []string, queryWords []string, limit int, minScore float64) (map[string][]WordMatch, error)
+}
+
 // getSystemActor generates a system-based actor string using environment variables.
 // This is used internally by DefaultActorDetector.
 func getSystemActor(fallback string) string {

--- a/ats/setup/executor.go
+++ b/ats/setup/executor.go
@@ -1,11 +1,13 @@
-// Package storage provides convenience functions for creating ATS executors with storage.
-package storage
+// Package setup provides convenience functions for assembling ATS executors
+// from storage and alias components.
+package setup
 
 import (
 	"database/sql"
 
 	"github.com/teranos/QNTX/ats/alias"
 	"github.com/teranos/QNTX/ats/ax"
+	"github.com/teranos/QNTX/ats/storage"
 )
 
 // NewExecutor creates a standard AxExecutor with all required dependencies initialized from a database connection.
@@ -23,11 +25,11 @@ import (
 //
 // Example:
 //
-//	executor := storage.NewExecutor(db)
+//	executor := setup.NewExecutor(db)
 //	result, err := executor.ExecuteAsk(ctx, filter)
 func NewExecutor(db *sql.DB) *ax.AxExecutor {
-	queryStore := NewSQLQueryStore(db)
-	aliasStore := NewAliasStore(db)
+	queryStore := storage.NewSQLQueryStore(db)
+	aliasStore := storage.NewAliasStore(db)
 	aliasResolver := alias.NewResolver(aliasStore)
 	return ax.NewAxExecutor(queryStore, aliasResolver)
 }
@@ -45,25 +47,25 @@ func NewExecutor(db *sql.DB) *ax.AxExecutor {
 //
 // Example with semantic query expansion:
 //
-//	executor := storage.NewExecutorWithOptions(db, ax.AxExecutorOptions{
+//	executor := setup.NewExecutorWithOptions(db, ax.AxExecutorOptions{
 //	    QueryExpander: &myapp.SemanticExpander{},
 //	})
 //
 // Example with both query expansion and entity resolution:
 //
-//	executor := storage.NewExecutorWithOptions(db, ax.AxExecutorOptions{
+//	executor := setup.NewExecutorWithOptions(db, ax.AxExecutorOptions{
 //	    QueryExpander:  &myapp.SemanticExpander{},
 //	    EntityResolver: atsAdapter.NewContactEntityResolver(db),
 //	})
 func NewExecutorWithOptions(db *sql.DB, opts ax.AxExecutorOptions) *ax.AxExecutor {
-	var queryStore *SQLQueryStore
+	var queryStore *storage.SQLQueryStore
 	if opts.QueryExpander != nil {
-		queryStore = NewSQLQueryStoreWithExpander(db, opts.QueryExpander)
+		queryStore = storage.NewSQLQueryStoreWithExpander(db, opts.QueryExpander)
 	} else {
-		queryStore = NewSQLQueryStore(db)
+		queryStore = storage.NewSQLQueryStore(db)
 	}
 
-	aliasStore := NewAliasStore(db)
+	aliasStore := storage.NewAliasStore(db)
 	aliasResolver := alias.NewResolver(aliasStore)
 
 	return ax.NewAxExecutorWithOptions(queryStore, aliasResolver, opts)

--- a/ats/so/actions/csv/handler.go
+++ b/ats/so/actions/csv/handler.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/setup"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
 )
@@ -16,7 +16,7 @@ import (
 // Execute generates a CSV file from attestations matching the filter
 func Execute(ctx context.Context, db *sql.DB, payload Payload) error {
 	// Execute the query
-	executor := storage.NewExecutor(db)
+	executor := setup.NewExecutor(db)
 	result, err := executor.ExecuteAsk(ctx, payload.AxFilter)
 	if err != nil {
 		err = errors.Wrap(err, "failed to execute query")

--- a/ats/storage/bounded_store.go
+++ b/ats/storage/bounded_store.go
@@ -35,10 +35,19 @@ type BoundedStore struct {
 	logger *zap.SugaredLogger
 	config *BoundedStoreConfig
 
+	// Fuzzy matcher for rich text search (nil = exact SQL matching only)
+	fuzzyMatcher ats.RichSearchMatcher
+
 	// Cache for type definitions (used by rich search)
 	typeFieldsCache     map[string][]string
 	typeFieldsCacheLock sync.RWMutex
 	typeFieldsCacheTime time.Time
+}
+
+// SetFuzzyMatcher sets the fuzzy matcher for rich text search.
+// If nil, rich search falls back to exact SQL substring matching.
+func (bs *BoundedStore) SetFuzzyMatcher(m ats.RichSearchMatcher) {
+	bs.fuzzyMatcher = m
 }
 
 // NewBoundedStore creates a new bounded storage manager with default limits (16/64/64)

--- a/ats/storage/executor_integration_test.go
+++ b/ats/storage/executor_integration_test.go
@@ -91,7 +91,7 @@ func setupTestDatabaseWithAttestations(t *testing.T) *sql.DB {
 func TestAxExecutorBasicQueries(t *testing.T) {
 	db := setupTestDatabaseWithAttestations(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	tests := []struct {
 		name             string
@@ -187,7 +187,7 @@ func TestAxExecutorBasicQueries(t *testing.T) {
 func TestAxExecutorTemporalFiltering(t *testing.T) {
 	db := setupTestDatabaseWithAttestations(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Test temporal filtering
 	startTime, _ := time.Parse(time.RFC3339, "2024-01-02T00:00:00Z")
@@ -246,7 +246,7 @@ func TestAxExecutorTemporalFiltering(t *testing.T) {
 func TestAxExecutorFuzzyPredicateExpansion(t *testing.T) {
 	db := setupTestDatabaseWithAttestations(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Test fuzzy predicate expansion directly
 	expanded, err := executor.expandFuzzyPredicates(context.Background(), []string{"engineer"})
@@ -276,7 +276,7 @@ func TestAxExecutorFuzzyPredicateExpansion(t *testing.T) {
 func TestAxExecutorGetAllPredicatesFromDB(t *testing.T) {
 	db := setupTestDatabaseWithAttestations(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Get predicates directly from query store
 	queryStore := NewSQLQueryStore(testDB)
@@ -306,7 +306,7 @@ func TestAxExecutorGetAllPredicatesFromDB(t *testing.T) {
 func TestAxExecutorLimitHandling(t *testing.T) {
 	db := setupTestDatabaseWithAttestations(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	tests := []struct {
 		name          string
@@ -378,7 +378,7 @@ func TestAxExecutorEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create fresh database and executor for each subtest
 			db := setupTestDatabaseWithAttestations(t)
-			executor := NewExecutor(db)
+			executor := newTestExecutor(db)
 
 			result, err := executor.ExecuteAsk(context.Background(), tt.filter)
 			require.NoError(t, err)

--- a/ats/storage/executor_test_helpers_test.go
+++ b/ats/storage/executor_test_helpers_test.go
@@ -1,0 +1,32 @@
+package storage
+
+// Test-only executor helpers. These replicate the assembly logic from ats/setup
+// for tests that live inside package storage and can't import setup (circular).
+
+import (
+	"database/sql"
+
+	"github.com/teranos/QNTX/ats/alias"
+	"github.com/teranos/QNTX/ats/ax"
+)
+
+func newTestExecutor(db *sql.DB) *ax.AxExecutor {
+	queryStore := NewSQLQueryStore(db)
+	aliasStore := NewAliasStore(db)
+	aliasResolver := alias.NewResolver(aliasStore)
+	return ax.NewAxExecutor(queryStore, aliasResolver)
+}
+
+func newTestExecutorWithOptions(db *sql.DB, opts ax.AxExecutorOptions) *ax.AxExecutor {
+	var queryStore *SQLQueryStore
+	if opts.QueryExpander != nil {
+		queryStore = NewSQLQueryStoreWithExpander(db, opts.QueryExpander)
+	} else {
+		queryStore = NewSQLQueryStore(db)
+	}
+
+	aliasStore := NewAliasStore(db)
+	aliasResolver := alias.NewResolver(aliasStore)
+
+	return ax.NewAxExecutorWithOptions(queryStore, aliasResolver, opts)
+}

--- a/ats/storage/natural_language_integration_test.go
+++ b/ats/storage/natural_language_integration_test.go
@@ -326,7 +326,7 @@ func TestNaturalLanguageQueries(t *testing.T) {
 
 	// Create executor with query expander for semantic expansion
 	expander := &testDomainExpander{}
-	executor := NewExecutorWithOptions(db, ax.AxExecutorOptions{
+	executor := newTestExecutorWithOptions(db, ax.AxExecutorOptions{
 		QueryExpander: expander,
 	})
 
@@ -519,7 +519,7 @@ func TestPredicateContextMatching(t *testing.T) {
 
 	// Create executor with query expander for semantic expansion
 	expander := &testDomainExpander{}
-	executor := NewExecutorWithOptions(db, ax.AxExecutorOptions{
+	executor := newTestExecutorWithOptions(db, ax.AxExecutorOptions{
 		QueryExpander: expander,
 	})
 
@@ -605,7 +605,7 @@ func TestCaseInsensitiveContextMatching(t *testing.T) {
 
 	// Create executor with query expander for semantic expansion
 	expander := &testDomainExpander{}
-	executor := NewExecutorWithOptions(testDB, ax.AxExecutorOptions{
+	executor := newTestExecutorWithOptions(testDB, ax.AxExecutorOptions{
 		QueryExpander: expander,
 	})
 

--- a/ats/storage/resolution_integration_test.go
+++ b/ats/storage/resolution_integration_test.go
@@ -46,7 +46,7 @@ func TestAttestationResolution(t *testing.T) {
 	db := setupResolutionTestDB(t)
 
 	// Use executor factory for smart resolution
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Test Evolution scenario: same actor, different times (DOZER)
 	t.Run("evolution_resolution", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestAttestationResolution(t *testing.T) {
 func TestResolutionPerformance(t *testing.T) {
 	db := setupResolutionTestDB(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Test that smart resolution doesn't significantly slow down queries
 	// Note: Performance benchmarking should use b.Run with testing.B for accurate metrics
@@ -165,7 +165,7 @@ func TestResolutionWithAliases(t *testing.T) {
 	`)
 	require.NoError(t, err, "Failed to insert alias test data")
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Test that resolution works with alias resolution
 	filter := types.AxFilter{
@@ -186,7 +186,7 @@ func TestResolutionWithAliases(t *testing.T) {
 func TestResolutionEdgeCases(t *testing.T) {
 	db := setupResolutionTestDB(t)
 
-	executor := NewExecutor(db)
+	executor := newTestExecutor(db)
 
 	// Test empty query
 	t.Run("empty_query", func(t *testing.T) {

--- a/ats/storage/security_test.go
+++ b/ats/storage/security_test.go
@@ -48,7 +48,7 @@ func TestSQLInjectionPrevention(t *testing.T) {
 		require.NoError(t, store.CreateAttestation(maliciousAttestation))
 
 		// Query should treat the malicious string as literal predicate value
-		executor := NewExecutor(testDB)
+		executor := newTestExecutor(testDB)
 		results, err := executor.ExecuteAsk(context.Background(), types.AxFilter{
 			Predicates: []string{"' OR '1'='1"},
 		})
@@ -73,7 +73,7 @@ func TestSQLInjectionPrevention(t *testing.T) {
 		require.NoError(t, store.CreateAttestation(percentAttestation))
 
 		// Query for literal "100% Coverage" should not act as wildcard
-		executor := NewExecutor(testDB)
+		executor := newTestExecutor(testDB)
 		results, err := executor.ExecuteAsk(context.Background(), types.AxFilter{
 			Subjects: []string{"100% Coverage"},
 		})
@@ -109,7 +109,7 @@ func TestSQLInjectionPrevention(t *testing.T) {
 		require.NoError(t, store.CreateAttestation(underscoreAttestation2))
 
 		// Query for "user_id" should not match "userXid"
-		executor := NewExecutor(testDB)
+		executor := newTestExecutor(testDB)
 		results, err := executor.ExecuteAsk(context.Background(), types.AxFilter{
 			Subjects: []string{"user_id"},
 		})
@@ -155,7 +155,7 @@ func TestNumericPredicateParameterization(t *testing.T) {
 		maliciousPredicate := "experience_years' OR '1'='1"
 
 		// Create executor with mock expander that returns malicious predicate
-		executor := NewExecutorWithOptions(testDB, ax.AxExecutorOptions{
+		executor := newTestExecutorWithOptions(testDB, ax.AxExecutorOptions{
 			QueryExpander: &mockNumericExpander{
 				numericPredicates: []string{maliciousPredicate},
 			},

--- a/cmd/qntx/commands/ax.go
+++ b/cmd/qntx/commands/ax.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/teranos/QNTX/ats/parser"
-	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/setup"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/sym"
@@ -66,7 +66,7 @@ func runAxCommand(cmd *cobra.Command, args []string) error {
 	defer database.Close()
 
 	// Create executor (uses default fuzzy matcher)
-	executor := storage.NewExecutor(database)
+	executor := setup.NewExecutor(database)
 
 	// Execute query
 	result, err := executor.ExecuteAsk(context.Background(), *filter)

--- a/cmd/qntx/commands/ax_test.go
+++ b/cmd/qntx/commands/ax_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/teranos/QNTX/ats/parser"
-	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/setup"
 	qntxtest "github.com/teranos/QNTX/internal/testing"
 )
 
@@ -39,7 +39,7 @@ func TestAxCommand_Integration(t *testing.T) {
 		filter, err := parser.ParseAxCommand(tt.args)
 		require.NoError(t, err)
 
-		executor := storage.NewExecutor(db)
+		executor := setup.NewExecutor(db)
 		result, err := executor.ExecuteAsk(context.Background(), *filter)
 		require.NoError(t, err)
 

--- a/docs/coupling-analysis.md
+++ b/docs/coupling-analysis.md
@@ -1,0 +1,145 @@
+# Backend Coupling Analysis
+
+## Overview
+
+Analysis of inter-package coupling in the Go backend, measured by fan-in (how many packages depend on it) and fan-out (how many packages it depends on).
+
+### Highest Fan-In (most depended-upon)
+
+| Package | Fan-In | Role |
+|---------|--------|------|
+| `errors` | 37 | Error wrapping |
+| `ats/types` | 16 | Core type definitions |
+| `logger` | 12 | Structured logging |
+| `ats` | 12 | Interface contracts |
+| `ats/storage` | 12 | Persistence layer |
+
+### Highest Fan-Out (most dependencies)
+
+| Package | Fan-Out | Role |
+|---------|---------|------|
+| `server` | 25 | WebSocket/HTTP server |
+| `cmd/qntx/commands` | 25 | CLI command handlers |
+| `ats/storage` | 12 | Persistence (imports ax, alias, fuzzyax) |
+| `ats/so/actions/prompt` | 12 | Prompt action handler |
+
+---
+
+## 5 Actionable Suggestions
+
+### 1. Extract executor assembly out of `ats/storage`
+
+**Problem:** `ats/storage` imports `ats/ax` and `ats/alias` solely to provide the convenience functions `NewExecutor` and `NewExecutorWithOptions` in `executor_factory.go`. This pulls the query execution layer into the persistence layer, creating a dependency from storage → ax → alias that doesn't belong there. `rich_search.go` also imports `ats/ax` to call `ax.NewDefaultMatcher()` for fuzzy backend detection.
+
+**Files:**
+- `ats/storage/executor_factory.go:7-9` — imports `ats/alias` and `ats/ax`
+- `ats/storage/rich_search.go:12-13` — imports `ats/ax` and `ats/ax/fuzzy-ax/fuzzyax`
+
+**Action:** Move `executor_factory.go` to a new package (e.g., `ats/setup` or just lift it into the callers that use it — `server/`, `cmd/`, `graph/`). For `rich_search.go`, inject the matcher via a field on `BoundedStore` at construction time rather than calling `ax.NewDefaultMatcher()` inline. This makes `ats/storage` a pure persistence package with zero knowledge of the query layer.
+
+**Impact:** Removes 2 import edges (`storage → ax`, `storage → alias`), drops storage fan-out from 12 to ~9.
+
+---
+
+### 2. Define local interfaces in `server` for its dependencies
+
+**Problem:** `QNTXServer` holds 15+ concrete types from external packages (`*graph.AxGraphBuilder`, `*budget.Tracker`, `*async.WorkerPool`, `*schedule.Ticker`, `*plugin.Registry`, `*lsp.Service`, `*tracker.UsageTracker`, `*vidstream.VideoEngine`, `*watcher.Engine`, `*handlers.CanvasHandler`, etc.). Every field is a concrete pointer — no interfaces. This means the server package has compile-time coupling to the full API surface of every dependency, and there is no seam for testing any handler in isolation.
+
+**File:** `server/server.go:30-82` — the `QNTXServer` struct definition.
+
+**Action:** For each dependency consumed by the server, define a narrow interface in `server/` that covers only the methods actually called. For example:
+
+```
+// server/interfaces.go
+
+type GraphBuilder interface {
+    BuildFromQuery(ctx context.Context, query string, opts BuildOptions) (*graph.Graph, error)
+}
+
+type BudgetTracker interface {
+    GetStatus() budget.Status
+    UpdateDailyBudget(amount int)
+}
+
+type JobPool interface {
+    Submit(job async.Job) error
+    GetQueue() []async.Job
+}
+```
+
+Then change `QNTXServer` fields from `*graph.AxGraphBuilder` to `GraphBuilder`, etc. Production code passes the real implementations; tests can pass stubs.
+
+**Impact:** Decouples server from 15 packages at compile time. Makes individual handlers testable without constructing the entire server. Does not require changes in any other package — Go's implicit interface satisfaction means existing types already satisfy the new interfaces.
+
+---
+
+### 3. Replace `client.go` message switch with a handler registry
+
+**Problem:** `client.go` contains a `routeMessage()` switch statement with 20+ cases (`"query"`, `"clear"`, `"daemon_control"`, `"rich_search"`, `"vidstream_init"`, `"watcher_upsert"`, etc.). Each case calls into a different subsystem. Adding a new message type requires modifying this central switch, which touches every import in the file and creates merge conflicts when features are developed in parallel.
+
+**File:** `server/client.go:225-261` — the `routeMessage()` switch.
+
+**Action:** Define a `MessageHandler` interface and a registry map:
+
+```
+type MessageHandler interface {
+    HandleMessage(ctx context.Context, client *Client, msg json.RawMessage) error
+}
+
+// In server setup:
+s.handlers["query"]          = &queryHandler{builder: s.builder}
+s.handlers["daemon_control"] = &daemonHandler{pool: s.daemon}
+s.handlers["rich_search"]    = &searchHandler{store: s.boundedStore}
+```
+
+Each handler lives in its own file (or even sub-package) and only imports the packages it needs. `routeMessage()` becomes a single map lookup + dispatch.
+
+**Impact:** Each handler has a focused dependency set instead of every message type sharing one file's imports. New message types are additive (register a handler) rather than requiring a central code change.
+
+---
+
+### 4. Split `broadcast.go` concerns: event broadcasting vs. daemon polling
+
+**Problem:** `broadcast.go` (868 lines) mixes two distinct responsibilities: (a) broadcasting graph updates and status to WebSocket clients, and (b) polling the daemon/pulse subsystem for job state changes (`startJobUpdateBroadcaster`, `startDaemonStatusBroadcaster`, `startScheduleBroadcaster`, `startUsageBroadcaster`, `startStorageEventsBroadcaster`). The polling logic directly instantiates `async.Job`, `schedule.Store`, and `budget.Status` types, coupling the broadcast layer to the full pulse subsystem.
+
+**File:** `server/broadcast.go` — 868 lines mixing client broadcast mechanics with daemon/pulse/usage polling.
+
+**Action:** Extract the polling goroutines into a separate file or package (e.g., `server/pollers.go` or `server/status/`). Each poller should accept an interface (e.g., `JobStatusProvider`, `BudgetStatusProvider`) rather than concrete pulse types. The poller emits a generic status update to the broadcast channel; the broadcast worker remains a simple fan-out to clients.
+
+**Impact:** `broadcast.go` shrinks to pure broadcast mechanics (~200 lines). Pollers become independently testable. Pulse package changes no longer ripple into broadcast logic.
+
+---
+
+### 5. Decouple `ats/storage/rich_search.go` from fuzzy engine internals
+
+**Problem:** `rich_search.go` (750 lines) directly imports `ats/ax/fuzzy-ax/fuzzyax`, creates a `fuzzyax.NewFuzzyEngine()`, manages its lifecycle (`defer engine.Close()`), builds vocabulary, and calls `engine.FindMatches()` and `engine.RebuildIndex()`. This embeds the full Rust FFI fuzzy matching engine inside the storage layer — a persistence package now owns vocabulary construction and fuzzy scoring logic.
+
+**Files:**
+- `ats/storage/rich_search.go:13` — imports `fuzzyax`
+- `ats/storage/rich_search.go:332-336` — creates and manages fuzzy engine lifecycle
+- `ats/storage/rich_search.go:462-465` — rebuilds fuzzy index
+- `ats/storage/rich_search.go:492` — calls `engine.FindMatches()`
+
+**Action:** Define a `FuzzyMatcher` interface that `BoundedStore` accepts at construction:
+
+```
+type FuzzyMatcher interface {
+    Match(query string, vocabulary []string, limit int, threshold float64) ([]FuzzyMatch, error)
+}
+```
+
+The Rust-backed implementation lives in `ats/ax/fuzzy-ax/`. The storage layer calls `matcher.Match()` without knowing about engine lifecycle, vocabulary indexing, or FFI details. A no-op matcher can be injected for tests or when Rust is unavailable (replacing the current runtime check for `ax.MatcherBackendRust`).
+
+**Impact:** Removes `fuzzyax` import from storage. Storage tests no longer require the Rust WASM binary. Fuzzy matching can evolve independently (swap implementations, add caching) without modifying storage.
+
+---
+
+## Summary
+
+| # | Suggestion | Edges Removed | Primary Benefit |
+|---|-----------|---------------|-----------------|
+| 1 | Move executor factory out of storage | 2 | Clean persistence boundary |
+| 2 | Server-local interfaces | 15 | Testability, compile-time decoupling |
+| 3 | Handler registry in client.go | N/A (structural) | Extensibility, reduced merge conflicts |
+| 4 | Split broadcast.go | 3-4 | Separation of concerns |
+| 5 | Inject fuzzy matcher into storage | 2 | Storage independent of Rust FFI |

--- a/graph/builder.go
+++ b/graph/builder.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/teranos/QNTX/ats/ax"
-	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/setup"
 	"go.uber.org/zap"
 )
 
@@ -19,7 +19,7 @@ type AxGraphBuilder struct {
 // NewAxGraphBuilder creates a new Ax graph builder.
 // Node types are determined purely from attested node_type predicates.
 func NewAxGraphBuilder(db *sql.DB, verbosity int, logger *zap.SugaredLogger) (*AxGraphBuilder, error) {
-	executor := storage.NewExecutorWithOptions(db, ax.AxExecutorOptions{
+	executor := setup.NewExecutorWithOptions(db, ax.AxExecutorOptions{
 		Logger: logger.Named("ax"),
 	})
 

--- a/server/client.go
+++ b/server/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/teranos/QNTX/ats/ax"
 	"github.com/teranos/QNTX/ats/parser"
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/errors"
@@ -871,8 +872,11 @@ func (c *Client) handleRichSearch(query string) {
 		"client_id", c.id,
 	)
 
-	// Create bounded store to access search functionality
+	// Create bounded store with fuzzy matcher for search
 	boundedStore := storage.NewBoundedStore(c.server.db, c.server.logger.Named("search"))
+	if m := ax.NewFuzzyRichSearchMatcher(); m != nil {
+		boundedStore.SetFuzzyMatcher(m)
+	}
 
 	// Just use the working substring search
 	ctx := c.server.ctx

--- a/server/prompt_handlers.go
+++ b/server/prompt_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/teranos/QNTX/ai/provider"
 	"github.com/teranos/QNTX/ats/alias"
 	"github.com/teranos/QNTX/ats/parser"
+	"github.com/teranos/QNTX/ats/setup"
 	"github.com/teranos/QNTX/ats/so/actions/prompt"
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
@@ -173,7 +174,7 @@ func (s *QNTXServer) HandlePromptPreview(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Execute the query using storage executor
-	executor := storage.NewExecutor(s.db)
+	executor := setup.NewExecutor(s.db)
 	result, err := executor.ExecuteAsk(r.Context(), *filter)
 	if err != nil {
 		writeWrappedError(w, s.logger, err, "Failed to execute ax query", http.StatusInternalServerError)


### PR DESCRIPTION
The server package and ats/storage hold concrete references to 15+ and 12+
packages respectively with zero interface boundaries. This documents the
specific coupling points and proposes targeted decoupling — extracting the
executor factory from storage, defining narrow server-local interfaces,
replacing the client.go message switch with a handler registry, splitting
broadcast.go's mixed concerns, and injecting the fuzzy matcher rather than
embedding Rust FFI in the persistence layer.

https://claude.ai/code/session_01E4dt5kZRSmDiLGPcPkDRXY