### PR TITLE
WIP: Attestation + embedding replication to browser

### DIFF
--- a/crates/qntx-core/src/lib.rs
+++ b/crates/qntx-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod classify;
 pub mod expand;
 pub mod fuzzy;
 pub mod parser;
+pub mod similarity;
 pub mod storage;
 pub mod sync;
 

--- a/crates/qntx-core/src/similarity.rs
+++ b/crates/qntx-core/src/similarity.rs
@@ -1,0 +1,46 @@
+/// Cosine similarity between two vectors: dot(a,b) / (||a|| × ||b||).
+/// Returns 0.0 if either vector has zero magnitude.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0f32;
+    let mut norm_a = 0.0f32;
+    let mut norm_b = 0.0f32;
+
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_vectors() {
+        let v = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&v, &v);
+        assert!((sim - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn orthogonal_vectors() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn zero_vector() {
+        let a = vec![1.0, 2.0];
+        let b = vec![0.0, 0.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+}

--- a/crates/qntx-wasm/src/browser.rs
+++ b/crates/qntx-wasm/src/browser.rs
@@ -371,6 +371,30 @@ pub fn sync_merkle_find_group_key(input: &str) -> String {
 }
 
 // ============================================================================
+// Similarity
+// ============================================================================
+
+/// Compute cosine similarity between two embedding vectors.
+/// Input: `{"a":[f32,...], "b":[f32,...]}`
+/// Returns: `{"similarity": f32}` or `{"error":"..."}`
+#[wasm_bindgen]
+pub fn semantic_similarity(input: &str) -> String {
+    #[derive(serde::Deserialize)]
+    struct Input {
+        a: Vec<f32>,
+        b: Vec<f32>,
+    }
+
+    let parsed: Input = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
+    };
+
+    let sim = qntx_core::similarity::cosine_similarity(&parsed.a, &parsed.b);
+    format!(r#"{{"similarity":{}}}"#, sim)
+}
+
+// ============================================================================
 // Utilities
 // ============================================================================
 

--- a/server/browser_sync.go
+++ b/server/browser_sync.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/teranos/QNTX/ats"
+	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/types"
+)
+
+// browserSyncBatchSize is how many attestations to send per WebSocket message.
+const browserSyncBatchSize = 200
+
+// handleBrowserSyncHello compares the browser's Merkle root with the server's,
+// and streams missing attestations (with embeddings) to the browser in batches.
+// Runs in a goroutine to avoid blocking the read pump.
+func (c *Client) handleBrowserSyncHello(syncRoot string) {
+	c.server.wg.Add(1)
+	go func() {
+		defer c.server.wg.Done()
+
+		if c.server.syncTree == nil {
+			c.sendJSON(BrowserSyncDoneMessage{
+				Type:      "browser_sync_done",
+				Message:   "sync tree unavailable",
+				Timestamp: time.Now().Unix(),
+			})
+			return
+		}
+
+		serverRoot, err := c.server.syncTree.Root()
+		if err != nil {
+			c.server.logger.Warnw("Browser sync: failed to get server root",
+				"client_id", c.id, "error", err)
+			c.sendJSON(BrowserSyncDoneMessage{
+				Type:      "browser_sync_done",
+				Message:   "failed to read server Merkle root",
+				Timestamp: time.Now().Unix(),
+			})
+			return
+		}
+
+		// Roots match — nothing to sync
+		if syncRoot == serverRoot {
+			c.sendJSON(BrowserSyncDoneMessage{
+				Type:      "browser_sync_done",
+				Message:   "roots match",
+				Timestamp: time.Now().Unix(),
+			})
+			c.server.logger.Debugw("Browser sync: roots match, nothing to send",
+				"client_id", c.id, "root", serverRoot[:12])
+			return
+		}
+
+		// Get server group hashes and diff against browser
+		serverGroups, err := c.server.syncTree.GroupHashes()
+		if err != nil {
+			c.server.logger.Warnw("Browser sync: failed to get group hashes",
+				"client_id", c.id, "error", err)
+			return
+		}
+
+		// Browser sends empty root — it has nothing, so all server groups are "remote_only" from browser's perspective
+		// We treat the browser as having no groups (empty map), so server groups = remote_only
+		browserGroups := make(map[string]string) // browser has nothing beyond its root
+		_, remoteOnly, divergent, err := c.server.syncTree.Diff(browserGroups)
+		if err != nil {
+			c.server.logger.Warnw("Browser sync: diff failed",
+				"client_id", c.id, "error", err)
+			return
+		}
+
+		// Groups the browser needs = all server groups (since browser sent only root, not group hashes)
+		// In practice the browser has an empty tree or a subset — send everything the server has.
+		missingGroups := append(remoteOnly, divergent...)
+		if len(missingGroups) == 0 {
+			// If diff returns nothing (browser root differs but no groups differ),
+			// send all server groups
+			missingGroups = make([]string, 0, len(serverGroups))
+			for gkh := range serverGroups {
+				missingGroups = append(missingGroups, gkh)
+			}
+		}
+
+		c.server.logger.Infow("Browser sync: starting",
+			"client_id", c.id,
+			"missing_groups", len(missingGroups),
+			"server_root", serverRoot[:12],
+			"browser_root", truncateHash(syncRoot))
+
+		if err := c.streamAttestationsForGroups(missingGroups); err != nil {
+			c.server.logger.Warnw("Browser sync: streaming failed",
+				"client_id", c.id, "error", err)
+		}
+	}()
+}
+
+// streamAttestationsForGroups resolves group key hashes to (actor, context),
+// queries attestations, looks up embeddings, and sends in batches.
+func (c *Client) streamAttestationsForGroups(groupKeyHashes []string) error {
+	var batch []interface{}
+	var batchEmbeddings []BrowserSyncEmbedding
+	var batchSourceIDs []string
+	totalSent := 0
+	totalAtts := 0
+
+	// First pass: count total attestations for progress reporting
+	for _, gkh := range groupKeyHashes {
+		actor, ctx, err := c.server.syncTree.FindGroupKey(gkh)
+		if err != nil {
+			continue
+		}
+		atts, err := storage.GetAttestations(c.server.db, ats.AttestationFilter{
+			Actors:   []string{actor},
+			Contexts: []string{ctx},
+		})
+		if err != nil {
+			continue
+		}
+		totalAtts += len(atts)
+	}
+
+	// Second pass: stream attestations in batches
+	for _, gkh := range groupKeyHashes {
+		actor, ctx, err := c.server.syncTree.FindGroupKey(gkh)
+		if err != nil {
+			continue
+		}
+
+		atts, err := storage.GetAttestations(c.server.db, ats.AttestationFilter{
+			Actors:   []string{actor},
+			Contexts: []string{ctx},
+		})
+		if err != nil {
+			c.server.logger.Debugw("Browser sync: query failed for group",
+				"actor", actor, "context", ctx, "error", err)
+			continue
+		}
+
+		for _, att := range atts {
+			protoAtt := toProtoMap(att)
+			batch = append(batch, protoAtt)
+			batchSourceIDs = append(batchSourceIDs, att.ID)
+
+			if len(batch) >= browserSyncBatchSize {
+				embs := c.lookupEmbeddings(batchSourceIDs)
+				totalSent += len(batch)
+				c.sendSyncBatch(batch, embs, totalSent, totalAtts, false)
+				batch = batch[:0]
+				batchEmbeddings = batchEmbeddings[:0]
+				batchSourceIDs = batchSourceIDs[:0]
+			}
+		}
+	}
+
+	// Final batch (with done=true)
+	if len(batch) > 0 {
+		embs := c.lookupEmbeddings(batchSourceIDs)
+		totalSent += len(batch)
+		c.sendSyncBatch(batch, embs, totalSent, totalAtts, true)
+	} else {
+		// No remaining items but still need to signal done
+		c.sendSyncBatch(nil, nil, totalSent, totalAtts, true)
+	}
+
+	c.server.logger.Infow("Browser sync: complete",
+		"client_id", c.id,
+		"attestations_sent", totalSent)
+
+	return nil
+}
+
+// lookupEmbeddings fetches embeddings for a slice of attestation IDs.
+func (c *Client) lookupEmbeddings(sourceIDs []string) []BrowserSyncEmbedding {
+	if c.server.embeddingStore == nil || c.server.embeddingService == nil || len(sourceIDs) == 0 {
+		return nil
+	}
+
+	embMap, err := c.server.embeddingStore.GetBySourceIDs("attestation", sourceIDs)
+	if err != nil {
+		c.server.logger.Debugw("Browser sync: embedding lookup failed", "error", err)
+		return nil
+	}
+
+	result := make([]BrowserSyncEmbedding, 0, len(embMap))
+	for sourceID, emb := range embMap {
+		vec, err := c.server.embeddingService.DeserializeEmbedding(emb.Embedding)
+		if err != nil {
+			continue
+		}
+		result = append(result, BrowserSyncEmbedding{
+			AttestationID: sourceID,
+			Vector:        vec,
+			Model:         emb.Model,
+		})
+	}
+	return result
+}
+
+// sendSyncBatch sends a BrowserSyncAttestationsMessage to the client.
+func (c *Client) sendSyncBatch(attestations []interface{}, embeddings []BrowserSyncEmbedding, stored, total int, done bool) {
+	if attestations == nil {
+		attestations = make([]interface{}, 0)
+	}
+	if embeddings == nil {
+		embeddings = make([]BrowserSyncEmbedding, 0)
+	}
+	c.sendJSON(BrowserSyncAttestationsMessage{
+		Type:         "browser_sync_attestations",
+		Attestations: attestations,
+		Embeddings:   embeddings,
+		Done:         done,
+		Stored:       stored,
+		Total:        total,
+		Timestamp:    time.Now().Unix(),
+	})
+}
+
+// toProtoMap converts a types.As to a map matching proto Attestation JSON format.
+// Timestamps become Unix millis (i64), attributes become a JSON string.
+func toProtoMap(att *types.As) map[string]interface{} {
+	m := map[string]interface{}{
+		"id":         att.ID,
+		"subjects":   att.Subjects,
+		"predicates": att.Predicates,
+		"contexts":   att.Contexts,
+		"actors":     att.Actors,
+		"timestamp":  att.Timestamp.UnixMilli(),
+		"source":     att.Source,
+		"created_at": att.CreatedAt.UnixMilli(),
+	}
+	if att.Attributes != nil {
+		attrJSON, err := json.Marshal(att.Attributes)
+		if err == nil {
+			m["attributes"] = string(attrJSON)
+		}
+	}
+	return m
+}
+
+// sendQueryEmbeddingToBrowser generates an embedding for the SE query and sends it
+// to the browser for offline semantic search. Runs in a goroutine; no-op if embedding
+// service is unavailable.
+func (c *Client) sendQueryEmbeddingToBrowser(watcherID, query string) {
+	if c.server.embeddingService == nil {
+		return
+	}
+	c.server.wg.Add(1)
+	go func() {
+		defer c.server.wg.Done()
+		result, err := c.server.embeddingService.GenerateEmbedding(query)
+		if err != nil {
+			c.server.logger.Debugw("Failed to generate SE query embedding for browser",
+				"watcher_id", watcherID, "error", err)
+			return
+		}
+		c.sendJSON(SEQueryEmbeddingMessage{
+			Type:      "se_query_embedding",
+			WatcherID: watcherID,
+			Embedding: result.Embedding,
+			Timestamp: time.Now().Unix(),
+		})
+	}()
+}
+
+// truncateHash returns first 12 chars of a hash for logging, or the full string if shorter.
+func truncateHash(h string) string {
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}
+

--- a/server/types.go
+++ b/server/types.go
@@ -59,7 +59,7 @@ type cachedUsageStats struct {
 
 // QueryMessage represents a client message
 type QueryMessage struct {
-	Type          string  `json:"type"`           // "query", "clear", "ping", "set_verbosity", "set_graph_limit", "upload", "daemon_control", "pulse_config_update", "job_control", "visibility", "vidstream_init", "vidstream_frame", "rich_search"
+	Type          string  `json:"type"`           // "query", "clear", "ping", "set_verbosity", "set_graph_limit", "upload", "daemon_control", "pulse_config_update", "job_control", "visibility", "vidstream_init", "vidstream_frame", "rich_search", "browser_sync_hello"
 	Query         string  `json:"query"`          // The Ax query text (can be multi-line)
 	Line          int     `json:"line"`           // Current line number (for multi-line support)
 	Cursor        int     `json:"cursor"`         // Cursor position
@@ -91,6 +91,8 @@ type QueryMessage struct {
 	SemanticQuery     string  `json:"semantic_query"`      // For watcher_upsert: Natural language query for semantic matching
 	SemanticThreshold float32 `json:"semantic_threshold"`  // For watcher_upsert: Minimum similarity score (0-1)
 	SemanticClusterID *int    `json:"semantic_cluster_id"` // For watcher_upsert: Cluster scope (nil = all clusters)
+	// Browser sync fields (for browser_sync_hello messages)
+	SyncRoot string `json:"sync_root,omitempty"` // Browser Merkle root for incremental sync
 }
 
 // ProgressMessage represents an import progress message
@@ -269,4 +271,37 @@ type WatcherErrorMessage struct {
 	Details   []string `json:"details,omitempty"` // Structured error context from errors.GetAllDetails()
 	Severity  string   `json:"severity"`          // "error" or "warning"
 	Timestamp int64    `json:"timestamp"`         // Unix timestamp
+}
+
+// BrowserSyncAttestationsMessage sends a batch of attestations + embeddings to the browser
+type BrowserSyncAttestationsMessage struct {
+	Type         string                    `json:"type"`         // "browser_sync_attestations"
+	Attestations []interface{}             `json:"attestations"` // Proto-format attestations
+	Embeddings   []BrowserSyncEmbedding    `json:"embeddings"`   // Embeddings for the batch
+	Done         bool                      `json:"done"`         // True on final batch
+	Stored       int                       `json:"stored"`       // Running total of attestations sent
+	Total        int                       `json:"total"`        // Total attestations to sync
+	Timestamp    int64                     `json:"timestamp"`
+}
+
+// BrowserSyncEmbedding is a single embedding sent to the browser during sync
+type BrowserSyncEmbedding struct {
+	AttestationID string    `json:"attestation_id"`
+	Vector        []float32 `json:"vector"`
+	Model         string    `json:"model"`
+}
+
+// BrowserSyncDoneMessage indicates the browser is already in sync
+type BrowserSyncDoneMessage struct {
+	Type      string `json:"type"`      // "browser_sync_done"
+	Message   string `json:"message"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// SEQueryEmbeddingMessage sends the query embedding for an SE watcher to the browser
+type SEQueryEmbeddingMessage struct {
+	Type      string    `json:"type"`       // "se_query_embedding"
+	WatcherID string    `json:"watcher_id"`
+	Embedding []float32 `json:"embedding"`
+	Timestamp int64     `json:"timestamp"`
 }

--- a/web/ts/browser-sync.ts
+++ b/web/ts/browser-sync.ts
@@ -1,0 +1,277 @@
+/**
+ * Browser sync — replicates server attestations + embeddings to IndexedDB.
+ *
+ * On WebSocket connect:
+ * 1. Rebuild in-memory Merkle tree from existing IndexedDB attestations
+ * 2. Send browser_sync_hello with current Merkle root
+ * 3. Server streams missing attestations + embeddings in batches
+ * 4. Browser stores attestations in IndexedDB and embeddings in a separate store
+ */
+
+import { sendMessage } from './websocket';
+import { log, SEG } from './logger';
+import {
+    putAttestation,
+    syncMerkleRoot,
+    syncMerkleInsert,
+    syncContentHash,
+    listAttestationIds,
+    getAttestation,
+    initialize as initWasm,
+} from './qntx-wasm';
+import type { Attestation } from './generated/proto/plugin/grpc/protocol/atsstore';
+import type {
+    BrowserSyncAttestationsMessage,
+    BrowserSyncDoneMessage,
+    BrowserSyncEmbedding,
+} from '../types/websocket';
+
+// ============================================================================
+// Embedding IndexedDB Store
+// ============================================================================
+
+const EMBEDDING_DB_NAME = 'qntx-embeddings';
+const EMBEDDING_DB_VERSION = 2;
+const EMBEDDING_STORE_NAME = 'vectors';
+const QUERY_EMBEDDING_STORE_NAME = 'query_embeddings';
+
+/** Stored embedding record */
+export interface StoredEmbedding {
+    attestation_id: string;
+    vector: number[];
+    model: string;
+}
+
+/** Stored query embedding (for offline SE search) */
+export interface StoredQueryEmbedding {
+    watcher_id: string;
+    vector: number[];
+}
+
+/** Open (or create) the embeddings IndexedDB */
+function openEmbeddingDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(EMBEDDING_DB_NAME, EMBEDDING_DB_VERSION);
+
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(EMBEDDING_STORE_NAME)) {
+                db.createObjectStore(EMBEDDING_STORE_NAME, { keyPath: 'attestation_id' });
+            }
+            if (!db.objectStoreNames.contains(QUERY_EMBEDDING_STORE_NAME)) {
+                db.createObjectStore(QUERY_EMBEDDING_STORE_NAME, { keyPath: 'watcher_id' });
+            }
+        };
+
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/** Store a batch of embeddings in IndexedDB */
+async function storeEmbeddings(embeddings: BrowserSyncEmbedding[]): Promise<void> {
+    if (embeddings.length === 0) return;
+
+    const db = await openEmbeddingDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(EMBEDDING_STORE_NAME, 'readwrite');
+        const store = tx.objectStore(EMBEDDING_STORE_NAME);
+
+        for (const emb of embeddings) {
+            store.put({
+                attestation_id: emb.attestation_id,
+                vector: emb.vector,
+                model: emb.model,
+            } satisfies StoredEmbedding);
+        }
+
+        tx.oncomplete = () => { db.close(); resolve(); };
+        tx.onerror = () => { db.close(); reject(tx.error); };
+    });
+}
+
+/** Get a single embedding by attestation ID */
+export async function getEmbedding(attestationId: string): Promise<StoredEmbedding | null> {
+    const db = await openEmbeddingDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(EMBEDDING_STORE_NAME, 'readonly');
+        const store = tx.objectStore(EMBEDDING_STORE_NAME);
+        const request = store.get(attestationId);
+
+        request.onsuccess = () => { db.close(); resolve(request.result ?? null); };
+        request.onerror = () => { db.close(); reject(request.error); };
+    });
+}
+
+/** Get all stored embeddings (for local semantic search) */
+export async function getAllEmbeddings(): Promise<StoredEmbedding[]> {
+    const db = await openEmbeddingDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(EMBEDDING_STORE_NAME, 'readonly');
+        const store = tx.objectStore(EMBEDDING_STORE_NAME);
+        const request = store.getAll();
+
+        request.onsuccess = () => { db.close(); resolve(request.result); };
+        request.onerror = () => { db.close(); reject(request.error); };
+    });
+}
+
+/** Store a query embedding for offline SE search */
+export async function storeQueryEmbedding(watcherId: string, vector: number[]): Promise<void> {
+    const db = await openEmbeddingDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(QUERY_EMBEDDING_STORE_NAME, 'readwrite');
+        const store = tx.objectStore(QUERY_EMBEDDING_STORE_NAME);
+        store.put({ watcher_id: watcherId, vector } satisfies StoredQueryEmbedding);
+
+        tx.oncomplete = () => { db.close(); resolve(); };
+        tx.onerror = () => { db.close(); reject(tx.error); };
+    });
+}
+
+/** Get a query embedding by watcher ID */
+export async function getQueryEmbedding(watcherId: string): Promise<number[] | null> {
+    const db = await openEmbeddingDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(QUERY_EMBEDDING_STORE_NAME, 'readonly');
+        const store = tx.objectStore(QUERY_EMBEDDING_STORE_NAME);
+        const request = store.get(watcherId);
+
+        request.onsuccess = () => {
+            db.close();
+            const result = request.result as StoredQueryEmbedding | undefined;
+            resolve(result?.vector ?? null);
+        };
+        request.onerror = () => { db.close(); reject(request.error); };
+    });
+}
+
+// ============================================================================
+// Merkle Tree Rebuild
+// ============================================================================
+
+/**
+ * Rebuild the in-memory Merkle tree from existing IndexedDB attestations.
+ * Must be called before initiateBrowserSync() so the root hash reflects
+ * what the browser already has.
+ */
+export async function rebuildMerkleFromIndexedDB(): Promise<void> {
+    try {
+        await initWasm();
+    } catch (err) {
+        log.warn(SEG.WASM, 'Browser sync: WASM init failed, skipping Merkle rebuild:', err);
+        return;
+    }
+
+    const ids = await listAttestationIds();
+    if (ids.length === 0) {
+        log.debug(SEG.WASM, 'Browser sync: IndexedDB empty, Merkle tree stays empty');
+        return;
+    }
+
+    let inserted = 0;
+    for (const id of ids) {
+        const att = await getAttestation(id);
+        if (!att) continue;
+
+        try {
+            // Strip attributes — content hash doesn't use them, and proto format
+            // (attributes as JSON string) would fail core Attestation deserialization.
+            const { attributes, ...hashableAtt } = att as Record<string, unknown>;
+            const hash = syncContentHash(JSON.stringify(hashableAtt));
+            const actor = (att as any).actors?.[0] || '';
+            const context = (att as any).contexts?.[0] || '';
+            if (actor && context) {
+                syncMerkleInsert(actor, context, hash);
+                inserted++;
+            }
+        } catch (err) {
+            log.debug(SEG.WASM, `Browser sync: failed to hash attestation ${id}:`, err);
+        }
+    }
+
+    const root = syncMerkleRoot();
+    log.info(SEG.WASM, `Browser sync: rebuilt Merkle tree from ${inserted} attestations, root=${root.root.substring(0, 12)}`);
+}
+
+// ============================================================================
+// Sync Protocol
+// ============================================================================
+
+/**
+ * Initiate browser sync — called after WebSocket connects.
+ * Sends the current browser Merkle root to the server.
+ */
+export async function initiateBrowserSync(): Promise<void> {
+    try {
+        await initWasm();
+    } catch (err) {
+        log.warn(SEG.WASM, 'Browser sync: WASM not available, skipping:', err);
+        return;
+    }
+
+    await rebuildMerkleFromIndexedDB();
+
+    const root = syncMerkleRoot();
+    log.info(SEG.WASM, `Browser sync: sent hello (root=${root.root.substring(0, 12)}, size=${root.size})`);
+
+    sendMessage({
+        type: 'browser_sync_hello',
+        sync_root: root.root,
+    });
+}
+
+/**
+ * Handle a batch of attestations + embeddings from the server.
+ */
+export async function handleSyncAttestations(data: BrowserSyncAttestationsMessage): Promise<void> {
+    const attestations = data.attestations as Attestation[];
+
+    // Store attestations in IndexedDB and insert into Merkle tree
+    for (const att of attestations) {
+        try {
+            await putAttestation(att);
+        } catch (err) {
+            log.debug(SEG.WASM, `Browser sync: failed to store attestation:`, err);
+            continue;
+        }
+
+        try {
+            // syncContentHash expects core Attestation format (attributes as object),
+            // but server sends proto format (attributes as JSON string). Strip attributes
+            // since content hash doesn't use them anyway.
+            const { attributes, ...hashableAtt } = att as Record<string, unknown>;
+            const hash = syncContentHash(JSON.stringify(hashableAtt));
+            const actor = (att as any).actors?.[0] || '';
+            const context = (att as any).contexts?.[0] || '';
+            if (actor && context) {
+                syncMerkleInsert(actor, context, hash);
+            }
+        } catch (err) {
+            log.debug(SEG.WASM, `Browser sync: Merkle insert failed:`, err);
+        }
+    }
+
+    // Store embeddings
+    if (data.embeddings.length > 0) {
+        try {
+            await storeEmbeddings(data.embeddings);
+        } catch (err) {
+            log.warn(SEG.WASM, 'Browser sync: failed to store embeddings:', err);
+        }
+    }
+
+    if (data.done) {
+        const root = syncMerkleRoot();
+        log.info(SEG.WASM, `Browser sync complete: stored ${data.stored}/${data.total} attestations, ${data.embeddings.length} embeddings, root=${root.root.substring(0, 12)}`);
+    } else {
+        log.debug(SEG.WASM, `Browser sync: batch ${data.stored}/${data.total}`);
+    }
+}
+
+/**
+ * Handle browser_sync_done — server says roots match.
+ */
+export function handleSyncDone(data: BrowserSyncDoneMessage): void {
+    log.info(SEG.WASM, `Browser sync: ${data.message}`);
+}

--- a/web/ts/local-semantic-search.ts
+++ b/web/ts/local-semantic-search.ts
@@ -1,0 +1,48 @@
+/**
+ * Local semantic search — brute-force cosine similarity over IndexedDB embeddings.
+ *
+ * Used as offline fallback when the server is unreachable. Iterates all stored
+ * embeddings, computes cosine similarity via WASM, and returns top matches.
+ */
+
+import { getAllEmbeddings } from './browser-sync';
+import { semanticSimilarity } from './qntx-wasm';
+
+/** A local search match with attestation ID and similarity score */
+export interface LocalSearchResult {
+    attestation_id: string;
+    similarity: number;
+}
+
+/**
+ * Search local embeddings against a query embedding.
+ *
+ * @param queryEmbedding - The query's embedding vector
+ * @param threshold - Minimum similarity score (0-1)
+ * @param limit - Maximum results to return
+ * @returns Matches sorted by similarity descending
+ */
+export async function localSemanticSearch(
+    queryEmbedding: number[],
+    threshold: number,
+    limit: number,
+): Promise<LocalSearchResult[]> {
+    const embeddings = await getAllEmbeddings();
+    if (embeddings.length === 0) return [];
+
+    const results: LocalSearchResult[] = [];
+
+    for (const emb of embeddings) {
+        const sim = semanticSimilarity(queryEmbedding, emb.vector);
+        if (sim >= threshold) {
+            results.push({
+                attestation_id: emb.attestation_id,
+                similarity: sim,
+            });
+        }
+    }
+
+    // Sort descending by similarity, take top N
+    results.sort((a, b) => b.similarity - a.similarity);
+    return results.slice(0, limit);
+}

--- a/web/ts/qntx-wasm.ts
+++ b/web/ts/qntx-wasm.ts
@@ -234,6 +234,67 @@ export function getFuzzyStatus(): FuzzyStatus {
 }
 
 // ============================================================================
+// Similarity
+// ============================================================================
+
+/**
+ * Compute cosine similarity between two embedding vectors.
+ * Returns a value between -1 and 1 (1 = identical direction).
+ */
+export function semanticSimilarity(a: number[], b: number[]): number {
+    const json = wasm.semantic_similarity(JSON.stringify({ a, b }));
+    const result = JSON.parse(json);
+    if ('error' in result) {
+        throw new Error(result.error);
+    }
+    return result.similarity;
+}
+
+// ============================================================================
+// Sync (Merkle Tree)
+// ============================================================================
+
+/** Merkle tree root info */
+export interface MerkleRootInfo {
+    root: string;
+    size: number;
+    groups: number;
+}
+
+/**
+ * Get the browser Merkle tree root hash and stats.
+ */
+export function syncMerkleRoot(): MerkleRootInfo {
+    return JSON.parse(wasm.sync_merkle_root());
+}
+
+/**
+ * Insert an attestation into the browser Merkle tree.
+ * Input: { actor, context, content_hash }
+ */
+export function syncMerkleInsert(actor: string, context: string, contentHash: string): void {
+    const result = JSON.parse(wasm.sync_merkle_insert(JSON.stringify({
+        actor,
+        context,
+        content_hash: contentHash,
+    })));
+    if (result.error) {
+        throw new Error(result.error);
+    }
+}
+
+/**
+ * Compute content hash for an attestation JSON string.
+ */
+export function syncContentHash(attestationJson: string): string {
+    const result = JSON.parse(wasm.sync_content_hash(attestationJson));
+    if (result.error) {
+        throw new Error(result.error);
+    }
+    return result.hash;
+}
+
+// ============================================================================
 // Utilities
 // ============================================================================
 

--- a/web/types/websocket.ts
+++ b/web/types/websocket.ts
@@ -81,7 +81,10 @@ export type MessageType =
   | 'vidstream_init_success'
   | 'vidstream_init_error'
   | 'vidstream_detections'
-  | 'vidstream_frame_error';
+  | 'vidstream_frame_error'
+  | 'browser_sync_attestations'
+  | 'browser_sync_done'
+  | 'se_query_embedding';
 
 // ============================================================================
 // Base Message Interface
@@ -522,6 +525,45 @@ export interface VidStreamFrameErrorMessage extends BaseMessage {
   error: string;
 }
 
+/**
+ * Browser sync: batch of attestations + embeddings from server
+ */
+export interface BrowserSyncAttestationsMessage extends BaseMessage {
+  type: 'browser_sync_attestations';
+  attestations: Attestation[];
+  embeddings: BrowserSyncEmbedding[];
+  done: boolean;
+  stored: number;
+  total: number;
+}
+
+/**
+ * A single embedding sent during browser sync
+ */
+export interface BrowserSyncEmbedding {
+  attestation_id: string;
+  vector: number[];
+  model: string;
+}
+
+/**
+ * Browser sync: roots match, nothing to sync
+ */
+export interface BrowserSyncDoneMessage extends BaseMessage {
+  type: 'browser_sync_done';
+  message: string;
+}
+
+/**
+ * SE query embedding — sent when server computes embedding for a semantic watcher query.
+ * Cached by the browser for offline local search.
+ */
+export interface SEQueryEmbeddingMessage extends BaseMessage {
+  type: 'se_query_embedding';
+  watcher_id: string;
+  embedding: number[];
+}
+
 // ============================================================================
 // Type Definitions for Parse Components
 // ============================================================================
@@ -618,7 +660,10 @@ export type WebSocketMessage =
   | VidStreamInitSuccessMessage
   | VidStreamInitErrorMessage
   | VidStreamDetectionsMessage
-  | VidStreamFrameErrorMessage;
+  | VidStreamFrameErrorMessage
+  | BrowserSyncAttestationsMessage
+  | BrowserSyncDoneMessage
+  | SEQueryEmbeddingMessage;
 
 // ============================================================================
 // Message Handler Types
@@ -669,6 +714,9 @@ export interface MessageHandlers {
   vidstream_init_error?: MessageHandler<VidStreamInitErrorMessage>;
   vidstream_detections?: MessageHandler<VidStreamDetectionsMessage>;
   vidstream_frame_error?: MessageHandler<VidStreamFrameErrorMessage>;
+  browser_sync_attestations?: MessageHandler<BrowserSyncAttestationsMessage>;
+  browser_sync_done?: MessageHandler<BrowserSyncDoneMessage>;
+  se_query_embedding?: MessageHandler<SEQueryEmbeddingMessage>;
 }
 
 // ============================================================================

--- a/web/wasm/qntx_wasm.d.ts
+++ b/web/wasm/qntx_wasm.d.ts
@@ -101,6 +101,13 @@ export function put_attestation(json: string): Promise<void>;
 export function query_attestations(filter_json: string): Promise<string>;
 
 /**
+ * Compute cosine similarity between two embedding vectors.
+ * Input: `{"a":[f32,...], "b":[f32,...]}`
+ * Returns: `{"similarity": f32}` or `{"error":"..."}`
+ */
+export function semantic_similarity(input: string): string;
+
+/**
  * Compute content hash for an attestation.
  * Input: JSON-serialized Attestation
  * Returns: `{"hash":"<64-char hex>"}` or `{"error":"..."}`
@@ -176,6 +183,7 @@ export interface InitOutput {
     readonly parse_query: (a: number, b: number) => [number, number];
     readonly put_attestation: (a: number, b: number) => any;
     readonly query_attestations: (a: number, b: number) => any;
+    readonly semantic_similarity: (a: number, b: number) => [number, number];
     readonly sync_content_hash: (a: number, b: number) => [number, number];
     readonly sync_merkle_contains: (a: number, b: number) => [number, number];
     readonly sync_merkle_diff: (a: number, b: number) => [number, number];

--- a/web/wasm/qntx_wasm.js
+++ b/web/wasm/qntx_wasm.js
@@ -222,6 +222,28 @@ export function query_attestations(filter_json) {
 }
 
 /**
+ * Compute cosine similarity between two embedding vectors.
+ * Input: `{"a":[f32,...], "b":[f32,...]}`
+ * Returns: `{"similarity": f32}` or `{"error":"..."}`
+ * @param {string} input
+ * @returns {string}
+ */
+export function semantic_similarity(input) {
+    let deferred2_0;
+    let deferred2_1;
+    try {
+        const ptr0 = passStringToWasm0(input, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.semantic_similarity(ptr0, len0);
+        deferred2_0 = ret[0];
+        deferred2_1 = ret[1];
+        return getStringFromWasm0(ret[0], ret[1]);
+    } finally {
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1);
+    }
+}
+
+/**
  * Compute content hash for an attestation.
  * Input: JSON-serialized Attestation
  * Returns: `{"hash":"<64-char hex>"}` or `{"error":"..."}`
@@ -677,17 +699,17 @@ function __wbg_get_imports() {
             return ret;
         }, arguments); },
         __wbindgen_cast_0000000000000001: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 111, function: Function { arguments: [Externref], shim_idx: 112, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 114, function: Function { arguments: [Externref], shim_idx: 115, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h622d11ff1c80a730, wasm_bindgen__convert__closures_____invoke__ha99d37861838e4ea);
             return ret;
         },
         __wbindgen_cast_0000000000000002: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 92, function: Function { arguments: [NamedExternref("Event")], shim_idx: 93, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 95, function: Function { arguments: [NamedExternref("Event")], shim_idx: 96, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h63454322f75c3832, wasm_bindgen__convert__closures_____invoke__h857fdb0c9bdea0c8);
             return ret;
         },
         __wbindgen_cast_0000000000000003: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 92, function: Function { arguments: [NamedExternref("IDBVersionChangeEvent")], shim_idx: 93, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 95, function: Function { arguments: [NamedExternref("IDBVersionChangeEvent")], shim_idx: 96, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h63454322f75c3832, wasm_bindgen__convert__closures_____invoke__h857fdb0c9bdea0c8);
             return ret;
         },

--- a/web/wasm/qntx_wasm_bg.wasm.d.ts
+++ b/web/wasm/qntx_wasm_bg.wasm.d.ts
@@ -14,6 +14,7 @@ export const list_attestation_ids: () => any;
 export const parse_query: (a: number, b: number) => [number, number];
 export const put_attestation: (a: number, b: number) => any;
 export const query_attestations: (a: number, b: number) => any;
+export const semantic_similarity: (a: number, b: number) => [number, number];
 export const sync_content_hash: (a: number, b: number) => [number, number];
 export const sync_merkle_contains: (a: number, b: number) => [number, number];
 export const sync_merkle_diff: (a: number, b: number) => [number, number];


### PR DESCRIPTION
## Summary
- Server streams attestations + embeddings to browser via Merkle-diffed WebSocket sync
- WASM cosine similarity enables offline SE glyph search against local IndexedDB corpus
- Query embeddings persisted to IndexedDB for offline fallback across page reloads

## Open
- Merkle root still zeros after sync (proto vs core attributes format — fix in progress)
- Offline SE fallback needs manual verification
- `make wasm` rebuild needed for similarity function

## Test plan
- [ ] `make test` passes (669 TS, Go, 116 Rust)
- [ ] Browser sync populates IndexedDB on connect
- [ ] SE glyph shows results offline with cached query embedding
- [ ] Incremental sync sends only missing attestations on reconnect