### PR TITLE
Subcanvas meld support (#483)

### DIFF
--- a/ai/openrouter/client.go
+++ b/ai/openrouter/client.go
@@ -111,9 +111,9 @@ type ChatCompletionRequest struct {
 type ChatRequest struct {
 	SystemPrompt string
 	UserPrompt   string
-	Temperature  *float64 // Override default temperature
-	MaxTokens    *int     // Override default max tokens
-	Model        *string  // Override default model
+	Temperature  *float64      // Override default temperature
+	MaxTokens    *int          // Override default max tokens
+	Model        *string       // Override default model
 	Attachments  []ContentPart // Multimodal attachments (base64 documents/images) — not serialized to JSON
 }
 

--- a/ai/openrouter/client_test.go
+++ b/ai/openrouter/client_test.go
@@ -103,7 +103,7 @@ func TestClient_Chat(t *testing.T) {
 				Model:   "test-model",
 				Choices: []Choice{
 					{
-						Index: 0,
+						Index:        0,
 						Message:      NewTextMessage("assistant", "Test response content"),
 						FinishReason: "stop",
 					},

--- a/crates/qntx-grpc/src/types/schedule.rs
+++ b/crates/qntx-grpc/src/types/schedule.rs
@@ -66,3 +66,37 @@ pub struct Execution {
     /// RFC3339 timestamp
     pub updated_at: String,
 }
+
+/// LogEntry represents a single log entry from a task execution
+#[doc = "Documentation: <https://github.com/teranos/QNTX/blob/main/docs/types/schedule.md#logentry>"]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogEntry {
+    pub timestamp: String,
+    pub level: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+/// StageInfo represents a stage with its tasks
+#[doc = "Documentation: <https://github.com/teranos/QNTX/blob/main/docs/types/schedule.md#stageinfo>"]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StageInfo {
+    pub stage: String,
+    pub tasks: Vec<TaskInfo>,
+}
+
+/// TaskInfo represents a task within a stage, with its log count
+#[doc = "Documentation: <https://github.com/teranos/QNTX/blob/main/docs/types/schedule.md#taskinfo>"]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TaskInfo {
+    pub task_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_count: Option<i64>,
+}
+
+/// TaskLogStore handles persistence of task-level execution logs.
+/// The task_logs table captures per-stage, per-task log output from async job executions.
+#[doc = "Documentation: <https://github.com/teranos/QNTX/blob/main/docs/types/schedule.md#tasklogstore>"]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TaskLogStore {}

--- a/docs/glyphs/result.md
+++ b/docs/glyphs/result.md
@@ -1,0 +1,38 @@
+# Result Glyph
+
+Execution output display. Shows stdout, stderr, and errors from glyph execution.
+
+## Spawning
+
+Result glyphs are not user-spawned. They are created automatically when a py, ts, or prompt glyph executes. The result auto-melds below its parent glyph via `autoMeldResultBelow`.
+
+## Structure
+
+- **Header**: duration label (`{n}ms`), expand-to-window button (not yet implemented, #440), close button
+- **Output area**: monospace `pre-wrap` container showing stdout (default color), stderr (error color), errors (bold error color)
+- Height auto-calculated from line count, clamped to 80–400px
+
+## Close behavior
+
+Closing a result that is inside a melded composition unmelds the entire composition first (via `unmeldComposition`), then removes the result element.
+
+## Meld position
+
+Result receives `bottom` connections from py and prompt glyphs. It can also chain downward to other result glyphs (`bottom → result`).
+
+## Chaining
+
+Result glyphs chain via `bottom` meld edges for conversational follow-ups. A hover-reveal input appears at the bottom edge of a result; typing a follow-up and pressing Enter sends the previous output plus the new prompt to the LLM, spawning a chained result below. Chains extend indefinitely through melded compositions.
+
+## Content persistence
+
+The `ExecutionResult` object is JSON-serialized into the glyph's `content` field for persistence across page reloads. `updateResultGlyphContent` updates an existing result in-place when re-execution occurs.
+
+## Files
+
+| File | Role |
+|------|------|
+| `web/ts/components/glyph/result-glyph.ts` | Glyph factory, `createResultGlyph`, `updateResultGlyphContent` |
+| `web/ts/components/glyph/meld/auto-meld-result.ts` | Auto-meld helper used by py/ts/prompt glyphs |
+| `web/ts/components/glyph/result-glyph.dom.test.ts` | DOM structure tests |
+| `web/ts/components/glyph/result-drag.test.ts` | Drag behavior tests |

--- a/docs/glyphs/subcanvas.md
+++ b/docs/glyphs/subcanvas.md
@@ -1,0 +1,79 @@
+# Subcanvas Glyph (⌗)
+
+Nested canvas workspace on the parent canvas. Compact form shows a purple glyph with grid preview; double-click morphs to a fullscreen workspace with its own spawn/drag/meld/pan context.
+
+## Two manifestations
+
+- **Compact** (`canvas-subcanvas-glyph`): 180×120 canvas-placed glyph with title bar and grid preview. Default label: `⌗ subcanvas`.
+- **Expanded** (`canvas-subcanvas-glyph-expanded`): fullscreen workspace reparented to `document.body`. Element is reparented, not recreated (Element Axiom). Breadcrumb bar shows nesting trail; minimize button or Escape returns to compact.
+
+## Naming
+
+Double-click the title bar label to edit inline. Blur or Enter commits the new name to `uiState` and persists via API. The name carries through to the breadcrumb bar when expanded.
+
+## Canvas ID mapping
+
+The glyph ID doubles as the `canvas_id` for inner glyphs — no mapping table. Inner glyphs are loaded from `uiState.getCanvasGlyphs(subcanvasId)` on expand.
+
+## Nesting
+
+Subcanvases nest arbitrarily. Each expanded level pushes a breadcrumb entry. Clicking an ancestor breadcrumb cascade-minimizes all levels above. Escape only collapses the innermost level (event listener is on the element, not document).
+
+## Melding
+
+Subcanvas is a universal connector in the meld grid:
+
+| Direction | Targets |
+|-----------|---------|
+| right | All glyph classes |
+| bottom | All glyph classes |
+| top | All glyph classes |
+
+All other glyphs also list subcanvas as a valid target in their port rules.
+
+When a melded subcanvas expands to fullscreen, a ghost placeholder (`.subcanvas-ghost`) holds its grid cell in the composition. On minimize, the ghost is replaced with the real element and grid positioning is restored.
+
+## Files
+
+| File | Role |
+|------|------|
+| `web/ts/components/glyph/subcanvas-glyph.ts` | Glyph factory, ghost placeholder, restore logic |
+| `web/ts/components/glyph/manifestations/canvas-expanded.ts` | Compact ↔ fullscreen morph path |
+| `web/ts/components/glyph/canvas/breadcrumb.ts` | Breadcrumb stack for nested subcanvases |
+| `web/ts/components/glyph/meld/meldability.ts` | `canvas-subcanvas-glyph` port rules |
+| `web/css/canvas.css` | `.canvas-subcanvas-glyph`, `.subcanvas-preview`, `.subcanvas-ghost` styles |
+
+## Status & roadmap
+
+### Built
+
+| PR | What |
+|----|------|
+| #484 | Compact ↔ fullscreen morph (Element Axiom) |
+| #495 | Per-workspace selection scoping |
+| #507 | Naming, breadcrumb navigation |
+| #483 | Meld grid participation, ghost placeholder, port rules |
+
+Physical melding works: subcanvas sits in a composition grid, ghost holds its cell when expanded, grid restores on minimize.
+
+### Not built — the usability gap
+
+| Issue | What | Why it matters |
+|-------|------|----------------|
+| #491 | Drag glyph into subcanvas | Can't populate a subcanvas from the parent canvas |
+| #492 | Drag composition into subcanvas | Can't move an entire composition into a subcanvas |
+
+### The melded subcanvas — DAG in a DAG
+
+Today melding is purely spatial. Compositions are edge DAGs used for CSS Grid layout and attachment aggregation (docs/notes collected as prompt context). No dataflow through edges.
+
+A melded subcanvas (`ax → ⌗ → prompt`) is a **sub-DAG node**: the inner workspace IS a DAG. The subcanvas's external meld ports map to its inner root and leaf glyphs. Upstream attestations enter through inner roots; inner leaves produce output that flows downstream. The composition DAG becomes recursive — a DAG whose nodes can themselves be DAGs.
+
+`ax → ⌗ → prompt` is really `ax → [inner-root → ... → inner-leaf] → prompt`. The subcanvas boundary is a scope gate with typed ports, not an opaque box.
+
+### Follow-ups (recommended order)
+
+1. **#491 — Drag glyph into subcanvas.** Single biggest usability blocker.
+2. **#492 — Drag composition into subcanvas.** Natural extension — move a melded chain into a subcanvas as a unit.
+3. **Sub-DAG wiring.** Map inner root/leaf glyphs to the subcanvas's external meld ports so attestations flow through. Starts as a vision doc update to `fractal-workspace.md`.
+4. **Phase 5 hardening.** Composition reconstruction on page load, stale edge cleanup, error propagation through DAG — all compositions, not just subcanvas, but more urgent as compositions nest.

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -15,11 +15,11 @@ Auto-generated documentation showing Go source code alongside TypeScript type de
 
 - **[async](./async.md)** - Asynchronous job processing with Pulse (9 types)
 - **[budget](./budget.md)** - Cost tracking and budget management (5 types)
-- **[schedule](./schedule.md)** - Scheduled execution with cron (1 types)
+- **[schedule](./schedule.md)** - Scheduled execution with cron (5 types)
 
 ### Server
 
-- **[server](./server.md)** - WebSocket message types for real-time updates (46 types)
+- **[server](./server.md)** - WebSocket message types for real-time updates (43 types)
 
 ## Usage
 

--- a/docs/types/schedule.md
+++ b/docs/types/schedule.md
@@ -46,3 +46,51 @@ type Execution struct {
 	UpdatedAt string `json:"updated_at"`
 }
 ```
+
+## LogEntry {#logentry}
+
+**Source**: [`pulse/schedule/task_log_store.go:23`](https://github.com/teranos/QNTX/blob/main/pulse/schedule/task_log_store.go#L23)
+
+
+```go
+type LogEntry struct {
+	Timestamp string `json:"timestamp"`
+	Level string `json:"level"`
+	Message string `json:"message"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+```
+
+## StageInfo {#stageinfo}
+
+**Source**: [`pulse/schedule/task_log_store.go:17`](https://github.com/teranos/QNTX/blob/main/pulse/schedule/task_log_store.go#L17)
+
+
+```go
+type StageInfo struct {
+	Stage string `json:"stage"`
+	Tasks []TaskInfo `json:"tasks"`
+}
+```
+
+## TaskInfo {#taskinfo}
+
+**Source**: [`pulse/schedule/task_log_store.go:11`](https://github.com/teranos/QNTX/blob/main/pulse/schedule/task_log_store.go#L11)
+
+
+```go
+type TaskInfo struct {
+	TaskID string `json:"task_id"`
+	LogCount int `json:"log_count,omitempty"`
+}
+```
+
+## TaskLogStore {#tasklogstore}
+
+**Source**: [`pulse/schedule/task_log_store.go:32`](https://github.com/teranos/QNTX/blob/main/pulse/schedule/task_log_store.go#L32)
+
+
+```go
+type TaskLogStore struct {
+}
+```

--- a/docs/types/server.md
+++ b/docs/types/server.md
@@ -12,7 +12,7 @@ This document shows Go type definitions from the codebase.
 
 ## ChildJobInfo {#childjobinfo}
 
-**Source**: [`server/pulse_types.go:90`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L90)
+**Source**: [`server/pulse_types.go:70`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L70)
 
 
 ```go
@@ -145,7 +145,7 @@ type GlyphFiredMessage struct {
 
 ## JobChildrenResponse {#jobchildrenresponse}
 
-**Source**: [`server/pulse_types.go:105`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L105)
+**Source**: [`server/pulse_types.go:85`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L85)
 
 
 ```go
@@ -157,13 +157,13 @@ type JobChildrenResponse struct {
 
 ## JobStagesResponse {#jobstagesresponse}
 
-**Source**: [`server/pulse_types.go:70`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L70)
+**Source**: [`server/pulse_types.go:58`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L58)
 
 
 ```go
 type JobStagesResponse struct {
 	JobID string `json:"job_id"`
-	Stages []StageInfo `json:"stages"`
+	Stages []schedule.StageInfo `json:"stages"`
 }
 ```
 
@@ -221,20 +221,6 @@ type ListExecutionsResponse struct {
 type ListScheduledJobsResponse struct {
 	Jobs []ScheduledJobResponse `json:"jobs"`
 	Count int `json:"count,omitempty"`
-}
-```
-
-## LogEntry {#logentry}
-
-**Source**: [`server/pulse_types.go:76`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L76)
-
-
-```go
-type LogEntry struct {
-	Timestamp string `json:"timestamp"`
-	Level string `json:"level"`
-	Message string `json:"message"`
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 ```
 
@@ -589,18 +575,6 @@ type ScheduledJobResponse struct {
 }
 ```
 
-## StageInfo {#stageinfo}
-
-**Source**: [`server/pulse_types.go:64`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L64)
-
-
-```go
-type StageInfo struct {
-	Stage string `json:"stage"`
-	Tasks []TaskInfo `json:"tasks"`
-}
-```
-
 ## StatsMessage {#statsmessage}
 
 **Source**: [`server/types.go:105`](https://github.com/teranos/QNTX/blob/main/server/types.go#L105)
@@ -633,27 +607,15 @@ type StorageWarningMessage struct {
 }
 ```
 
-## TaskInfo {#taskinfo}
-
-**Source**: [`server/pulse_types.go:58`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L58)
-
-
-```go
-type TaskInfo struct {
-	TaskID string `json:"task_id"`
-	LogCount int `json:"log_count,omitempty"`
-}
-```
-
 ## TaskLogsResponse {#tasklogsresponse}
 
-**Source**: [`server/pulse_types.go:84`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L84)
+**Source**: [`server/pulse_types.go:64`](https://github.com/teranos/QNTX/blob/main/server/pulse_types.go#L64)
 
 
 ```go
 type TaskLogsResponse struct {
 	TaskID string `json:"task_id"`
-	Logs []LogEntry `json:"logs"`
+	Logs []schedule.LogEntry `json:"logs"`
 }
 ```
 

--- a/server/handlers_types_test.go
+++ b/server/handlers_types_test.go
@@ -84,11 +84,11 @@ func TestRichStringFieldsForRestaurantDomain(t *testing.T) {
 			Label: "Restaurant",
 			Color: "#e74c3c", // Appetizing red
 			RichStringFields: []string{
-				"name",           // "Chez Laurent"
-				"cuisine_type",   // "French Bistro"
-				"chef_bio",       // "Trained at Le Cordon Bleu..."
-				"specialties",    // "Duck confit, Bouillabaisse"
-				"neighborhood",   // "Mission District"
+				"name",         // "Chez Laurent"
+				"cuisine_type", // "French Bistro"
+				"chef_bio",     // "Trained at Le Cordon Bleu..."
+				"specialties",  // "Duck confit, Bouillabaisse"
+				"neighborhood", // "Mission District"
 			},
 			// NOT searchable: tax_id, license_number, owner_ssn
 		}
@@ -114,11 +114,11 @@ func TestRichStringFieldsForRestaurantDomain(t *testing.T) {
 			Label: "Menu Item",
 			Color: "#f39c12", // Golden like a croissant
 			RichStringFields: []string{
-				"dish_name",        // "Coq au Vin"
-				"description",      // "Braised chicken in wine sauce..."
-				"ingredients",      // "chicken, red wine, mushrooms, pearl onions"
-				"dietary_tags",     // "gluten-free, dairy-free"
-				"wine_pairing",     // "Pairs well with Burgundy"
+				"dish_name",    // "Coq au Vin"
+				"description",  // "Braised chicken in wine sauce..."
+				"ingredients",  // "chicken, red wine, mushrooms, pearl onions"
+				"dietary_tags", // "gluten-free, dairy-free"
+				"wine_pairing", // "Pairs well with Burgundy"
 			},
 			ArrayFields: []string{
 				"allergens", // ["nuts", "shellfish"]
@@ -147,10 +147,10 @@ func TestRichStringFieldsForRestaurantDomain(t *testing.T) {
 			Label: "City",
 			Color: "#3498db", // Ocean blue for SF
 			RichStringFields: []string{
-				"name",              // "San Francisco"
-				"culinary_scene",    // "Famous for sourdough, Dungeness crab..."
-				"famous_districts",  // "Mission for burritos, Chinatown for dim sum"
-				"food_festivals",    // "Eat Drink SF, SF Street Food Festival"
+				"name",             // "San Francisco"
+				"culinary_scene",   // "Famous for sourdough, Dungeness crab..."
+				"famous_districts", // "Mission for burritos, Chinatown for dim sum"
+				"food_festivals",   // "Eat Drink SF, SF Street Food Festival"
 			},
 			// Hints at future relationships:
 			// - city has_many restaurants
@@ -177,10 +177,10 @@ func TestRichStringFieldsForRestaurantDomain(t *testing.T) {
 			Label: "Food Review",
 			Color: "#9b59b6", // Sophisticated purple
 			RichStringFields: []string{
-				"reviewer_name",     // "Ruth Reichl"
-				"review_text",       // "The Duck à l'Orange transported me..."
+				"reviewer_name",      // "Ruth Reichl"
+				"review_text",        // "The Duck à l'Orange transported me..."
 				"highlighted_dishes", // "Don't miss the soufflé"
-				"ambiance_notes",    // "Romantic lighting, jazz trio on Fridays"
+				"ambiance_notes",     // "Romantic lighting, jazz trio on Fridays"
 			},
 			// Relationships hinted at:
 			// - food_review reviews restaurant

--- a/typegen/util/types.go
+++ b/typegen/util/types.go
@@ -34,6 +34,10 @@ type TypeConverterConfig struct {
 func ConvertGoType(expr ast.Expr, config *TypeConverterConfig) string {
 	switch t := expr.(type) {
 	case *ast.Ident:
+		// Go's `any` is an alias for interface{} — map to UnknownType
+		if t.Name == "any" {
+			return config.UnknownType
+		}
 		// Basic type or type reference in same package
 		if mapped, ok := config.TypeMapping[t.Name]; ok {
 			return mapped

--- a/types/generated/typescript/index.ts
+++ b/types/generated/typescript/index.ts
@@ -81,6 +81,10 @@ export type {
 // Types from schedule
 export type {
   Execution,
+  LogEntry,
+  StageInfo,
+  TaskInfo,
+  TaskLogStore,
 } from './schedule';
 
 // Types from server
@@ -99,7 +103,6 @@ export type {
   LLMStreamMessage,
   ListExecutionsResponse,
   ListScheduledJobsResponse,
-  LogEntry,
   ParsedATSCode,
   PluginHealthMessage,
   PluginInfo,
@@ -120,10 +123,8 @@ export type {
   QueryMessage,
   Result,
   ScheduledJobResponse,
-  StageInfo,
   StatsMessage,
   StorageWarningMessage,
-  TaskInfo,
   TaskLogsResponse,
   UpdateScheduledJobRequest,
   UsageUpdateMessage,

--- a/types/generated/typescript/schedule.ts
+++ b/types/generated/typescript/schedule.ts
@@ -64,3 +64,23 @@ export interface Execution {
   updated_at: string;
 }
 
+export interface LogEntry {
+  timestamp: string;
+  level: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StageInfo {
+  stage: string;
+  tasks: TaskInfo[];
+}
+
+export interface TaskInfo {
+  task_id: string;
+  log_count?: number;
+}
+
+export interface TaskLogStore {
+}
+

--- a/types/generated/typescript/server.ts
+++ b/types/generated/typescript/server.ts
@@ -5,7 +5,7 @@
 // TODO: Migrate to proto generation (web/ts/generated/proto/)
 
 import { Job } from './async';
-import { Execution } from './schedule';
+import { Execution, LogEntry, StageInfo } from './schedule';
 import { As } from './types';
 
 export interface ChildJobInfo {
@@ -257,13 +257,6 @@ export interface ListExecutionsResponse {
 export interface ListScheduledJobsResponse {
   jobs: ScheduledJobResponse[];
   count?: number;
-}
-
-export interface LogEntry {
-  timestamp: string;
-  level: string;
-  message: string;
-  metadata?: Record<string, unknown>;
 }
 
 export interface ParsedATSCode {
@@ -783,11 +776,6 @@ export interface ScheduledJobResponse {
   updated_at: string;
 }
 
-export interface StageInfo {
-  stage: string;
-  tasks: TaskInfo[];
-}
-
 export interface StatsMessage {
   /**
    * "import_stats"
@@ -840,11 +828,6 @@ export interface StorageWarningMessage {
    * Unix timestamp
    */
   timestamp: number;
-}
-
-export interface TaskInfo {
-  task_id: string;
-  log_count?: number;
 }
 
 export interface TaskLogsResponse {

--- a/web/css/canvas.css
+++ b/web/css/canvas.css
@@ -372,6 +372,14 @@
         );
 }
 
+/* Ghost placeholder — holds grid cell when melded subcanvas is expanded fullscreen */
+.subcanvas-ghost {
+    border: 1px dashed rgba(160, 120, 200, 0.3);
+    background: rgba(160, 120, 200, 0.05);
+    border-radius: var(--border-radius);
+    pointer-events: none;
+}
+
 /* Expanded subcanvas fullscreen state */
 .canvas-subcanvas-glyph-expanded {
     background: var(--bg-primary);

--- a/web/ts/components/glyph/meld/meldability.test.ts
+++ b/web/ts/components/glyph/meld/meldability.test.ts
@@ -97,7 +97,7 @@ describe('Port-aware MELDABILITY registry', () => {
     });
 
     describe('getInitiatorClasses', () => {
-        test('includes ax, se, py, prompt, doc, note, result', () => {
+        test('includes ax, se, py, prompt, doc, note, result, subcanvas', () => {
             const classes = getInitiatorClasses();
             expect(classes).toContain('canvas-ax-glyph');
             expect(classes).toContain('canvas-se-glyph');
@@ -106,15 +106,18 @@ describe('Port-aware MELDABILITY registry', () => {
             expect(classes).toContain('canvas-doc-glyph');
             expect(classes).toContain('canvas-note-glyph');
             expect(classes).toContain('canvas-result-glyph');
+            expect(classes).toContain('canvas-subcanvas-glyph');
         });
     });
 
     describe('getTargetClasses', () => {
-        test('includes prompt, py, result (all targets across all ports)', () => {
+        test('includes prompt, py, doc, result, subcanvas (all targets across all ports)', () => {
             const classes = getTargetClasses();
             expect(classes).toContain('canvas-prompt-glyph');
             expect(classes).toContain('canvas-py-glyph');
+            expect(classes).toContain('canvas-doc-glyph');
             expect(classes).toContain('canvas-result-glyph');
+            expect(classes).toContain('canvas-subcanvas-glyph');
         });
     });
 
@@ -126,18 +129,20 @@ describe('Port-aware MELDABILITY registry', () => {
             expect(targets).toContain('canvas-result-glyph');
         });
 
-        test('ax can target prompt and py', () => {
+        test('ax can target prompt, py, and subcanvas', () => {
             const targets = getCompatibleTargets('canvas-ax-glyph');
             expect(targets).toContain('canvas-prompt-glyph');
             expect(targets).toContain('canvas-py-glyph');
-            expect(targets.length).toBe(2);
+            expect(targets).toContain('canvas-subcanvas-glyph');
+            expect(targets.length).toBe(3);
         });
 
-        test('se can target prompt and py (same as ax)', () => {
+        test('se can target prompt, py, and subcanvas (same as ax)', () => {
             const targets = getCompatibleTargets('canvas-se-glyph');
             expect(targets).toContain('canvas-prompt-glyph');
             expect(targets).toContain('canvas-py-glyph');
-            expect(targets.length).toBe(2);
+            expect(targets).toContain('canvas-subcanvas-glyph');
+            expect(targets.length).toBe(3);
         });
 
         test('unknown class returns empty', () => {
@@ -487,6 +492,57 @@ describe('Port-aware MELDABILITY registry', () => {
             // note1 at row 1 → prompt1 at row 0 → normalized: prompt1=1, note1=2
             expect(positions.get('prompt1')).toEqual({ row: 1, col: 1 });
             expect(positions.get('note1')).toEqual({ row: 2, col: 1 });
+        });
+    });
+
+    describe('Subcanvas meld compatibility - Tim (Happy Path)', () => {
+        test('Tim: subcanvas is compatible as target from ax (right)', () => {
+            expect(areClassesCompatible('canvas-ax-glyph', 'canvas-subcanvas-glyph')).toBe('right');
+        });
+
+        test('Tim: subcanvas is compatible as target from py (right and bottom)', () => {
+            expect(areClassesCompatible('canvas-py-glyph', 'canvas-subcanvas-glyph')).toBe('right');
+        });
+
+        test('Tim: subcanvas is compatible as target from se (right)', () => {
+            expect(areClassesCompatible('canvas-se-glyph', 'canvas-subcanvas-glyph')).toBe('right');
+        });
+
+        test('Tim: subcanvas is compatible as target from note (bottom)', () => {
+            expect(areClassesCompatible('canvas-note-glyph', 'canvas-subcanvas-glyph')).toBe('bottom');
+        });
+
+        test('Tim: subcanvas is compatible as target from prompt (bottom)', () => {
+            expect(areClassesCompatible('canvas-prompt-glyph', 'canvas-subcanvas-glyph')).toBe('bottom');
+        });
+
+        test('Tim: subcanvas can initiate meld toward prompt (right)', () => {
+            expect(areClassesCompatible('canvas-subcanvas-glyph', 'canvas-prompt-glyph')).toBe('right');
+        });
+
+        test('Tim: subcanvas can initiate meld toward py (right)', () => {
+            expect(areClassesCompatible('canvas-subcanvas-glyph', 'canvas-py-glyph')).toBe('right');
+        });
+
+        test('Tim: subcanvas can initiate meld toward result (right)', () => {
+            expect(areClassesCompatible('canvas-subcanvas-glyph', 'canvas-result-glyph')).toBe('right');
+        });
+    });
+
+    describe('Subcanvas meld compatibility - Spike (Edge Cases)', () => {
+        test('Spike: subcanvas-to-subcanvas compatibility works', () => {
+            expect(areClassesCompatible('canvas-subcanvas-glyph', 'canvas-subcanvas-glyph')).toBe('right');
+        });
+
+        test('Spike: subcanvas has ports in all three directions', () => {
+            const targets = getCompatibleTargets('canvas-subcanvas-glyph');
+            expect(targets).toContain('canvas-ax-glyph');
+            expect(targets).toContain('canvas-se-glyph');
+            expect(targets).toContain('canvas-py-glyph');
+            expect(targets).toContain('canvas-prompt-glyph');
+            expect(targets).toContain('canvas-note-glyph');
+            expect(targets).toContain('canvas-result-glyph');
+            expect(targets).toContain('canvas-subcanvas-glyph');
         });
     });
 });

--- a/web/ts/components/glyph/meld/meldability.ts
+++ b/web/ts/components/glyph/meld/meldability.ts
@@ -17,35 +17,47 @@ export interface PortRule {
     targets: readonly string[];
 }
 
+/** All glyph classes that participate in melding */
+const ALL_GLYPH_CLASSES = [
+    'canvas-ax-glyph', 'canvas-se-glyph', 'canvas-py-glyph',
+    'canvas-prompt-glyph', 'canvas-doc-glyph', 'canvas-note-glyph',
+    'canvas-result-glyph', 'canvas-subcanvas-glyph',
+] as const;
+
 /**
  * Port-aware meldability rules: maps glyph classes to their output ports
  * Each port specifies a direction and which target classes can connect there
  */
 export const MELDABILITY: Record<string, readonly PortRule[]> = {
     'canvas-ax-glyph': [
-        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph'] }
+        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph', 'canvas-subcanvas-glyph'] }
     ],
     'canvas-se-glyph': [
-        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph'] }
+        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph', 'canvas-subcanvas-glyph'] }
     ],
     'canvas-py-glyph': [
-        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph'] },
-        { direction: 'bottom', targets: ['canvas-result-glyph'] }
+        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph', 'canvas-subcanvas-glyph'] },
+        { direction: 'bottom', targets: ['canvas-result-glyph', 'canvas-subcanvas-glyph'] }
     ],
     'canvas-prompt-glyph': [
-        { direction: 'bottom', targets: ['canvas-result-glyph'] }
+        { direction: 'bottom', targets: ['canvas-result-glyph', 'canvas-subcanvas-glyph'] }
     ],
     'canvas-doc-glyph': [
         // Right-meld onto result chains targets topmost result (#521)
-        { direction: 'right', targets: ['canvas-result-glyph', 'canvas-prompt-glyph', 'canvas-doc-glyph'] },
-        { direction: 'bottom', targets: ['canvas-prompt-glyph', 'canvas-doc-glyph'] }
+        { direction: 'right', targets: ['canvas-result-glyph', 'canvas-prompt-glyph', 'canvas-doc-glyph', 'canvas-subcanvas-glyph'] },
+        { direction: 'bottom', targets: ['canvas-prompt-glyph', 'canvas-doc-glyph', 'canvas-subcanvas-glyph'] }
     ],
     'canvas-note-glyph': [
-        { direction: 'bottom', targets: ['canvas-prompt-glyph'] }
+        { direction: 'bottom', targets: ['canvas-prompt-glyph', 'canvas-subcanvas-glyph'] }
     ],
     'canvas-result-glyph': [
         { direction: 'bottom', targets: ['canvas-result-glyph'] }
-    ]
+    ],
+    'canvas-subcanvas-glyph': [
+        { direction: 'right', targets: ALL_GLYPH_CLASSES },
+        { direction: 'bottom', targets: ALL_GLYPH_CLASSES },
+        { direction: 'top', targets: ALL_GLYPH_CLASSES },
+    ],
 } as const;
 
 // Cached class lists — derived from static MELDABILITY registry

--- a/web/ts/components/glyph/subcanvas-glyph.ts
+++ b/web/ts/components/glyph/subcanvas-glyph.ts
@@ -53,11 +53,25 @@ export function createSubcanvasGlyph(glyph: Glyph): HTMLElement {
         const parentCanvas = contentLayer?.closest('.canvas-workspace') as HTMLElement | null;
         const canvasId = parentCanvas?.dataset?.canvasId ?? 'canvas-workspace';
 
+        // If melded, insert ghost placeholder to hold the grid cell
+        const composition = element.closest('.melded-composition') as HTMLElement | null;
+        let ghost: HTMLElement | null = null;
+        if (composition) {
+            ghost = document.createElement('div');
+            ghost.className = 'subcanvas-ghost';
+            ghost.style.gridRow = element.style.gridRow;
+            ghost.style.gridColumn = element.style.gridColumn;
+            ghost.style.width = element.offsetWidth + 'px';
+            ghost.style.height = element.offsetHeight + 'px';
+            element.parentNode!.insertBefore(ghost, element);
+            log.debug(SEG.GLYPH, `[Subcanvas] Ghost inserted for ${glyph.id} at grid(${element.style.gridRow}, ${element.style.gridColumn})`);
+        }
+
         morphCanvasPlacedToFullscreen(
             element,
             glyph,
             canvasId,
-            (el, g) => restoreToCanvas(el, g, contentLayer as HTMLElement)
+            (el, g) => restoreToCanvas(el, g, contentLayer as HTMLElement, ghost, composition)
         );
     });
 
@@ -134,7 +148,9 @@ function wireEditableLabel(titleBar: HTMLElement, glyph: Glyph): void {
 function restoreToCanvas(
     element: HTMLElement,
     glyph: Glyph,
-    contentLayer: HTMLElement | null
+    contentLayer: HTMLElement | null,
+    ghost: HTMLElement | null,
+    composition: HTMLElement | null
 ): void {
     if (!contentLayer) {
         log.error(SEG.GLYPH, `[Subcanvas] Cannot restore ${glyph.id} — no content layer`);
@@ -169,9 +185,19 @@ function restoreToCanvas(
     preview.className = 'subcanvas-preview';
     element.appendChild(preview);
 
-    // Reparent to canvas content layer — dblclick handler from createSubcanvasGlyph
-    // persists on the element (it uses closest() at dispatch time, no re-registration needed)
-    contentLayer.appendChild(element);
+    // Replace ghost with real element in the composition, or reparent to content layer
+    if (ghost && composition && ghost.parentNode) {
+        // Restore grid positioning — canvasPlaced sets absolute left/top which fights CSS grid
+        element.style.position = 'relative';
+        element.style.left = '';
+        element.style.top = '';
+        element.style.gridRow = ghost.style.gridRow;
+        element.style.gridColumn = ghost.style.gridColumn;
+        ghost.parentNode.replaceChild(element, ghost);
+        log.debug(SEG.GLYPH, `[Subcanvas] Replaced ghost for ${glyph.id}, back in composition at grid(${element.style.gridRow}, ${element.style.gridColumn})`);
+    } else {
+        contentLayer.appendChild(element);
+    }
 
     log.debug(SEG.GLYPH, `[Subcanvas] Restored ${glyph.id} to canvas at (${glyph.x}, ${glyph.y})`);
 }


### PR DESCRIPTION
Re-land of #517 (reverted in #526 due to merge timing).

## Summary
- Subcanvas glyphs participate in the meld grid as universal connectors — accept and initiate meld from any direction and any glyph type
- Ghost placeholder holds grid cell when melded subcanvas expands to fullscreen, replaced on minimize
- Grid position correctly restored on minimize
- Result glyph doc updated for result→result chaining
- Subcanvas doc added with status & roadmap (DAG-in-DAG vision)
- Typegen fix: Go's `any` alias no longer emitted literally into Rust

## Test plan
- [x] `make test` — 655 pass, 0 fail
- [x] Meld formation: drag py/note/ax/se/prompt near subcanvas → composition forms
- [x] Expand melded subcanvas → fullscreen with ghost holding grid cell
- [x] Minimize → element returns to composition, ghost removed
- [x] Non-melded expand → no ghost