### PR TITLE
Persist system drawer collapsed state and fix fullscreen canvas layout

### DIFF
--- a/web/css/feedback.css
+++ b/web/css/feedback.css
@@ -2,6 +2,7 @@
 
 /* System Drawer (formerly Log Panel) */
 #system-drawer {
+    --system-drawer-header-height: 32px;
     position: fixed;
     bottom: 0;
     left: 0;
@@ -9,14 +10,14 @@
     background: var(--bg-almost-black);
     border-top: 1px solid var(--border-on-dark);
     max-height: 300px;
-    z-index: 1000;
+    z-index: 10002; /* Always above fullscreen canvas (10000) and minimize btn (10001) */
     display: flex;
     flex-direction: column;
     transition: max-height 0.3s ease-in-out;
 }
 
 #system-drawer.collapsed {
-    max-height: 32px;
+    max-height: var(--system-drawer-header-height);
 }
 
 #system-drawer-header {

--- a/web/ts/components/glyph/manifestations/canvas.ts
+++ b/web/ts/components/glyph/manifestations/canvas.ts
@@ -31,11 +31,12 @@ export function morphToCanvas(
     // Get current glyph position and size
     const glyphRect = glyphElement.getBoundingClientRect();
 
-    // Target: full viewport
+    // Target: full viewport minus system drawer header (always visible)
+    const SYSTEM_DRAWER_HEADER_HEIGHT = 32;
     const targetX = 0;
     const targetY = 0;
     const targetWidth = window.innerWidth;
-    const targetHeight = window.innerHeight;
+    const targetHeight = window.innerHeight - SYSTEM_DRAWER_HEADER_HEIGHT;
 
     // Remove from indicator container and reparent to body
     glyphElement.remove();
@@ -72,7 +73,7 @@ export function morphToCanvas(
         glyphElement.style.left = '0';
         glyphElement.style.top = '0';
         glyphElement.style.width = '100vw';
-        glyphElement.style.height = '100vh';
+        glyphElement.style.height = 'calc(100vh - 32px)'; /* Leave room for system drawer header */
         glyphElement.style.borderRadius = '0'; // No rounded corners
         glyphElement.style.backgroundColor = 'var(--bg-primary)';
         glyphElement.style.boxShadow = 'none'; // No shadow


### PR DESCRIPTION
## Summary
This PR adds persistence for the system drawer's collapsed/expanded state using IndexedDB storage, and fixes layout issues when the canvas morphs to fullscreen by accounting for the system drawer header height.

## Key Changes
- **Persist drawer state**: The system drawer's collapsed state is now saved to IndexedDB and restored on page load, improving user experience by remembering their preference
- **Restore state on init**: Added logic to restore the collapsed state during `initSystemDrawer()` initialization
- **Fix fullscreen canvas layout**: Updated canvas fullscreen calculations to account for the 32px system drawer header that remains visible, preventing content overlap
- **Improve z-index layering**: Increased system drawer z-index to 10002 to ensure it stays above fullscreen canvas (10000) and minimize button (10001)
- **CSS variable for header height**: Introduced `--system-drawer-header-height` CSS variable for consistency across stylesheets
