### PR TITLE
SE glyph: show rich text, hide structural noise

### DIFF
--- a/web/ts/components/glyph/semantic-glyph.ts
+++ b/web/ts/components/glyph/semantic-glyph.ts
@@ -313,15 +313,9 @@ function extractRichText(attestation: Attestation): string {
                 }
             }
             if (parts.length > 0) return parts.join(' ');
-        } catch { /* fall through to structural */ }
+        } catch { /* ignore parse errors */ }
     }
-    // Fallback: structural fields
-    const parts = [
-        ...(attestation.subjects || []),
-        ...(attestation.predicates || []),
-        ...(attestation.contexts || []),
-    ].filter(Boolean);
-    return parts.join(' ') || 'N/A';
+    return '';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Results show rich text content instead of raw attestation fields
- Hover tooltip shows attestation structure and attribute field names
- Server filters out structural-only attestations from semantic matches entirely

Follow-up to #496