### PR TITLE
Fix lateral meld breaking vertical chain layout (#521)

### DIFF
--- a/web/ts/components/glyph/glyph-interaction.ts
+++ b/web/ts/components/glyph/glyph-interaction.ts
@@ -21,7 +21,7 @@ import {
     PROXIMITY_THRESHOLD,
     MELD_THRESHOLD
 } from './meld/meld-system';
-import { getMeldOptions, getGlyphClass } from './meld/meldability';
+import { getMeldOptions, selectPreferredMeldOption, getGlyphClass } from './meld/meldability';
 import { isGlyphSelected, getSelectedGlyphIds } from './canvas/selection';
 import { getTransform } from './canvas/canvas-pan.js';
 import { addComposition, findCompositionByGlyph } from '../../state/compositions';
@@ -294,8 +294,8 @@ export function makeDraggable(
 
                     if (existingComp && standaloneClass) {
                         const options = getMeldOptions(standaloneClass, compositionElement, existingComp.edges);
-                        if (options.length > 0) {
-                            const option = options[0];
+                        const option = selectPreferredMeldOption(options, anchorId);
+                        if (option) {
                             extendComposition(compositionElement, standaloneElement, standaloneId, option.glyphId, option.direction, option.incomingRole);
 
                             const updatedId = compositionElement.getAttribute('data-glyph-id') || '';

--- a/web/ts/components/glyph/meld/meldability.test.ts
+++ b/web/ts/components/glyph/meld/meldability.test.ts
@@ -13,6 +13,7 @@ import {
     getLeafGlyphIds,
     getRootGlyphIds,
     getMeldOptions,
+    selectPreferredMeldOption,
     computeGridPositions,
     type EdgeDirection
 } from './meldability';
@@ -299,6 +300,41 @@ describe('Port-aware MELDABILITY registry', () => {
             expect(appendOption).toBeDefined();
         });
 
+        test('doc right-meld onto result chain returns options for all results (#521)', () => {
+            const composition = document.createElement('div');
+            const r1 = document.createElement('div');
+            r1.className = 'canvas-result-glyph';
+            r1.setAttribute('data-glyph-id', 'result1');
+            const r2 = document.createElement('div');
+            r2.className = 'canvas-result-glyph';
+            r2.setAttribute('data-glyph-id', 'result2');
+            const r3 = document.createElement('div');
+            r3.className = 'canvas-result-glyph';
+            r3.setAttribute('data-glyph-id', 'result3');
+            composition.appendChild(r1);
+            composition.appendChild(r2);
+            composition.appendChild(r3);
+
+            const edges = [
+                { from: 'result1', to: 'result2', direction: 'bottom' },
+                { from: 'result2', to: 'result3', direction: 'bottom' }
+            ];
+
+            const options = getMeldOptions('canvas-doc-glyph', composition, edges);
+
+            // All three results have free right-incoming ports → doc can meld onto any
+            const rightOptions = options.filter(o => o.direction === 'right');
+            expect(rightOptions.length).toBe(3);
+
+            // The preferred option should match the anchor (spatially nearest) glyph
+            const preferredOption = selectPreferredMeldOption(options, 'result3');
+            expect(preferredOption!.glyphId).toBe('result3');
+
+            // Falls back to first option when anchor has no match
+            const fallbackOption = selectPreferredMeldOption(options, 'nonexistent');
+            expect(fallbackOption).toBeDefined();
+        });
+
         test('incompatible glyph returns no options', () => {
             const composition = document.createElement('div');
             const ax = document.createElement('div');
@@ -412,13 +448,45 @@ describe('Port-aware MELDABILITY registry', () => {
             expect(positions.get('note1')).toBeDefined();
         });
 
-        test('top direction edge → row above parent', () => {
+        test('lateral root right-melded onto mid-chain preserves vertical layout (#521)', () => {
+            // doc melds right onto r3 in a vertical chain r1→r2→r3→r4
+            // Expected: chain stays vertical, doc sits left of r3
+            const edges = [
+                { from: 'r1', to: 'r2', direction: 'bottom' },
+                { from: 'r2', to: 'r3', direction: 'bottom' },
+                { from: 'r3', to: 'r4', direction: 'bottom' },
+                { from: 'doc1', to: 'r3', direction: 'right' }
+            ];
+            const positions = computeGridPositions(edges);
+
+            // Chain remains vertical in one column
+            const r1 = positions.get('r1')!;
+            const r2 = positions.get('r2')!;
+            const r3 = positions.get('r3')!;
+            const r4 = positions.get('r4')!;
+            const doc = positions.get('doc1')!;
+
+            // Vertical chain: same column, ascending rows
+            expect(r1.col).toBe(r2.col);
+            expect(r2.col).toBe(r3.col);
+            expect(r3.col).toBe(r4.col);
+            expect(r1.row).toBeLessThan(r2.row);
+            expect(r2.row).toBeLessThan(r3.row);
+            expect(r3.row).toBeLessThan(r4.row);
+
+            // Doc sits left of r3 (same row, earlier column)
+            expect(doc.row).toBe(r3.row);
+            expect(doc.col).toBeLessThan(r3.col);
+        });
+
+        test('top direction edge → target above parent, normalized', () => {
             const edges = [
                 { from: 'note1', to: 'prompt1', direction: 'top' }
             ];
             const positions = computeGridPositions(edges);
-            expect(positions.get('note1')).toEqual({ row: 1, col: 1 });
-            expect(positions.get('prompt1')).toEqual({ row: 0, col: 1 });
+            // note1 at row 1 → prompt1 at row 0 → normalized: prompt1=1, note1=2
+            expect(positions.get('prompt1')).toEqual({ row: 1, col: 1 });
+            expect(positions.get('note1')).toEqual({ row: 2, col: 1 });
         });
     });
 });

--- a/web/ts/components/glyph/meld/meldability.ts
+++ b/web/ts/components/glyph/meld/meldability.ts
@@ -260,9 +260,25 @@ export function getMeldOptions(
 }
 
 /**
+ * Select the best meld option, preferring the one matching the anchor glyph
+ * (the spatially nearest glyph from drag detection). Falls back to first option.
+ */
+export function selectPreferredMeldOption(
+    options: MeldOption[],
+    anchorGlyphId: string
+): MeldOption | null {
+    if (options.length === 0) return null;
+    return options.find(o => o.glyphId === anchorGlyphId) ?? options[0];
+}
+
+/**
  * Compute grid row/col for each glyph in an edge DAG.
  * BFS from roots: 'right' → same row, next col; 'bottom' → next row, same col.
  * Single source of truth for composition spatial layout.
+ *
+ * Roots are processed sequentially, deepest chains first. Lateral roots
+ * (those whose targets are already positioned by a longer chain) derive
+ * their position from the connection rather than starting at row 1.
  */
 export function computeGridPositions(
     edges: Array<{ from: string; to: string; direction: string }>
@@ -280,37 +296,107 @@ export function computeGridPositions(
         adjacency.get(edge.from)!.push({ to: edge.to, direction: edge.direction });
     }
 
-    // BFS from roots
-    const queue: string[] = [];
-    for (let i = 0; i < roots.length; i++) {
-        positions.set(roots[i], { row: 1, col: 1 + i });
-        queue.push(roots[i]);
+    // Sort roots: deepest chains first so they establish positions before lateral roots
+    function countReachable(id: string): number {
+        let count = 0;
+        const visited = new Set<string>();
+        const q = [id];
+        while (q.length > 0) {
+            const n = q.shift()!;
+            for (const { to } of adjacency.get(n) || []) {
+                if (!visited.has(to)) {
+                    visited.add(to);
+                    count++;
+                    q.push(to);
+                }
+            }
+        }
+        return count;
+    }
+    roots.sort((a, b) => countReachable(b) - countReachable(a));
+
+    // Process each root sequentially: place + full BFS before next root
+    let nextRootCol = 1;
+    for (const root of roots) {
+        if (positions.has(root)) continue;
+
+        // Lateral root: target already positioned → derive position from connection
+        let derived = false;
+        const rootNeighbors = adjacency.get(root);
+        if (rootNeighbors) {
+            for (const { to, direction } of rootNeighbors) {
+                const targetPos = positions.get(to);
+                if (!targetPos) continue;
+
+                let candidate: { row: number; col: number } | null = null;
+                if (direction === 'right') {
+                    candidate = { row: targetPos.row, col: targetPos.col - 1 };
+                } else if (direction === 'bottom') {
+                    candidate = { row: targetPos.row - 1, col: targetPos.col };
+                } else if (direction === 'top') {
+                    candidate = { row: targetPos.row + 1, col: targetPos.col };
+                }
+
+                // Only use derived position if it doesn't collide with an existing glyph
+                if (candidate) {
+                    const occupied = [...positions.values()].some(
+                        p => p.row === candidate!.row && p.col === candidate!.col
+                    );
+                    if (!occupied) {
+                        positions.set(root, candidate);
+                        derived = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!derived) {
+            positions.set(root, { row: 1, col: nextRootCol });
+            nextRootCol++;
+        }
+
+        // BFS from this root
+        const queue = [root];
+        while (queue.length > 0) {
+            const current = queue.shift()!;
+            const pos = positions.get(current)!;
+            const neighbors = adjacency.get(current);
+            if (!neighbors) continue;
+
+            const dirOffset = new Map<string, number>();
+
+            for (const { to, direction } of neighbors) {
+                if (positions.has(to)) continue; // first assignment wins
+
+                const offset = dirOffset.get(direction) || 0;
+
+                if (direction === 'right') {
+                    positions.set(to, { row: pos.row, col: pos.col + 1 + offset });
+                } else if (direction === 'bottom') {
+                    positions.set(to, { row: pos.row + 1 + offset, col: pos.col });
+                } else if (direction === 'top') {
+                    positions.set(to, { row: pos.row - 1 - offset, col: pos.col });
+                }
+
+                dirOffset.set(direction, offset + 1);
+                queue.push(to);
+            }
+        }
     }
 
-    while (queue.length > 0) {
-        const current = queue.shift()!;
-        const pos = positions.get(current)!;
-        const neighbors = adjacency.get(current);
-        if (!neighbors) continue;
-
-        // Track offset for multiple children in the same direction (e.g., two results below py)
-        const dirOffset = new Map<string, number>();
-
-        for (const { to, direction } of neighbors) {
-            if (positions.has(to)) continue; // first assignment wins
-
-            const offset = dirOffset.get(direction) || 0;
-
-            if (direction === 'right') {
-                positions.set(to, { row: pos.row, col: pos.col + 1 + offset });
-            } else if (direction === 'bottom') {
-                positions.set(to, { row: pos.row + 1 + offset, col: pos.col });
-            } else if (direction === 'top') {
-                positions.set(to, { row: pos.row - 1 - offset, col: pos.col });
-            }
-
-            dirOffset.set(direction, offset + 1);
-            queue.push(to);
+    // Normalize: shift all positions so minimum row and col are both 1
+    let minRow = Infinity, minCol = Infinity;
+    for (const pos of positions.values()) {
+        minRow = Math.min(minRow, pos.row);
+        minCol = Math.min(minCol, pos.col);
+    }
+    if (minRow < 1 || minCol < 1) {
+        const rowShift = 1 - minRow;
+        const colShift = 1 - minCol;
+        for (const [, pos] of positions) {
+            pos.row += rowShift;
+            pos.col += colShift;
         }
     }
 


### PR DESCRIPTION
## Summary

- Right-melding a doc onto a mid-chain result tore the chain apart because all roots were placed at row 1 before BFS — lateral roots now derive position from already-positioned targets, deepest chains first
- Meld option selection prefers the spatially nearest anchor glyph instead of blindly picking the first match

## Test plan

- [x] `make test` — 642 pass
- [x] `make dev`, create a result chain (3+ results), right-meld a doc onto a middle result → chain stays vertical, doc sits left
- [x] Drag the composition → all glyphs move together
- [x] Reload → composition persists

Closes #521