### PR TITLE
Add attrs package for typed attestation attribute access

### DIFF
--- a/ats/attrs/attrs.go
+++ b/ats/attrs/attrs.go
@@ -1,0 +1,181 @@
+// Package attrs provides typed access to attestation attributes.
+//
+// Attestation attributes are stored as map[string]interface{} (JSON).
+// This package bridges between the schemaless bag and typed Go structs
+// using struct tags.
+//
+// Usage:
+//
+//	type PromptAttrs struct {
+//	    Template string `attr:"template"`
+//	    Version  int    `attr:"version"`
+//	    Model    string `attr:"model,omitempty"`
+//	}
+//
+//	// Read: map → struct
+//	var p PromptAttrs
+//	attrs.Scan(as.Attributes, &p)
+//
+//	// Write: struct → map
+//	as.Attributes = attrs.From(p)
+package attrs
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Scan reads values from a map[string]interface{} into a struct using `attr` tags.
+// Fields without a matching key are left at their zero value.
+// Handles JSON number coercion (float64 → int).
+func Scan(m map[string]any, dst any) {
+	if m == nil {
+		return
+	}
+
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return
+	}
+
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		key := tagKey(field)
+		if key == "" {
+			continue
+		}
+
+		val, ok := m[key]
+		if !ok || val == nil {
+			continue
+		}
+
+		setField(v.Field(i), val)
+	}
+}
+
+// From converts a struct into map[string]interface{} using `attr` tags.
+// Fields tagged with "omitempty" are skipped when at their zero value.
+func From(src any) map[string]any {
+	v := reflect.ValueOf(src)
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+
+	t := v.Type()
+	m := make(map[string]any)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("attr")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		key, omitempty := parseTag(tag)
+		fv := v.Field(i)
+
+		if omitempty && fv.IsZero() {
+			continue
+		}
+
+		// Dereference pointers for clean map values
+		if fv.Kind() == reflect.Pointer {
+			if fv.IsNil() {
+				continue
+			}
+			fv = fv.Elem()
+		}
+
+		m[key] = fv.Interface()
+	}
+
+	return m
+}
+
+func tagKey(f reflect.StructField) string {
+	tag := f.Tag.Get("attr")
+	if tag == "" || tag == "-" {
+		return ""
+	}
+	key, _ := parseTag(tag)
+	return key
+}
+
+func parseTag(tag string) (key string, omitempty bool) {
+	parts := strings.SplitN(tag, ",", 2)
+	key = parts[0]
+	if len(parts) > 1 && parts[1] == "omitempty" {
+		omitempty = true
+	}
+	return
+}
+
+func setField(fv reflect.Value, val any) {
+	switch fv.Kind() {
+	case reflect.String:
+		if s, ok := val.(string); ok {
+			fv.SetString(s)
+		}
+
+	case reflect.Int, reflect.Int64:
+		switch n := val.(type) {
+		case float64:
+			fv.SetInt(int64(n))
+		case int:
+			fv.SetInt(int64(n))
+		case int64:
+			fv.SetInt(n)
+		}
+
+	case reflect.Float64:
+		if n, ok := val.(float64); ok {
+			fv.SetFloat(n)
+		}
+
+	case reflect.Bool:
+		if b, ok := val.(bool); ok {
+			fv.SetBool(b)
+		}
+
+	case reflect.Slice:
+		if fv.Type().Elem().Kind() == reflect.String {
+			switch items := val.(type) {
+			case []string:
+				fv.Set(reflect.ValueOf(items))
+			case []any:
+				strs := make([]string, 0, len(items))
+				for _, item := range items {
+					if s, ok := item.(string); ok {
+						strs = append(strs, s)
+					}
+				}
+				fv.Set(reflect.ValueOf(strs))
+			}
+		}
+
+	case reflect.Pointer:
+		// *float64, *bool, etc.
+		if fv.Type().Elem().Kind() == reflect.Float64 {
+			if n, ok := val.(float64); ok {
+				fv.Set(reflect.ValueOf(&n))
+			}
+		}
+		if fv.Type().Elem().Kind() == reflect.Bool {
+			if b, ok := val.(bool); ok {
+				fv.Set(reflect.ValueOf(&b))
+			}
+		}
+	}
+}

--- a/ats/attrs/attrs_test.go
+++ b/ats/attrs/attrs_test.go
@@ -1,0 +1,221 @@
+package attrs
+
+import (
+	"testing"
+)
+
+type promptAttrs struct {
+	Template     string `attr:"template"`
+	Version      int    `attr:"version"`
+	SystemPrompt string `attr:"system_prompt,omitempty"`
+	Model        string `attr:"model,omitempty"`
+}
+
+func TestScanBasic(t *testing.T) {
+	m := map[string]any{
+		"template": "Hello {{name}}",
+		"version":  float64(3), // JSON numbers are float64
+		"model":    "gpt-4",
+	}
+
+	var p promptAttrs
+	Scan(m, &p)
+
+	if p.Template != "Hello {{name}}" {
+		t.Errorf("Template = %q, want %q", p.Template, "Hello {{name}}")
+	}
+	if p.Version != 3 {
+		t.Errorf("Version = %d, want 3", p.Version)
+	}
+	if p.Model != "gpt-4" {
+		t.Errorf("Model = %q, want %q", p.Model, "gpt-4")
+	}
+	if p.SystemPrompt != "" {
+		t.Errorf("SystemPrompt = %q, want empty", p.SystemPrompt)
+	}
+}
+
+func TestScanNilMap(t *testing.T) {
+	var p promptAttrs
+	Scan(nil, &p) // should not panic
+	if p.Template != "" {
+		t.Errorf("expected zero value")
+	}
+}
+
+func TestFromBasic(t *testing.T) {
+	p := promptAttrs{
+		Template: "Hello",
+		Version:  2,
+		Model:    "gpt-4",
+	}
+
+	m := From(p)
+
+	if m["template"] != "Hello" {
+		t.Errorf("template = %v, want Hello", m["template"])
+	}
+	if m["version"] != 2 {
+		t.Errorf("version = %v, want 2", m["version"])
+	}
+	if m["model"] != "gpt-4" {
+		t.Errorf("model = %v, want gpt-4", m["model"])
+	}
+}
+
+func TestFromOmitempty(t *testing.T) {
+	p := promptAttrs{
+		Template: "Hello",
+		Version:  1,
+		// SystemPrompt and Model are zero → omitempty
+	}
+
+	m := From(p)
+
+	if _, ok := m["system_prompt"]; ok {
+		t.Error("system_prompt should be omitted when empty")
+	}
+	if _, ok := m["model"]; ok {
+		t.Error("model should be omitted when empty")
+	}
+	// template and version are NOT omitempty, so version=1 is included
+	if m["version"] != 1 {
+		t.Errorf("version = %v, want 1", m["version"])
+	}
+}
+
+type typeDefAttrs struct {
+	Color            string   `attr:"display_color"`
+	Label            string   `attr:"display_label"`
+	Deprecated       bool     `attr:"deprecated"`
+	Opacity          float64  `attr:"opacity"`
+	RichStringFields []string `attr:"rich_string_fields,omitempty"`
+	ArrayFields      []string `attr:"array_fields,omitempty"`
+}
+
+func TestScanSlice(t *testing.T) {
+	m := map[string]any{
+		"display_color":      "#3498db",
+		"display_label":      "Commit",
+		"deprecated":         false,
+		"opacity":            0.8,
+		"rich_string_fields": []any{"notes", "description"},
+	}
+
+	var td typeDefAttrs
+	Scan(m, &td)
+
+	if td.Color != "#3498db" {
+		t.Errorf("Color = %q", td.Color)
+	}
+	if td.Opacity != 0.8 {
+		t.Errorf("Opacity = %f", td.Opacity)
+	}
+	if len(td.RichStringFields) != 2 || td.RichStringFields[0] != "notes" {
+		t.Errorf("RichStringFields = %v", td.RichStringFields)
+	}
+	if td.ArrayFields != nil {
+		t.Errorf("ArrayFields should be nil, got %v", td.ArrayFields)
+	}
+}
+
+func TestScanStringSlice(t *testing.T) {
+	// When attributes come from Go code (not JSON), slices are already []string
+	m := map[string]any{
+		"rich_string_fields": []string{"content", "summary"},
+	}
+
+	var td typeDefAttrs
+	Scan(m, &td)
+
+	if len(td.RichStringFields) != 2 || td.RichStringFields[0] != "content" {
+		t.Errorf("RichStringFields = %v", td.RichStringFields)
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	original := promptAttrs{
+		Template:     "Hello {{name}}",
+		Version:      5,
+		SystemPrompt: "Be helpful",
+		Model:        "claude",
+	}
+
+	m := From(original)
+	var back promptAttrs
+	Scan(m, &back)
+
+	if back != original {
+		t.Errorf("roundtrip failed: got %+v, want %+v", back, original)
+	}
+}
+
+type ptrAttrs struct {
+	Opacity *float64 `attr:"opacity,omitempty"`
+}
+
+func TestScanPointerFloat(t *testing.T) {
+	m := map[string]any{
+		"opacity": 0.5,
+	}
+
+	var p ptrAttrs
+	Scan(m, &p)
+
+	if p.Opacity == nil || *p.Opacity != 0.5 {
+		t.Errorf("Opacity = %v, want 0.5", p.Opacity)
+	}
+}
+
+func TestScanPointerMissing(t *testing.T) {
+	m := map[string]any{}
+
+	var p ptrAttrs
+	Scan(m, &p)
+
+	if p.Opacity != nil {
+		t.Errorf("Opacity should be nil, got %v", *p.Opacity)
+	}
+}
+
+func TestFromDereferencesPointers(t *testing.T) {
+	opacity := 0.5
+	p := ptrAttrs{Opacity: &opacity}
+
+	m := From(p)
+
+	// Value should be float64, not *float64
+	v, ok := m["opacity"].(float64)
+	if !ok {
+		t.Fatalf("opacity should be float64, got %T", m["opacity"])
+	}
+	if v != 0.5 {
+		t.Errorf("opacity = %f, want 0.5", v)
+	}
+}
+
+func TestFromSkipsNilPointers(t *testing.T) {
+	p := ptrAttrs{Opacity: nil}
+
+	m := From(p)
+
+	if _, ok := m["opacity"]; ok {
+		t.Error("nil pointer should not appear in map")
+	}
+}
+
+func TestFromSkipsUntaggedFields(t *testing.T) {
+	type mixed struct {
+		Tagged   string `attr:"tagged"`
+		Untagged string
+	}
+
+	m := From(mixed{Tagged: "yes", Untagged: "no"})
+
+	if m["tagged"] != "yes" {
+		t.Errorf("tagged = %v", m["tagged"])
+	}
+	if _, ok := m["Untagged"]; ok {
+		t.Error("untagged field should not appear in map")
+	}
+}

--- a/ats/so/actions/prompt/handler.go
+++ b/ats/so/actions/prompt/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/teranos/QNTX/am"
 	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/alias"
+	"github.com/teranos/QNTX/ats/attrs"
 	"github.com/teranos/QNTX/ats/ax"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
@@ -22,6 +23,14 @@ import (
 
 // HandlerName is the registered name for the prompt handler
 const HandlerName = "prompt.execute"
+
+// promptResultAttrs defines the attribute schema for prompt result attestations.
+type promptResultAttrs struct {
+	Response      string `attr:"response"`
+	SourceID      string `attr:"source_id"`
+	Template      string `attr:"template"`
+	PromptHandler string `attr:"prompt_handler"`
+}
 
 // Payload represents the job payload for prompt execution
 type Payload struct {
@@ -399,12 +408,12 @@ func (h *Handler) createResultAttestation(
 		Actors:     []string{actor},
 		Timestamp:  now,
 		Source:     "prompt",
-		Attributes: map[string]interface{}{
-			"response":       response,
-			"source_id":      sourceAs.ID,
-			"template":       payload.Template,
-			"prompt_handler": HandlerName,
-		},
+		Attributes: attrs.From(promptResultAttrs{
+			Response:      response,
+			SourceID:      sourceAs.ID,
+			Template:      payload.Template,
+			PromptHandler: HandlerName,
+		}),
 	}
 
 	// Store the attestation

--- a/ats/so/actions/prompt/store.go
+++ b/ats/so/actions/prompt/store.go
@@ -5,25 +5,27 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/teranos/QNTX/ats/attrs"
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
 	id "github.com/teranos/vanity-id"
 )
 
-// StoredPrompt represents a prompt stored as an attestation
+// StoredPrompt represents a prompt stored as an attestation.
+// Fields sourced from attestation attributes carry `attr` tags.
 type StoredPrompt struct {
 	ID           string    `json:"id"`
 	Name         string    `json:"name"`
-	Filename     string    `json:"filename"`        // Source file (used as context)
-	Template     string    `json:"template"`
-	SystemPrompt string    `json:"system_prompt,omitempty"`
-	AxPattern    string    `json:"ax_pattern,omitempty"` // Optional linked ax query
-	Provider     string    `json:"provider,omitempty"`
-	Model        string    `json:"model,omitempty"`
+	Filename     string    `json:"filename"` // Source file (used as context)
+	Template     string    `json:"template" attr:"template"`
+	SystemPrompt string    `json:"system_prompt,omitempty" attr:"system_prompt,omitempty"`
+	AxPattern    string    `json:"ax_pattern,omitempty" attr:"ax_pattern,omitempty"` // Optional linked ax query
+	Provider     string    `json:"provider,omitempty" attr:"provider,omitempty"`
+	Model        string    `json:"model,omitempty" attr:"model,omitempty"`
 	CreatedBy    string    `json:"created_by"`
 	CreatedAt    time.Time `json:"created_at"`
-	Version      int       `json:"version"`
+	Version      int       `json:"version" attr:"version"`
 }
 
 // PromptStore handles prompt persistence as attestations
@@ -80,24 +82,7 @@ func (ps *PromptStore) SavePrompt(ctx context.Context, prompt *StoredPrompt, act
 	}
 
 	now := time.Now()
-
-	// Build attributes
-	attrs := map[string]interface{}{
-		"template": prompt.Template,
-		"version":  version,
-	}
-	if prompt.SystemPrompt != "" {
-		attrs["system_prompt"] = prompt.SystemPrompt
-	}
-	if prompt.AxPattern != "" {
-		attrs["ax_pattern"] = prompt.AxPattern
-	}
-	if prompt.Provider != "" {
-		attrs["provider"] = prompt.Provider
-	}
-	if prompt.Model != "" {
-		attrs["model"] = prompt.Model
-	}
+	prompt.Version = version
 
 	// Create the attestation
 	as := &types.As{
@@ -108,7 +93,7 @@ func (ps *PromptStore) SavePrompt(ctx context.Context, prompt *StoredPrompt, act
 		Actors:     []string{actor},
 		Timestamp:  now,
 		Source:     "prompt-editor",
-		Attributes: attrs,
+		Attributes: attrs.From(prompt),
 		CreatedAt:  now,
 	}
 
@@ -284,50 +269,19 @@ func (ps *PromptStore) GetPromptVersions(ctx context.Context, filename string, l
 
 // attestationToPrompt converts an attestation into a StoredPrompt
 func (ps *PromptStore) attestationToPrompt(as *types.As) *StoredPrompt {
-	name := ""
-	if len(as.Subjects) > 0 {
-		name = as.Subjects[0]
-	}
-
-	filename := ""
-	if len(as.Contexts) > 0 {
-		filename = as.Contexts[0]
-	}
-
-	createdBy := ""
-	if len(as.Actors) > 0 {
-		createdBy = as.Actors[0]
-	}
-
 	prompt := &StoredPrompt{
 		ID:        as.ID,
-		Name:      name,
-		Filename:  filename,
-		CreatedBy: createdBy,
 		CreatedAt: as.Timestamp,
 	}
-
-	// Extract attributes
-	if as.Attributes != nil {
-		if template, ok := as.Attributes["template"].(string); ok {
-			prompt.Template = template
-		}
-		if systemPrompt, ok := as.Attributes["system_prompt"].(string); ok {
-			prompt.SystemPrompt = systemPrompt
-		}
-		if axPattern, ok := as.Attributes["ax_pattern"].(string); ok {
-			prompt.AxPattern = axPattern
-		}
-		if provider, ok := as.Attributes["provider"].(string); ok {
-			prompt.Provider = provider
-		}
-		if model, ok := as.Attributes["model"].(string); ok {
-			prompt.Model = model
-		}
-		if version, ok := as.Attributes["version"].(float64); ok {
-			prompt.Version = int(version)
-		}
+	if len(as.Subjects) > 0 {
+		prompt.Name = as.Subjects[0]
 	}
-
+	if len(as.Contexts) > 0 {
+		prompt.Filename = as.Contexts[0]
+	}
+	if len(as.Actors) > 0 {
+		prompt.CreatedBy = as.Actors[0]
+	}
+	attrs.Scan(as.Attributes, prompt)
 	return prompt
 }

--- a/ats/storage/rich_search.go
+++ b/ats/storage/rich_search.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/teranos/QNTX/ats"
+	"github.com/teranos/QNTX/ats/attrs"
 	"github.com/teranos/QNTX/ats/ax"
+	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
 )
 
@@ -352,23 +354,14 @@ func (bs *BoundedStore) getTypeDefinitions(ctx context.Context) (map[string][]st
 		}
 		typeName := attestation.Subjects[0]
 
-		// Extract rich_string_fields from attributes
-		if attestation.Attributes != nil {
-			if richFields, ok := attestation.Attributes["rich_string_fields"].([]interface{}); ok {
-				fields := make([]string, 0, len(richFields))
-				for _, field := range richFields {
-					if fieldStr, ok := field.(string); ok {
-						fields = append(fields, fieldStr)
-					}
-				}
-				if len(fields) > 0 {
-					typeFields[typeName] = fields
-					if bs.logger != nil {
-						bs.logger.Debugw("Found type with rich fields",
-							"type", typeName,
-							"fields", fields)
-					}
-				}
+		var def types.TypeDef
+		attrs.Scan(attestation.Attributes, &def)
+		if len(def.RichStringFields) > 0 {
+			typeFields[typeName] = def.RichStringFields
+			if bs.logger != nil {
+				bs.logger.Debugw("Found type with rich fields",
+					"type", typeName,
+					"fields", def.RichStringFields)
 			}
 		}
 	}

--- a/graph/node_types.go
+++ b/graph/node_types.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"sort"
 
+	"github.com/teranos/QNTX/ats/attrs"
 	"github.com/teranos/QNTX/ats/types"
 )
 
@@ -52,45 +53,11 @@ func (b *AxGraphBuilder) extractTypeDefinitions(attestations []types.As) map[str
 			if claim.Predicate == "type" && claim.Context == "graph" {
 				typeName := claim.Subject
 
-				// Create TypeDef from attestation attributes
-				opacity := 1.0 // Default full opacity
-				def := types.TypeDef{
-					Name:    typeName,
-					Opacity: &opacity,
-				}
-
-				// Parse Attributes if present
-				if attestation.Attributes != nil {
-					if color, ok := attestation.Attributes["display_color"].(string); ok {
-						def.Color = color
-					}
-					if label, ok := attestation.Attributes["display_label"].(string); ok {
-						def.Label = label
-					}
-					if deprecated, ok := attestation.Attributes["deprecated"].(bool); ok {
-						def.Deprecated = deprecated
-					}
-					if opacityVal, ok := attestation.Attributes["opacity"].(float64); ok {
-						def.Opacity = &opacityVal
-					}
-					// Extract rich_string_fields array if present
-					if richFields, ok := attestation.Attributes["rich_string_fields"].([]interface{}); ok {
-						def.RichStringFields = make([]string, 0, len(richFields))
-						for _, field := range richFields {
-							if fieldStr, ok := field.(string); ok {
-								def.RichStringFields = append(def.RichStringFields, fieldStr)
-							}
-						}
-					}
-					// Extract array_fields array if present
-					if arrayFields, ok := attestation.Attributes["array_fields"].([]interface{}); ok {
-						def.ArrayFields = make([]string, 0, len(arrayFields))
-						for _, field := range arrayFields {
-							if fieldStr, ok := field.(string); ok {
-								def.ArrayFields = append(def.ArrayFields, fieldStr)
-							}
-						}
-					}
+				def := types.TypeDef{Name: typeName}
+				attrs.Scan(attestation.Attributes, &def)
+				if def.Opacity == nil {
+					defaultOpacity := 1.0
+					def.Opacity = &defaultOpacity
 				}
 
 				// Later attestations override earlier ones (natural evolution)

--- a/graph/relationship_types.go
+++ b/graph/relationship_types.go
@@ -3,18 +3,19 @@ package graph
 import (
 	"sort"
 
+	"github.com/teranos/QNTX/ats/attrs"
 	"github.com/teranos/QNTX/ats/types"
 )
 
 // RelationshipDefinition holds physics and display metadata for a relationship type from attestations.
 // Relationship type definitions use the "relationship_type" predicate in typespace.
 type RelationshipDefinition struct {
-	PredicateName string   `json:"predicate_name"`          // e.g., "is_child_of", "points_to"
-	DisplayLabel  string   `json:"display_label"`           // Human-readable label
-	Color         string   `json:"color,omitempty"`         // Optional link color override
-	LinkDistance  *float64 `json:"link_distance,omitempty"` // D3 force distance (nil = use default)
-	LinkStrength  *float64 `json:"link_strength,omitempty"` // D3 force strength (nil = use default)
-	Deprecated    bool     `json:"deprecated"`              // Whether this relationship type is deprecated
+	PredicateName string   `json:"predicate_name"`                                         // e.g., "is_child_of", "points_to"
+	DisplayLabel  string   `json:"display_label" attr:"display_label"`                     // Human-readable label
+	Color         string   `json:"color,omitempty" attr:"color,omitempty"`                 // Optional link color override
+	LinkDistance  *float64 `json:"link_distance,omitempty" attr:"link_distance,omitempty"` // D3 force distance (nil = use default)
+	LinkStrength  *float64 `json:"link_strength,omitempty" attr:"link_strength,omitempty"` // D3 force strength (nil = use default)
+	Deprecated    bool     `json:"deprecated" attr:"deprecated"`                           // Whether this relationship type is deprecated
 }
 
 // extractRelationshipTypeDefinitions extracts relationship type definitions from attestations with physics metadata.
@@ -47,29 +48,8 @@ func (b *AxGraphBuilder) extractRelationshipTypeDefinitions(attestations []types
 			if claim.Predicate == "relationship_type" && claim.Context == "graph" {
 				predicateName := claim.Subject
 
-				// Extract physics and display metadata from Attributes
-				def := RelationshipDefinition{
-					PredicateName: predicateName,
-				}
-
-				// Parse Attributes if present
-				if attestation.Attributes != nil {
-					if label, ok := attestation.Attributes["display_label"].(string); ok {
-						def.DisplayLabel = label
-					}
-					if color, ok := attestation.Attributes["color"].(string); ok {
-						def.Color = color
-					}
-					if distance, ok := attestation.Attributes["link_distance"].(float64); ok {
-						def.LinkDistance = &distance
-					}
-					if strength, ok := attestation.Attributes["link_strength"].(float64); ok {
-						def.LinkStrength = &strength
-					}
-					if deprecated, ok := attestation.Attributes["deprecated"].(bool); ok {
-						def.Deprecated = deprecated
-					}
-				}
+				def := RelationshipDefinition{PredicateName: predicateName}
+				attrs.Scan(attestation.Attributes, &def)
 
 				// Later attestations override earlier ones (natural evolution)
 				relationshipDefinitions[predicateName] = def

--- a/server/embeddings_labeling.go
+++ b/server/embeddings_labeling.go
@@ -14,6 +14,7 @@ import (
 	"github.com/teranos/QNTX/ai/openrouter"
 	"github.com/teranos/QNTX/ai/provider"
 	appcfg "github.com/teranos/QNTX/am"
+	"github.com/teranos/QNTX/ats/attrs"
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/pulse/async"
@@ -147,6 +148,14 @@ func (h *ClusterLabelHandler) Execute(ctx context.Context, job *async.Job) error
 	return nil
 }
 
+// clusterLabelAttrs defines the attribute schema for cluster label attestations.
+type clusterLabelAttrs struct {
+	Label      string `attr:"label"`
+	Model      string `attr:"model"`
+	SampleSize int    `attr:"sample_size"`
+	NMembers   int    `attr:"n_members"`
+}
+
 func (h *ClusterLabelHandler) createLabelAttestation(asStore *storage.SQLStore, clusterID int, label, model string, sampleSize, nMembers int) {
 	subject := fmt.Sprintf("cluster:%d", clusterID)
 	asid, err := vanity.GenerateASID(subject, "labeled", "embeddings", "qntx@embeddings")
@@ -165,12 +174,12 @@ func (h *ClusterLabelHandler) createLabelAttestation(asStore *storage.SQLStore, 
 		Actors:     []string{"qntx@embeddings"},
 		Timestamp:  now,
 		Source:     "cluster-labeling",
-		Attributes: map[string]interface{}{
-			"label":       label,
-			"model":       model,
-			"sample_size": sampleSize,
-			"n_members":   nMembers,
-		},
+		Attributes: attrs.From(clusterLabelAttrs{
+			Label:      label,
+			Model:      model,
+			SampleSize: sampleSize,
+			NMembers:   nMembers,
+		}),
 		CreatedAt: now,
 	}
 


### PR DESCRIPTION
## Summary
- New `ats/attrs` package: `Scan()` and `From()` bridge between `map[string]any` and typed Go structs via `attr` struct tags
- Replaces manual type assertions and map building across 7 files, eliminating ~120 lines of boilerplate
- No behavior change — storage model, attestation table, and JSON serialization are untouched

## Test plan
- [x] `make test` passes (668 Go + TS tests)
- [x] `ats/attrs` has dedicated unit tests covering scan, from, roundtrip, pointer deref, omitempty, slices
- [x] Existing tests for prompt store, type definitions, graph, and rich search continue to pass