### PR TITLE
Directional sweep animation for glyph execution

### DIFF
--- a/web/css/glyph/base.css
+++ b/web/css/glyph/base.css
@@ -55,24 +55,6 @@
     transition: border-color 0.2s ease;
 }
 
-/* Execution state — functional border color driven by data-execution-state attribute.
-   Set by glyph_fired WebSocket handler during meld-edge triggered execution.
-   Specificity 0,3,0 to override canvas.css sync-state border-color (0,2,0). */
-.canvas-glyph[data-execution-state="running"]:not(.canvas-error-glyph) {
-    border-color: var(--glyph-status-running-text);
-    transition: border-color 0.2s ease;
-}
-
-.canvas-glyph[data-execution-state="completed"]:not(.canvas-error-glyph) {
-    border-color: var(--glyph-status-success-text);
-    transition: border-color 0.2s ease;
-}
-
-.canvas-glyph[data-execution-state="failed"]:not(.canvas-error-glyph) {
-    border-color: var(--glyph-status-error-text);
-    transition: border-color 0.2s ease;
-}
-
 /* Shared resize handle for canvas glyphs (bottom-right corner) */
 .glyph-resize-handle {
     position: absolute;

--- a/web/css/glyph/execution-state.css
+++ b/web/css/glyph/execution-state.css
@@ -1,0 +1,96 @@
+/**
+ * Glyph Execution State — visual feedback for meld-edge triggered execution.
+ *
+ * Driven by data-execution-state attribute set by glyph_fired WebSocket handler.
+ * Loads after canvas.css — specificity 0,3,0 overrides sync-state border-color (0,2,0).
+ *
+ * Sweep animation moves left→right matching meld data flow direction.
+ * Cascades naturally through melded chains via sequential glyph_fired timing.
+ */
+
+/* --- Border color --- */
+
+.canvas-glyph[data-execution-state="running"]:not(.canvas-error-glyph) {
+    border-color: var(--glyph-status-running-text);
+    transition: border-color 0.2s ease;
+}
+
+.canvas-glyph[data-execution-state="completed"]:not(.canvas-error-glyph) {
+    border-color: var(--glyph-status-success-text);
+    transition: border-color 0.2s ease;
+}
+
+.canvas-glyph[data-execution-state="failed"]:not(.canvas-error-glyph) {
+    border-color: var(--glyph-status-error-text);
+    transition: border-color 0.2s ease;
+}
+
+/* --- Sweep overlay --- */
+
+.canvas-glyph[data-execution-state]::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 10;
+}
+
+/* Running: repeating blue sweep left→right */
+.canvas-glyph[data-execution-state="running"]::after {
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(107, 155, 209, 0.15) 30%,
+        rgba(107, 155, 209, 0.3) 50%,
+        rgba(107, 155, 209, 0.15) 70%,
+        transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: glyph-sweep 1s ease-in-out infinite;
+}
+
+/* Completed: green band sweeps out to the right, fades */
+.canvas-glyph[data-execution-state="completed"]::after {
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(168, 230, 161, 0.25) 40%,
+        rgba(168, 230, 161, 0.4) 50%,
+        rgba(168, 230, 161, 0.25) 60%,
+        transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: glyph-sweep-exit 0.4s ease-out forwards;
+}
+
+/* Failed: red band halts mid-glyph, fades */
+.canvas-glyph[data-execution-state="failed"]::after {
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(255, 107, 107, 0.2) 30%,
+        rgba(255, 107, 107, 0.35) 50%,
+        rgba(255, 107, 107, 0.2) 70%,
+        transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: glyph-sweep-halt 0.3s ease-out forwards;
+}
+
+/* --- Keyframes --- */
+
+@keyframes glyph-sweep {
+    0%   { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+}
+
+@keyframes glyph-sweep-exit {
+    0%   { background-position: 50% 0; opacity: 1; }
+    100% { background-position: -100% 0; opacity: 0; }
+}
+
+@keyframes glyph-sweep-halt {
+    0%   { background-position: 50% 0; opacity: 1; }
+    60%  { background-position: 40% 0; opacity: 0.8; }
+    100% { background-position: 40% 0; opacity: 0; }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -64,6 +64,7 @@
     <link rel="stylesheet" href="/css/glyph/meld.css">
     <link rel="stylesheet" href="/css/glyph/rectangle-selection.css">
     <link rel="stylesheet" href="/css/canvas.css">
+    <link rel="stylesheet" href="/css/glyph/execution-state.css">
     <link rel="stylesheet" href="/css/type-definition-window.css">
     <link rel="stylesheet" href="/css/ctp2.css">
 </head>


### PR DESCRIPTION
## Summary
- Blue sweep left→right during execution, green exit sweep on success, red halt on failure
- Directional animation matches meld data flow — cascades naturally through melded chains
- Extracted execution state styles from base.css into dedicated execution-state.css

## Test plan
- [x] Meld ax→py, create attestation, watch blue sweep followed by green exit
- [x] Chain ax→py→prompt, watch cascade flow through both glyphs in sequence