### PR TITLE
Extract task_logs and async_job_id queries into store layer

### DIFF
--- a/pulse/schedule/task_log_store.go
+++ b/pulse/schedule/task_log_store.go
@@ -1,0 +1,144 @@
+package schedule
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	"github.com/teranos/QNTX/errors"
+)
+
+// TaskInfo represents a task within a stage, with its log count
+type TaskInfo struct {
+	TaskID   string `json:"task_id"`
+	LogCount int    `json:"log_count,omitempty"`
+}
+
+// StageInfo represents a stage with its tasks
+type StageInfo struct {
+	Stage string     `json:"stage"`
+	Tasks []TaskInfo `json:"tasks"`
+}
+
+// LogEntry represents a single log entry from a task execution
+type LogEntry struct {
+	Timestamp string                 `json:"timestamp"`
+	Level     string                 `json:"level"`
+	Message   string                 `json:"message"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// TaskLogStore handles persistence of task-level execution logs.
+// The task_logs table captures per-stage, per-task log output from async job executions.
+type TaskLogStore struct {
+	db *sql.DB
+}
+
+// NewTaskLogStore creates a new task log store
+func NewTaskLogStore(db *sql.DB) *TaskLogStore {
+	return &TaskLogStore{db: db}
+}
+
+// ListStagesForJob returns stages and tasks for a job, grouped by stage with log counts.
+// Stages are returned in execution order (by earliest log entry).
+func (s *TaskLogStore) ListStagesForJob(jobID string) ([]StageInfo, error) {
+	query := `
+		SELECT
+			COALESCE(stage, 'unknown') as stage,
+			COALESCE(task_id, stage, 'unknown') as task_id,
+			COUNT(*) as log_count
+		FROM task_logs
+		WHERE job_id = ?
+		GROUP BY stage, task_id
+		ORDER BY MIN(id) ASC
+	`
+
+	rows, err := s.db.Query(query, jobID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query task logs for job %s", jobID)
+	}
+	defer rows.Close()
+
+	stageMap := make(map[string][]TaskInfo)
+	stageOrder := []string{}
+
+	for rows.Next() {
+		var stage, taskID string
+		var logCount int
+		if err := rows.Scan(&stage, &taskID, &logCount); err != nil {
+			return nil, errors.Wrapf(err, "failed to scan task log row for job %s", jobID)
+		}
+
+		if _, exists := stageMap[stage]; !exists {
+			stageOrder = append(stageOrder, stage)
+			stageMap[stage] = []TaskInfo{}
+		}
+
+		stageMap[stage] = append(stageMap[stage], TaskInfo{
+			TaskID:   taskID,
+			LogCount: logCount,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error iterating task logs for job %s", jobID)
+	}
+
+	stages := make([]StageInfo, 0, len(stageOrder))
+	for _, stage := range stageOrder {
+		stages = append(stages, StageInfo{
+			Stage: stage,
+			Tasks: stageMap[stage],
+		})
+	}
+
+	return stages, nil
+}
+
+// ListLogsForTask returns log entries for a specific task within a job.
+// Matches on task_id column, or falls back to stage column for stage-level logs
+// where task_id is NULL.
+func (s *TaskLogStore) ListLogsForTask(jobID, taskID string) ([]LogEntry, error) {
+	query := `
+		SELECT timestamp, level, message, metadata
+		FROM task_logs
+		WHERE job_id = ? AND (task_id = ? OR (task_id IS NULL AND stage = ?))
+		ORDER BY timestamp ASC
+	`
+
+	rows, err := s.db.Query(query, jobID, taskID, taskID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query logs for task %s in job %s", taskID, jobID)
+	}
+	defer rows.Close()
+
+	var logs []LogEntry
+	for rows.Next() {
+		var timestamp, level, message string
+		var metadataJSON *string
+
+		if err := rows.Scan(&timestamp, &level, &message, &metadataJSON); err != nil {
+			return nil, errors.Wrapf(err, "failed to scan log row for task %s in job %s", taskID, jobID)
+		}
+
+		var metadata map[string]any
+		if metadataJSON != nil {
+			if err := json.Unmarshal([]byte(*metadataJSON), &metadata); err != nil {
+				// Non-fatal: use empty metadata rather than failing the whole query
+				metadata = make(map[string]any)
+			}
+		}
+
+		logs = append(logs, LogEntry{
+			Timestamp: timestamp,
+			Level:     level,
+			Message:   message,
+			Metadata:  metadata,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error iterating logs for task %s in job %s", taskID, jobID)
+	}
+
+	return logs, nil
+}

--- a/pulse/schedule/task_log_store_test.go
+++ b/pulse/schedule/task_log_store_test.go
@@ -1,0 +1,157 @@
+package schedule
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	qntxtest "github.com/teranos/QNTX/internal/testing"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// insertAsyncJob creates a minimal async_ix_jobs row to satisfy the task_logs FK
+func insertAsyncJob(t *testing.T, db *sql.DB, jobID string) {
+	t.Helper()
+	now := time.Now().Format(time.RFC3339)
+	_, err := db.Exec(
+		`INSERT INTO async_ix_jobs (id, source, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		jobID, "test", "completed", now, now,
+	)
+	require.NoError(t, err)
+}
+
+func TestListStagesForJob(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	insertAsyncJob(t, db, "JB_stages_test")
+
+	now := time.Now()
+	// Insert logs across 3 stages, multiple tasks per stage, in a realistic order
+	logs := []struct {
+		stage  string
+		taskID *string
+		msg    string
+		offset time.Duration
+	}{
+		// Stage 1: fetch_jd — 2 tasks
+		{"fetch_jd", ptr("jd_001"), "Fetching JD", 0},
+		{"fetch_jd", ptr("jd_001"), "JD fetched", 1 * time.Second},
+		{"fetch_jd", ptr("jd_002"), "Fetching JD", 2 * time.Second},
+		// Stage 2: extract_requirements — 1 task
+		{"extract_requirements", ptr("jd_001"), "Extracting", 3 * time.Second},
+		{"extract_requirements", ptr("jd_001"), "Extracted 5 requirements", 4 * time.Second},
+		// Stage 3: score_candidates — 2 tasks
+		{"score_candidates", ptr("CNT_abc"), "Scoring candidate", 5 * time.Second},
+		{"score_candidates", ptr("CNT_def"), "Scoring candidate", 6 * time.Second},
+		{"score_candidates", ptr("CNT_def"), "Score: 0.85", 7 * time.Second},
+	}
+
+	for _, l := range logs {
+		ts := now.Add(l.offset).Format(time.RFC3339)
+		_, err := db.Exec(
+			`INSERT INTO task_logs (job_id, stage, task_id, timestamp, level, message) VALUES (?, ?, ?, ?, ?, ?)`,
+			"JB_stages_test", l.stage, l.taskID, ts, "info", l.msg,
+		)
+		require.NoError(t, err)
+	}
+
+	store := NewTaskLogStore(db)
+	stages, err := store.ListStagesForJob("JB_stages_test")
+	require.NoError(t, err)
+
+	// 3 stages in execution order
+	require.Len(t, stages, 3)
+	assert.Equal(t, "fetch_jd", stages[0].Stage)
+	assert.Equal(t, "extract_requirements", stages[1].Stage)
+	assert.Equal(t, "score_candidates", stages[2].Stage)
+
+	// fetch_jd: 2 tasks, jd_001 has 2 logs, jd_002 has 1
+	require.Len(t, stages[0].Tasks, 2)
+	assert.Equal(t, "jd_001", stages[0].Tasks[0].TaskID)
+	assert.Equal(t, 2, stages[0].Tasks[0].LogCount)
+	assert.Equal(t, "jd_002", stages[0].Tasks[1].TaskID)
+	assert.Equal(t, 1, stages[0].Tasks[1].LogCount)
+
+	// extract_requirements: 1 task with 2 logs
+	require.Len(t, stages[1].Tasks, 1)
+	assert.Equal(t, "jd_001", stages[1].Tasks[0].TaskID)
+	assert.Equal(t, 2, stages[1].Tasks[0].LogCount)
+
+	// score_candidates: 2 tasks
+	require.Len(t, stages[2].Tasks, 2)
+	assert.Equal(t, "CNT_abc", stages[2].Tasks[0].TaskID)
+	assert.Equal(t, 1, stages[2].Tasks[0].LogCount)
+	assert.Equal(t, "CNT_def", stages[2].Tasks[1].TaskID)
+	assert.Equal(t, 2, stages[2].Tasks[1].LogCount)
+
+	// Empty job returns empty slice, not error
+	empty, err := store.ListStagesForJob("JB_nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
+func TestListLogsForTask(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	insertAsyncJob(t, db, "JB_logs_test")
+
+	now := time.Now()
+	meta := map[string]any{"score": 0.92, "model": "gpt-4"}
+	metaJSON, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	// Insert logs: 2 with explicit task_id, 1 stage-level (task_id NULL, matched by stage)
+	entries := []struct {
+		taskID   *string
+		stage    string
+		level    string
+		msg      string
+		metadata *string
+		offset   time.Duration
+	}{
+		// Stage-level log (task_id is NULL) — should match when querying by stage name
+		{nil, "score_candidates", "info", "Stage started", nil, 0},
+		// Task-level logs
+		{ptr("score_candidates"), "score_candidates", "info", "Scoring started", nil, 1 * time.Second},
+		{ptr("score_candidates"), "score_candidates", "info", "Score complete", ptr(string(metaJSON)), 2 * time.Second},
+		// Different task — should NOT appear
+		{ptr("other_task"), "score_candidates", "info", "Other task log", nil, 3 * time.Second},
+	}
+
+	for _, e := range entries {
+		ts := now.Add(e.offset).Format(time.RFC3339)
+		_, err := db.Exec(
+			`INSERT INTO task_logs (job_id, stage, task_id, timestamp, level, message, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			"JB_logs_test", e.stage, e.taskID, ts, e.level, e.msg, e.metadata,
+		)
+		require.NoError(t, err)
+	}
+
+	store := NewTaskLogStore(db)
+	logs, err := store.ListLogsForTask("JB_logs_test", "score_candidates")
+	require.NoError(t, err)
+
+	// Should return 3 logs: the NULL task_id row (matched by stage) + 2 explicit task_id rows
+	// NOT the "other_task" row
+	require.Len(t, logs, 3)
+
+	// Ordered by timestamp ASC
+	assert.Equal(t, "Stage started", logs[0].Message)
+	assert.Equal(t, "Scoring started", logs[1].Message)
+	assert.Equal(t, "Score complete", logs[2].Message)
+
+	// Metadata parsed correctly on the third entry
+	assert.NotNil(t, logs[2].Metadata)
+	assert.Equal(t, 0.92, logs[2].Metadata["score"])
+	assert.Equal(t, "gpt-4", logs[2].Metadata["model"])
+
+	// First two have nil metadata
+	assert.Nil(t, logs[0].Metadata)
+	assert.Nil(t, logs[1].Metadata)
+
+	// Nonexistent task returns empty, not error
+	empty, err := store.ListLogsForTask("JB_logs_test", "nonexistent_task")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}

--- a/server/pulse_job_children.go
+++ b/server/pulse_job_children.go
@@ -1,64 +1,55 @@
+// pulse_job_children.go — GET /api/pulse/jobs/{id}/children
+// Returns child async jobs spawned by a parent scheduled job's most recent execution.
 package server
 
 import (
-	"database/sql"
 	"net/http"
 	"time"
 
-	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/logger"
 	"github.com/teranos/QNTX/pulse/async"
+	"github.com/teranos/QNTX/pulse/schedule"
 )
 
 // handleGetJobChildren returns all child jobs for a given parent job
 func (s *QNTXServer) handleGetJobChildren(w http.ResponseWriter, r *http.Request, scheduledJobID string) {
 	// The incoming ID is a scheduled job ID (SP...), but child tasks are linked to async job IDs (JB...).
 	// We need to find the most recent execution's async_job_id for this scheduled job.
+	execStore := schedule.NewExecutionStore(s.db)
 
-	var asyncJobID string
-	err := s.db.QueryRow(`
-		SELECT async_job_id
-		FROM pulse_executions
-		WHERE scheduled_job_id = ?
-		ORDER BY started_at DESC
-		LIMIT 1
-	`, scheduledJobID).Scan(&asyncJobID)
-
+	asyncJobID, err := execStore.GetAsyncJobIDForScheduledJob(scheduledJobID)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			// No executions yet for this scheduled job - return empty list
-			writeJSON(w, http.StatusOK, map[string]interface{}{
-				"children": []ChildJobInfo{},
-			})
-			return
-		}
-		wrappedErr := errors.Wrap(err, "failed to find async job for scheduled job")
 		logger.AddPulseSymbol(s.logger).Errorw("Failed to find async job for scheduled job",
 			"scheduled_job_id", scheduledJobID,
-			"error", wrappedErr)
-		writeError(w, http.StatusInternalServerError, wrappedErr.Error())
+			"error", err)
+		writeWrappedError(w, s.logger, err, "failed to find async job for scheduled job", http.StatusInternalServerError)
 		return
 	}
 
-	// Get the async job queue
-	queue := async.NewQueue(s.db)
+	if asyncJobID == "" {
+		// No executions yet for this scheduled job - return empty list
+		writeJSON(w, http.StatusOK, JobChildrenResponse{
+			ParentJobID: scheduledJobID,
+			Children:    []ChildJobInfo{},
+		})
+		return
+	}
 
 	// Fetch child jobs using the async job ID
+	queue := async.NewQueue(s.db)
 	childJobs, err := queue.ListTasksByParent(asyncJobID)
 	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to fetch child jobs")
 		logger.AddPulseSymbol(s.logger).Errorw("Failed to fetch child jobs",
 			"scheduled_job_id", scheduledJobID,
 			"async_job_id", asyncJobID,
-			"error", wrappedErr)
-		writeError(w, http.StatusInternalServerError, wrappedErr.Error())
+			"error", err)
+		writeWrappedError(w, s.logger, err, "failed to fetch child jobs", http.StatusInternalServerError)
 		return
 	}
 
 	// Convert to response format
 	children := make([]ChildJobInfo, 0, len(childJobs))
 	for _, job := range childJobs {
-		// Calculate progress percentage
 		var progressPct float64
 		if job.Progress.Total > 0 {
 			progressPct = float64(job.Progress.Current) / float64(job.Progress.Total) * 100

--- a/server/pulse_task_logs.go
+++ b/server/pulse_task_logs.go
@@ -1,71 +1,22 @@
+// pulse_task_logs.go — GET /api/pulse/jobs/{id}/tasks/{task_id}/logs
+// Returns log entries for a specific task within a job context.
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/teranos/QNTX/errors"
-	"github.com/teranos/QNTX/logger"
+	"github.com/teranos/QNTX/pulse/schedule"
 )
 
-// handleGetTaskLogsForJob returns logs for a specific task within a job context
-// NEW: Requires both job_id and task_id to avoid ambiguity
-// NOTE: task_id may be NULL in database (for stage-level logs), so we also check stage column
+// handleGetTaskLogsForJob returns logs for a specific task within a job context.
+// task_id may be NULL in database (for stage-level logs), so the store also checks the stage column.
 func (s *QNTXServer) handleGetTaskLogsForJob(w http.ResponseWriter, r *http.Request, jobID string, taskID string) {
-	query := `
-		SELECT timestamp, level, message, metadata
-		FROM task_logs
-		WHERE job_id = ? AND (task_id = ? OR (task_id IS NULL AND stage = ?))
-		ORDER BY timestamp ASC
-	`
+	store := schedule.NewTaskLogStore(s.db)
 
-	pulseLog := logger.AddPulseSymbol(s.logger)
-
-	rows, err := s.db.Query(query, jobID, taskID, taskID)
+	logs, err := store.ListLogsForTask(jobID, taskID)
 	if err != nil {
-		wrappedErr := errors.Wrap(err, "failed to query task logs")
-		pulseLog.Errorw("Failed to query task logs",
-			"job_id", jobID,
-			"task_id", taskID,
-			"error", wrappedErr)
-		writeError(w, http.StatusInternalServerError, wrappedErr.Error())
+		writeWrappedError(w, s.logger, err, "failed to query task logs", http.StatusInternalServerError)
 		return
-	}
-	defer rows.Close()
-
-	logs := []LogEntry{}
-	for rows.Next() {
-		var timestamp, level, message string
-		var metadataJSON *string
-
-		if err := rows.Scan(&timestamp, &level, &message, &metadataJSON); err != nil {
-			wrappedErr := errors.Wrap(err, "failed to scan task log row")
-			pulseLog.Errorw("Failed to scan task log row - database type mismatch or corrupt data",
-				"job_id", jobID,
-				"task_id", taskID,
-				"error", wrappedErr,
-				"expected_columns", []string{"timestamp (DATETIME)", "level (TEXT)", "message (TEXT)", "metadata (TEXT/NULL)"})
-			writeError(w, http.StatusInternalServerError, wrappedErr.Error())
-			return
-		}
-
-		var metadata map[string]interface{}
-		if metadataJSON != nil {
-			if err := json.Unmarshal([]byte(*metadataJSON), &metadata); err != nil {
-				pulseLog.Warnw("Failed to unmarshal metadata, using empty object",
-					"job_id", jobID,
-					"task_id", taskID,
-					"error", errors.Wrap(err, "json unmarshal failed"))
-				metadata = make(map[string]interface{})
-			}
-		}
-
-		logs = append(logs, LogEntry{
-			Timestamp: timestamp,
-			Level:     level,
-			Message:   message,
-			Metadata:  metadata,
-		})
 	}
 
 	writeJSON(w, http.StatusOK, TaskLogsResponse{

--- a/server/pulse_task_stages.go
+++ b/server/pulse_task_stages.go
@@ -1,67 +1,21 @@
+// pulse_task_stages.go — GET /api/pulse/jobs/{id}/stages
+// Returns stages and tasks for a job, grouped by execution phase with log counts.
 package server
 
 import (
 	"net/http"
+
+	"github.com/teranos/QNTX/pulse/schedule"
 )
 
 // handleGetJobStages returns stages and tasks for a job
 func (s *QNTXServer) handleGetJobStages(w http.ResponseWriter, r *http.Request, jobID string) {
-	// Query task_logs grouped by stage and task_id
-	query := `
-		SELECT
-			COALESCE(stage, 'unknown') as stage,
-			COALESCE(task_id, stage, 'unknown') as task_id,
-			COUNT(*) as log_count
-		FROM task_logs
-		WHERE job_id = ?
-		GROUP BY stage, task_id
-		ORDER BY MIN(id) ASC
-	`
+	store := schedule.NewTaskLogStore(s.db)
 
-	rows, err := s.db.Query(query, jobID)
+	stages, err := store.ListStagesForJob(jobID)
 	if err != nil {
 		writeWrappedError(w, s.logger, err, "failed to query task logs", http.StatusInternalServerError)
 		return
-	}
-	defer rows.Close()
-
-	// Build stage map
-	stageMap := make(map[string][]TaskInfo)
-	stageOrder := []string{} // Track order of stages
-
-	for rows.Next() {
-		var stage, taskID string
-		var logCount int
-		if err := rows.Scan(&stage, &taskID, &logCount); err != nil {
-			s.logger.Errorw("Failed to scan task log row - database type mismatch or corrupt data",
-				"job_id", jobID,
-				"error", err,
-				"error_detail", err.Error(),
-				"expected_columns", []string{"stage (TEXT)", "task_id (TEXT)", "log_count (INTEGER)"},
-				"query", "SELECT COALESCE(stage, 'unknown'), COALESCE(task_id, stage), COUNT(*) FROM task_logs",
-			)
-			continue
-		}
-
-		// Track stage order
-		if _, exists := stageMap[stage]; !exists {
-			stageOrder = append(stageOrder, stage)
-			stageMap[stage] = []TaskInfo{}
-		}
-
-		stageMap[stage] = append(stageMap[stage], TaskInfo{
-			TaskID:   taskID,
-			LogCount: logCount,
-		})
-	}
-
-	// Convert to ordered stages array
-	stages := make([]StageInfo, 0, len(stageOrder))
-	for _, stage := range stageOrder {
-		stages = append(stages, StageInfo{
-			Stage: stage,
-			Tasks: stageMap[stage],
-		})
 	}
 
 	writeJSON(w, http.StatusOK, JobStagesResponse{

--- a/server/pulse_types.go
+++ b/server/pulse_types.go
@@ -54,36 +54,16 @@ type ErrorResponse struct {
 	Details []string `json:"details,omitempty"` // Structured error context from errors.GetAllDetails()
 }
 
-// TaskInfo represents a task within a stage
-type TaskInfo struct {
-	TaskID   string `json:"task_id"`
-	LogCount int    `json:"log_count,omitempty"`
-}
-
-// StageInfo represents a stage with its tasks
-type StageInfo struct {
-	Stage string     `json:"stage"`
-	Tasks []TaskInfo `json:"tasks"`
-}
-
 // JobStagesResponse represents the response for GET /jobs/:job_id/stages
 type JobStagesResponse struct {
-	JobID  string      `json:"job_id"`
-	Stages []StageInfo `json:"stages"`
-}
-
-// LogEntry represents a single log entry
-type LogEntry struct {
-	Timestamp string                 `json:"timestamp"`
-	Level     string                 `json:"level"`
-	Message   string                 `json:"message"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	JobID  string               `json:"job_id"`
+	Stages []schedule.StageInfo `json:"stages"`
 }
 
 // TaskLogsResponse represents the response for GET /tasks/:task_id/logs
 type TaskLogsResponse struct {
-	TaskID string     `json:"task_id"`
-	Logs   []LogEntry `json:"logs"`
+	TaskID string              `json:"task_id"`
+	Logs   []schedule.LogEntry `json:"logs"`
 }
 
 // ChildJobInfo represents a child job summary


### PR DESCRIPTION
## Summary
- New `TaskLogStore` in `pulse/schedule/` — single point of access for `task_logs` table (was raw SQL in 2 handler files)
- New `ExecutionStore.GetAsyncJobIDForScheduledJob` — replaces raw SQL in `pulse_job_children.go`
- Handler files reduced to thin HTTP adapters calling store methods
- Survey doc updated with backend coupling analysis and decoupling roadmap

## Test plan
- [x] `make test` — 638 pass, 0 fail
- [x] 3 new store tests (stages grouping, task log NULL fallback, async job ID lookup)
- [x] Manual: stage tree loads, task logs render, child jobs resolve