### PR TITLE
Sync peer name advertising + log noise reduction

### DIFF
--- a/am.example.toml
+++ b/am.example.toml
@@ -141,3 +141,22 @@ timeout_seconds = 3600
 # Used when no actor is explicitly specified
 # Default: "ax@user"
 default_actor = "ax@user"
+
+# ════════════════════════════════════════════════════════════════
+# Sync Configuration (Peer-to-Peer Attestation Sync)
+# ════════════════════════════════════════════════════════════════
+
+[sync]
+# Node name advertised to peers during sync handshake.
+# Shows up in peer logs so operators know which node synced.
+# Default: "" (anonymous)
+# name = "laptop"
+
+# Automatic sync interval in seconds (0 = manual only via UI)
+# Default: 0
+# interval_seconds = 300
+
+# [sync.peers]
+# Named peers to sync with. Name is for your logs; URL is the peer's address.
+# phone = "http://phone.local:877"
+# server = "https://server.example.com:877"

--- a/am/am.go
+++ b/am/am.go
@@ -16,6 +16,7 @@ type Config struct {
 
 // SyncConfig configures peer-to-peer attestation sync
 type SyncConfig struct {
+	Name            string            `mapstructure:"name"`             // advertised to peers in hello (e.g., "laptop")
 	IntervalSeconds int               `mapstructure:"interval_seconds"` // 0 = manual only
 	Peers           map[string]string `mapstructure:"peers"`            // name = "url" (e.g., phone = "http://phone.local:877")
 }

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -78,7 +78,7 @@ The reconciliation protocol is **symmetric** — both sides run the same state m
 
 | Phase | Both send | Purpose |
 |-------|-----------|---------|
-| 1 | `sync_hello` (root hash) | Quick check — if roots match, done |
+| 1 | `sync_hello` (root hash, name) | Quick check — if roots match, done |
 | 2 | `sync_group_hashes` | Exchange all group hash pairs |
 | 3 | `sync_need` | Each side says which groups it wants |
 | 4 | `sync_attestations` | Each side sends what the other asked for |
@@ -173,6 +173,7 @@ Response:
 ```toml
 # am.toml
 [sync]
+name = "laptop"         # advertised to peers in hello (shows in their logs)
 interval_seconds = 300  # reconcile every 5 minutes (0 = manual only)
 
 [sync.peers]

--- a/server/server.go
+++ b/server/server.go
@@ -86,7 +86,8 @@ type QNTXServer struct {
 	// Sync: Merkle tree observer for content-addressed attestation sync
 	syncTree       syncPkg.SyncTree      // nil if WASM unavailable
 	syncObserver   *syncPkg.TreeObserver // nil if WASM unavailable
-	syncPeerStatus sync.Map              // map[string]string — peer name → "ok" or "unreachable"
+	syncPeerStatus sync.Map              // map[string]string — peer name → "ok", "unreachable", or "self"
+	syncPeerRemoteName sync.Map          // map[string]string — peer name → advertised name from hello
 
 	// Embedding service for semantic search (optional, requires rustembeddings build tag)
 	embeddingService interface {

--- a/sync/protocol.go
+++ b/sync/protocol.go
@@ -43,6 +43,7 @@ type Msg struct {
 
 	// Hello
 	RootHash string `json:"root_hash,omitempty"`
+	Name     string `json:"name,omitempty"` // self-identified node name (from [sync] name)
 
 	// GroupHashes: hex-encoded group key hash → hex-encoded group hash
 	Groups map[string]string `json:"groups,omitempty"`

--- a/web/ts/default-glyphs.ts
+++ b/web/ts/default-glyphs.ts
@@ -141,9 +141,10 @@ function renderSync(): void {
                     padding: 2px 8px; border-radius: 3px; cursor: pointer;
                     font-family: monospace; font-size: 11px; margin-left: 8px;
                 ">Sync</button>`;
+            const advertisedName = p.advertised_name ? ` <span style="color: #9ca3af;">(${p.advertised_name})</span>` : '';
             return `
             <div class="glyph-row" style="align-items: center;">
-                ${statusDot}<span class="glyph-label">${p.name}:</span>
+                ${statusDot}<span class="glyph-label">${p.name}${advertisedName}:</span>
                 <span class="glyph-value" style="font-size: 11px; flex: 1;">${p.url}</span>
                 ${syncBtn}
             </div>`;

--- a/web/ts/logger.ts
+++ b/web/ts/logger.ts
@@ -135,7 +135,7 @@ const logger = {
      */
     debug(context: string, message: string, ...args: unknown[]): void {
         if (shouldLog('debug')) {
-            console.log(formatPrefix(context), message, ...args);
+            console.debug(formatPrefix(context), message, ...args);
         }
     },
 

--- a/web/ts/websocket.ts
+++ b/web/ts/websocket.ts
@@ -74,7 +74,7 @@ const MESSAGE_HANDLERS = {
     },
 
     daemon_status: (data: DaemonStatusMessage) => {
-        log.info(SEG.PULSE, 'Daemon status:',
+        log.debug(SEG.PULSE, 'Daemon status:',
             data.server_state || 'running',
             `${data.active_jobs} active`,
             `${data.queued_jobs} queued`,
@@ -163,7 +163,7 @@ const MESSAGE_HANDLERS = {
     },
 
     sync_status: (data: SyncStatusMessage) => {
-        log.info(SEG.WS, 'Sync status:', {
+        log.debug(SEG.WS, 'Sync status:', {
             available: data.available,
             root: data.root?.substring(0, 12),
             groups: data.groups,

--- a/web/types/websocket.ts
+++ b/web/types/websocket.ts
@@ -463,7 +463,7 @@ export interface SyncStatusMessage extends BaseMessage {
   available: boolean;
   root?: string;      // Merkle root hash (64-char hex)
   groups?: number;    // Number of (actor, context) groups in the tree
-  peers?: Array<{ name: string; url: string; status?: string }>;
+  peers?: Array<{ name: string; url: string; status?: string; advertised_name?: string }>;
   reason?: string;    // Why sync is unavailable
   error?: string;     // Error reading tree state
 }


### PR DESCRIPTION
## Summary

- Nodes advertise a configurable name (`[sync] name`) in the hello handshake — peers see it in logs and the sync glyph shows it as `peer8774 (laptop-tmp3)`
- Sync tick logging consolidated to one summary line per interval with named peers and grouped failure reasons
- Browser debug messages (`log.debug`) now use `console.debug` so they're properly filtered by server verbosity instead of flooding the terminal