### PR TITLE
Quiet eviction logs, surface summary through Pulse ticker

### DIFF
--- a/ats/storage/bounded_store_telemetry.go
+++ b/ats/storage/bounded_store_telemetry.go
@@ -92,7 +92,7 @@ func (bs *BoundedStore) logStorageEventWithDetails(eventType, actor, context, en
 			msg += " (deleted oldest)"
 		}
 
-		bs.logger.Infow(msg,
+		bs.logger.Debugw(msg,
 			"event_type", eventType,
 			"actor", actor,
 			"context", context,

--- a/server/init.go
+++ b/server/init.go
@@ -267,6 +267,7 @@ func NewQNTXServer(db *sql.DB, dbPath string, verbosity int, initialQuery ...str
 	// Create and start storage events poller for broadcasting warnings/evictions
 	storagePoller := NewStorageEventsPoller(db, server, serverLogger)
 	server.storageEventsPoller = storagePoller
+	ticker.SetEvictionStats(storagePoller)
 	server.wg.Add(1)
 	go func() {
 		defer server.wg.Done()

--- a/server/storage_events.go
+++ b/server/storage_events.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/teranos/QNTX/logger"
@@ -18,6 +19,10 @@ type StorageEventsPoller struct {
 	logger   *zap.SugaredLogger
 	interval time.Duration
 	lastID   int64 // Track last processed event ID
+
+	// Accumulated eviction counters, drained by the Pulse ticker for periodic summaries
+	evictionEvents       atomic.Int64
+	evictedAttestations  atomic.Int64
 }
 
 // NewStorageEventsPoller creates a new storage events poller
@@ -158,6 +163,9 @@ func (p *StorageEventsPoller) broadcastEviction(eventType, actor, context, entit
 
 	logger.AddDBSymbol(p.logger).Debugw("Storage eviction", logFields...)
 
+	p.evictionEvents.Add(1)
+	p.evictedAttestations.Add(int64(deletionsCount))
+
 	// Broadcast as storage_eviction message
 	msg := map[string]interface{}{
 		"type":            "storage_eviction",
@@ -201,6 +209,12 @@ func (p *StorageEventsPoller) broadcastWarning(actor, context string, current, l
 	}
 
 	p.server.broadcastMessage(msg)
+}
+
+// DrainEvictionCounts atomically reads and resets the accumulated eviction counters.
+// Returns (eviction events, attestations evicted). Both zero means no evictions since last drain.
+func (p *StorageEventsPoller) DrainEvictionCounts() (events int, attestations int) {
+	return int(p.evictionEvents.Swap(0)), int(p.evictedAttestations.Swap(0))
 }
 
 // getDefaultLimit returns the default limit for a given event type

--- a/web/ts/websocket-handlers/storage-eviction.ts
+++ b/web/ts/websocket-handlers/storage-eviction.ts
@@ -12,7 +12,7 @@ import type { StorageEvictionMessage } from '../../types/websocket';
  * Handle storage eviction message
  */
 export function handleStorageEviction(data: StorageEvictionMessage): void {
-    log.warn(SEG.DB, 'Storage eviction:', data.message, 'Event type:', data.event_type);
+    log.debug(SEG.DB, 'Storage eviction:', data.message, 'Event type:', data.event_type);
 
     // TODO: figure out how to make evictions observable without toast spam —
     // candidates: database status indicator flash, system drawer log entry, or dedicated eviction counter


### PR DESCRIPTION
## Summary
- Demote per-eviction logs to Debug across storage layer, server poller, and browser handler
- Pulse ticker drains accumulated eviction counts every 50 ticks (~50s) and logs a single Info-level summary