### PR TITLE
Enable SE→py and SE→prompt melding

### DIFF
--- a/web/ts/components/glyph/meld/meldability.ts
+++ b/web/ts/components/glyph/meld/meldability.ts
@@ -25,6 +25,9 @@ export const MELDABILITY: Record<string, readonly PortRule[]> = {
     'canvas-ax-glyph': [
         { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph'] }
     ],
+    'canvas-se-glyph': [
+        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph'] }
+    ],
     'canvas-py-glyph': [
         { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph'] },
         { direction: 'bottom', targets: ['canvas-result-glyph'] }


### PR DESCRIPTION
## Summary
- Register `canvas-se-glyph` in the MELDABILITY registry with right-axis targets (py, prompt)
- Backend was already wired in #496 — `compileSubscriptions()` handles `case "semantic"` and `glyphSymbolToType()` maps `sym.SE` → `"semantic"`

Closes the se-py meld item from #496.

## Test plan
- [x] `make test` passes (614 pass, 0 fail)
- [x] Meldability tests cover SE→py, SE→prompt compatibility
- [x] Manual: drag SE glyph next to py glyph → they meld, semantic matches trigger py execution
<img width="539" height="325" alt="Screenshot 2026-02-15 at 17 59 35" src="https://github.com/user-attachments/assets/9462c54b-2290-4f93-a67f-f8a208b59706" />

