### PR TITLE
Add browser-to-browser P2P sync (WebRTC)

### DIFF
--- a/web/ts/components/glyph/p2p-sync-glyph.ts
+++ b/web/ts/components/glyph/p2p-sync-glyph.ts
@@ -1,0 +1,353 @@
+/**
+ * P2P Sync Window Glyph
+ *
+ * UI for peer-to-peer browser sync over WebRTC.
+ * Generate invite links, connect to peers, trigger sync.
+ */
+
+import type { Glyph } from './glyph';
+import { glyphRun } from './run';
+import { generateInviteLink, connectToInvite, acceptAnswer, type P2PConnection } from '../../p2p-connection-manager';
+import { log, SEG } from '../../logger';
+
+const P2P_GLYPH_ID = 'p2p-sync';
+
+let activeConnection: P2PConnection | null = null;
+let pendingInviteLink: string | null = null;
+
+function renderP2PContent(): HTMLElement {
+    const el = document.createElement('div');
+    el.className = 'p2p-sync-content';
+    el.style.cssText = `
+        padding: 20px;
+        font-family: monospace;
+        font-size: 13px;
+        line-height: 1.6;
+        color: var(--text-on-dark);
+        overflow-y: auto;
+        height: 100%;
+    `;
+
+    el.innerHTML = `
+        <h3 style="margin: 0 0 16px 0; font-size: 16px; color: #60a5fa;">
+            Peer-to-Peer Sync
+        </h3>
+
+        <div class="p2p-section" style="margin-bottom: 20px;">
+            <h4 style="margin: 0 0 8px 0; font-size: 14px;">
+                1. Initiate Connection
+            </h4>
+            <button class="generate-invite-btn" style="
+                padding: 8px 16px;
+                background: #3b82f6;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-family: monospace;
+            ">Generate Invite Link</button>
+            <div class="invite-link-display" style="
+                margin-top: 12px;
+                padding: 12px;
+                background: rgba(0, 0, 0, 0.3);
+                border-radius: 4px;
+                display: none;
+            ">
+                <div style="margin-bottom: 8px; color: #9ca3af;">
+                    Share this with your peer:
+                </div>
+                <textarea class="invite-link-text" readonly style="
+                    width: 100%;
+                    height: 80px;
+                    background: #000;
+                    color: #0f0;
+                    border: 1px solid #333;
+                    border-radius: 4px;
+                    padding: 8px;
+                    font-family: monospace;
+                    font-size: 11px;
+                    resize: none;
+                "></textarea>
+                <button class="copy-invite-btn" style="
+                    margin-top: 8px;
+                    padding: 6px 12px;
+                    background: #10b981;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    cursor: pointer;
+                    font-family: monospace;
+                    font-size: 12px;
+                ">Copy to Clipboard</button>
+            </div>
+        </div>
+
+        <div class="p2p-section" style="margin-bottom: 20px;">
+            <h4 style="margin: 0 0 8px 0; font-size: 14px;">
+                2. Connect to Peer
+            </h4>
+            <textarea class="peer-invite-input" placeholder="Paste peer's invite link here..." style="
+                width: 100%;
+                height: 80px;
+                background: rgba(0, 0, 0, 0.3);
+                color: var(--text-on-dark);
+                border: 1px solid #444;
+                border-radius: 4px;
+                padding: 8px;
+                font-family: monospace;
+                font-size: 11px;
+                margin-bottom: 8px;
+            "></textarea>
+            <button class="connect-to-peer-btn" style="
+                padding: 8px 16px;
+                background: #8b5cf6;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-family: monospace;
+            ">Connect</button>
+            <div class="answer-display" style="
+                margin-top: 12px;
+                padding: 12px;
+                background: rgba(0, 0, 0, 0.3);
+                border-radius: 4px;
+                display: none;
+            ">
+                <div style="margin-bottom: 8px; color: #9ca3af;">
+                    Send this answer back to your peer:
+                </div>
+                <textarea class="answer-text" readonly style="
+                    width: 100%;
+                    height: 80px;
+                    background: #000;
+                    color: #0f0;
+                    border: 1px solid #333;
+                    border-radius: 4px;
+                    padding: 8px;
+                    font-family: monospace;
+                    font-size: 11px;
+                    resize: none;
+                "></textarea>
+                <button class="copy-answer-btn" style="
+                    margin-top: 8px;
+                    padding: 6px 12px;
+                    background: #10b981;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    cursor: pointer;
+                    font-family: monospace;
+                    font-size: 12px;
+                ">Copy to Clipboard</button>
+            </div>
+        </div>
+
+        <div class="answer-input-section" style="margin-bottom: 20px; display: none;">
+            <h4 style="margin: 0 0 8px 0; font-size: 14px;">
+                3. Complete Connection
+            </h4>
+            <textarea class="peer-answer-input" placeholder="Paste peer's answer here..." style="
+                width: 100%;
+                height: 80px;
+                background: rgba(0, 0, 0, 0.3);
+                color: var(--text-on-dark);
+                border: 1px solid #444;
+                border-radius: 4px;
+                padding: 8px;
+                font-family: monospace;
+                font-size: 11px;
+                margin-bottom: 8px;
+            "></textarea>
+            <button class="accept-answer-btn" style="
+                padding: 8px 16px;
+                background: #f59e0b;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-family: monospace;
+            ">Complete Connection</button>
+        </div>
+
+        <div class="connection-status" style="
+            margin-bottom: 20px;
+            padding: 12px;
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 4px;
+            display: none;
+        ">
+            <div style="color: #10b981; margin-bottom: 8px;">
+                ✓ Connected to peer
+            </div>
+            <button class="sync-now-btn" style="
+                padding: 8px 16px;
+                background: #ef4444;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-family: monospace;
+                margin-right: 8px;
+            ">Sync Now</button>
+            <button class="disconnect-btn" style="
+                padding: 8px 16px;
+                background: #6b7280;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-family: monospace;
+            ">Disconnect</button>
+        </div>
+
+        <div class="sync-results" style="
+            padding: 12px;
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 4px;
+            display: none;
+            color: #9ca3af;
+        "></div>
+    `;
+
+    // Event listeners
+    const generateBtn = el.querySelector('.generate-invite-btn') as HTMLButtonElement;
+    const copyInviteBtn = el.querySelector('.copy-invite-btn') as HTMLButtonElement;
+    const connectBtn = el.querySelector('.connect-to-peer-btn') as HTMLButtonElement;
+    const copyAnswerBtn = el.querySelector('.copy-answer-btn') as HTMLButtonElement;
+    const acceptAnswerBtn = el.querySelector('.accept-answer-btn') as HTMLButtonElement;
+    const syncBtn = el.querySelector('.sync-now-btn') as HTMLButtonElement;
+    const disconnectBtn = el.querySelector('.disconnect-btn') as HTMLButtonElement;
+
+    generateBtn.onclick = async () => {
+        try {
+            pendingInviteLink = await generateInviteLink();
+            const display = el.querySelector('.invite-link-display') as HTMLElement;
+            const textarea = el.querySelector('.invite-link-text') as HTMLTextAreaElement;
+            textarea.value = pendingInviteLink;
+            display.style.display = 'block';
+
+            const answerSection = el.querySelector('.answer-input-section') as HTMLElement;
+            answerSection.style.display = 'block';
+
+            log.info(SEG.WS, '[P2P] Invite link generated');
+        } catch (err) {
+            showError(el, `Failed to generate invite: ${err}`);
+        }
+    };
+
+    copyInviteBtn.onclick = () => {
+        const textarea = el.querySelector('.invite-link-text') as HTMLTextAreaElement;
+        navigator.clipboard.writeText(textarea.value);
+        log.info(SEG.WS, '[P2P] Invite link copied');
+    };
+
+    connectBtn.onclick = async () => {
+        try {
+            const input = el.querySelector('.peer-invite-input') as HTMLTextAreaElement;
+            const inviteJson = input.value.trim();
+            if (!inviteJson) return;
+
+            const { answerJson, connection } = await connectToInvite(inviteJson);
+            activeConnection = connection;
+
+            const answerDisplay = el.querySelector('.answer-display') as HTMLElement;
+            const answerText = el.querySelector('.answer-text') as HTMLTextAreaElement;
+            answerText.value = answerJson;
+            answerDisplay.style.display = 'block';
+
+            showConnected(el);
+            log.info(SEG.WS, '[P2P] Connected to peer invite');
+        } catch (err) {
+            showError(el, `Failed to connect: ${err}`);
+        }
+    };
+
+    copyAnswerBtn.onclick = () => {
+        const textarea = el.querySelector('.answer-text') as HTMLTextAreaElement;
+        navigator.clipboard.writeText(textarea.value);
+        log.info(SEG.WS, '[P2P] Answer copied');
+    };
+
+    acceptAnswerBtn.onclick = async () => {
+        try {
+            if (!pendingInviteLink) {
+                showError(el, 'No invite link found');
+                return;
+            }
+
+            const input = el.querySelector('.peer-answer-input') as HTMLTextAreaElement;
+            const answerJson = input.value.trim();
+            if (!answerJson) return;
+
+            activeConnection = await acceptAnswer(pendingInviteLink, answerJson);
+            showConnected(el);
+            log.info(SEG.WS, '[P2P] Connection completed');
+        } catch (err) {
+            showError(el, `Failed to accept answer: ${err}`);
+        }
+    };
+
+    syncBtn.onclick = async () => {
+        if (!activeConnection) return;
+
+        try {
+            const resultsDiv = el.querySelector('.sync-results') as HTMLElement;
+            resultsDiv.textContent = 'Syncing...';
+            resultsDiv.style.display = 'block';
+            resultsDiv.style.color = '#9ca3af';
+
+            const { sent, received } = await activeConnection.sync.reconcile();
+
+            resultsDiv.textContent = `Sync complete: sent=${sent}, received=${received}`;
+            log.info(SEG.WS, `[P2P] Sync complete: sent=${sent} received=${received}`);
+        } catch (err) {
+            showError(el, `Sync failed: ${err}`);
+        }
+    };
+
+    disconnectBtn.onclick = () => {
+        if (activeConnection) {
+            activeConnection.peer.close();
+            activeConnection = null;
+        }
+        const statusDiv = el.querySelector('.connection-status') as HTMLElement;
+        statusDiv.style.display = 'none';
+        log.info(SEG.WS, '[P2P] Disconnected');
+    };
+
+    return el;
+}
+
+function showConnected(el: HTMLElement): void {
+    const statusDiv = el.querySelector('.connection-status') as HTMLElement;
+    statusDiv.style.display = 'block';
+}
+
+function showError(el: HTMLElement, message: string): void {
+    const resultsDiv = el.querySelector('.sync-results') as HTMLElement;
+    resultsDiv.textContent = `Error: ${message}`;
+    resultsDiv.style.display = 'block';
+    resultsDiv.style.color = '#ef4444';
+    log.error(SEG.WS, `[P2P] ${message}`);
+}
+
+/**
+ * Open the P2P sync window glyph.
+ * Call this from the UI (e.g., button in system drawer).
+ */
+export function openP2PSyncWindow(): void {
+    const glyph: Glyph = {
+        id: P2P_GLYPH_ID,
+        title: 'P2P Sync',
+        renderContent: renderP2PContent,
+        initialWidth: '600px',
+        initialHeight: '700px',
+        onClose: () => {
+            log.debug(SEG.GLYPH, '[P2PSync] Window closed');
+        },
+    };
+
+    glyphRun.add(glyph);
+    glyphRun.openGlyph(P2P_GLYPH_ID);
+}

--- a/web/ts/p2p-connection-manager.ts
+++ b/web/ts/p2p-connection-manager.ts
@@ -27,7 +27,10 @@ export interface P2PConnection {
  * Returns a JSON string containing SDP offer. Peer pastes this to connect.
  */
 export async function generateInviteLink(): Promise<string> {
-    const peer = new WebRTCPeer();
+    // For localhost testing, use empty ICE servers (local connection only)
+    const peer = new WebRTCPeer({
+        iceServers: window.location.hostname === 'localhost' ? [] : undefined,
+    });
     const offer = await peer.createOffer();
 
     const inviteData: InviteLink = {
@@ -55,7 +58,9 @@ export async function connectToInvite(inviteLinkJson: string): Promise<{ answerJ
 
     const offer = JSON.parse(atob(inviteData.offer));
 
-    const peer = new WebRTCPeer();
+    const peer = new WebRTCPeer({
+        iceServers: window.location.hostname === 'localhost' ? [] : undefined,
+    });
     const answer = await peer.createAnswer(offer);
 
     const answerData = {

--- a/web/ts/p2p-connection-manager.ts
+++ b/web/ts/p2p-connection-manager.ts
@@ -1,0 +1,105 @@
+/**
+ * P2P Connection Manager
+ *
+ * Handles WebRTC signaling (SDP offer/answer exchange) for peer-to-peer sync.
+ * Initial implementation uses manual copy-paste (invite links).
+ */
+
+import { log, SEG } from './logger';
+import { WebRTCPeer } from './webrtc-peer';
+import { P2PSync } from './p2p-sync';
+
+export interface InviteLink {
+    /** Base64-encoded SDP offer */
+    offer: string;
+    /** Version for future compatibility */
+    version: number;
+}
+
+export interface P2PConnection {
+    peer: WebRTCPeer;
+    sync: P2PSync;
+}
+
+/**
+ * Generate an invite link to share with remote peer.
+ *
+ * Returns a JSON string containing SDP offer. Peer pastes this to connect.
+ */
+export async function generateInviteLink(): Promise<string> {
+    const peer = new WebRTCPeer();
+    const offer = await peer.createOffer();
+
+    const inviteData: InviteLink = {
+        offer: btoa(JSON.stringify(offer)),
+        version: 1,
+    };
+
+    // Store peer in global map keyed by offer (so we can resume when answer arrives)
+    pendingPeers.set(inviteData.offer, peer);
+
+    return JSON.stringify(inviteData);
+}
+
+/**
+ * Connect to a peer using their invite link.
+ *
+ * Takes invite link JSON, creates answer, returns answer JSON to paste back.
+ */
+export async function connectToInvite(inviteLinkJson: string): Promise<{ answerJson: string; connection: P2PConnection }> {
+    const inviteData: InviteLink = JSON.parse(inviteLinkJson);
+
+    if (inviteData.version !== 1) {
+        throw new Error(`Unsupported invite version: ${inviteData.version}`);
+    }
+
+    const offer = JSON.parse(atob(inviteData.offer));
+
+    const peer = new WebRTCPeer();
+    const answer = await peer.createAnswer(offer);
+
+    const answerData = {
+        answer: btoa(JSON.stringify(answer)),
+        version: 1,
+    };
+
+    const sync = new P2PSync(peer);
+
+    log.info(SEG.WS, '[P2P] Connected to invite, waiting for channel open');
+
+    return {
+        answerJson: JSON.stringify(answerData),
+        connection: { peer, sync },
+    };
+}
+
+/**
+ * Complete connection (initiator receives answer from peer).
+ *
+ * Takes the answer JSON, completes WebRTC handshake, returns connection.
+ */
+export async function acceptAnswer(inviteLinkJson: string, answerJson: string): Promise<P2PConnection> {
+    const inviteData: InviteLink = JSON.parse(inviteLinkJson);
+    const answerData = JSON.parse(answerJson);
+
+    if (answerData.version !== 1) {
+        throw new Error(`Unsupported answer version: ${answerData.version}`);
+    }
+
+    const peer = pendingPeers.get(inviteData.offer);
+    if (!peer) {
+        throw new Error('No pending peer found for this invite');
+    }
+
+    const answer = JSON.parse(atob(answerData.answer));
+    await peer.acceptAnswer(answer);
+
+    const sync = new P2PSync(peer);
+
+    log.info(SEG.WS, '[P2P] Answer accepted, waiting for channel open');
+
+    return { peer, sync };
+}
+
+// Pending peers waiting for answer (keyed by base64 offer)
+const pendingPeers = new Map<string, WebRTCPeer>();

--- a/web/ts/p2p-sync.ts
+++ b/web/ts/p2p-sync.ts
@@ -1,0 +1,193 @@
+/**
+ * Peer-to-Peer Sync Orchestrator
+ *
+ * Browser-to-browser Merkle sync over WebRTC.
+ * Reuses the same sync protocol as browser-to-server, just different transport.
+ */
+
+import { log, SEG } from './logger';
+import { WebRTCPeer } from './webrtc-peer';
+import {
+    syncMerkleRoot,
+    syncMerkleGroupHashes,
+    syncMerkleFindGroupKey,
+    listAttestationIds,
+    getAttestation,
+    putAttestation,
+} from './qntx-wasm';
+
+interface SyncMessage {
+    type: 'sync_hello' | 'sync_group_hashes' | 'sync_need' | 'sync_attestations' | 'sync_done';
+    root_hash?: string;
+    name?: string;
+    groups?: Record<string, string>;
+    need?: string[];
+    attestations?: Record<string, any[]>;
+    sent?: number;
+    received?: number;
+}
+
+export interface P2PSyncResult {
+    sent: number;
+    received: number;
+}
+
+/**
+ * Sync with a remote peer over WebRTC.
+ *
+ * Same Merkle reconciliation logic as server sync, but peer-to-peer.
+ * Works completely offline — no server required.
+ */
+export class P2PSync {
+    private peer: WebRTCPeer;
+
+    constructor(peer: WebRTCPeer) {
+        this.peer = peer;
+    }
+
+    /**
+     * Perform Merkle reconciliation with remote peer.
+     *
+     * Returns number of attestations sent and received.
+     */
+    async reconcile(): Promise<P2PSyncResult> {
+        await this.peer.waitForOpen();
+
+        let sent = 0;
+        let received = 0;
+
+        // Phase 1: Exchange root hashes
+        const localRoot = syncMerkleRoot();
+
+        this.sendMessage({
+            type: 'sync_hello',
+            root_hash: localRoot.root,
+            name: 'browser-peer',
+        });
+
+        const hello = await this.receiveMessage();
+        if (hello.type !== 'sync_hello') {
+            throw new Error(`Expected sync_hello, got ${hello.type}`);
+        }
+
+        // Roots match — already in sync
+        if (hello.root_hash === localRoot.root) {
+            log.debug(SEG.WASM, '[P2PSync] Roots match, already in sync');
+            this.sendMessage({ type: 'sync_done', sent: 0, received: 0 });
+            await this.receiveMessage(); // recv peer's sync_done
+            return { sent: 0, received: 0 };
+        }
+
+        log.debug(SEG.WASM, `[P2PSync] Roots differ, local=${localRoot.root.slice(0, 12)}... remote=${hello.root_hash?.slice(0, 12)}...`);
+
+        // Phase 2: Exchange group hashes
+        const localGroupHashes = syncMerkleGroupHashes();
+
+        this.sendMessage({
+            type: 'sync_group_hashes',
+            groups: localGroupHashes,
+        });
+
+        const groupHashesMsg = await this.receiveMessage();
+        if (groupHashesMsg.type !== 'sync_group_hashes') {
+            throw new Error(`Expected sync_group_hashes, got ${groupHashesMsg.type}`);
+        }
+
+        const remoteGroupHashes = groupHashesMsg.groups || {};
+
+        // Phase 3: Determine what we need
+        const needGroupKeys: string[] = [];
+        for (const [groupKey, remoteHash] of Object.entries(remoteGroupHashes)) {
+            const localHash = localGroupHashes[groupKey];
+            if (localHash !== remoteHash) {
+                needGroupKeys.push(groupKey);
+            }
+        }
+
+        this.sendMessage({
+            type: 'sync_need',
+            need: needGroupKeys,
+        });
+
+        // Phase 4: Receive what peer needs
+        const needMsg = await this.receiveMessage();
+        if (needMsg.type !== 'sync_need') {
+            throw new Error(`Expected sync_need, got ${needMsg.type}`);
+        }
+
+        const peerNeeds = needMsg.need || [];
+
+        // Phase 5: Send attestations peer needs
+        const toSend: Record<string, any[]> = {};
+        for (const groupKey of peerNeeds) {
+            const ids = listAttestationIds().filter((id) => {
+                const key = syncMerkleFindGroupKey(id);
+                return key === groupKey;
+            });
+
+            toSend[groupKey] = ids.map((id) => {
+                const as = getAttestation(id);
+                if (!as) {
+                    log.warn(SEG.WASM, `[P2PSync] Attestation ${id} disappeared during sync`);
+                    return null;
+                }
+                return as;
+            }).filter((a) => a !== null);
+
+            sent += toSend[groupKey].length;
+        }
+
+        this.sendMessage({
+            type: 'sync_attestations',
+            attestations: toSend,
+        });
+
+        // Phase 6: Receive attestations we need
+        const attestationsMsg = await this.receiveMessage();
+        if (attestationsMsg.type !== 'sync_attestations') {
+            throw new Error(`Expected sync_attestations, got ${attestationsMsg.type}`);
+        }
+
+        const receivedAttestations = attestationsMsg.attestations || {};
+        for (const groupAtts of Object.values(receivedAttestations)) {
+            for (const att of groupAtts) {
+                putAttestation(att);
+                received++;
+            }
+        }
+
+        // Phase 7: Exchange done
+        this.sendMessage({ type: 'sync_done', sent, received });
+        await this.receiveMessage(); // recv peer's sync_done
+
+        log.info(SEG.WASM, `[P2PSync] Reconciled: sent=${sent} received=${received}`);
+
+        return { sent, received };
+    }
+
+    private sendMessage(msg: SyncMessage): void {
+        this.peer.send(JSON.stringify(msg));
+    }
+
+    private async receiveMessage(): Promise<SyncMessage> {
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(new Error('P2P sync message timeout'));
+            }, 30_000); // 30 second timeout
+
+            this.peer.onMessage((data) => {
+                clearTimeout(timeout);
+                try {
+                    const msg = JSON.parse(data) as SyncMessage;
+                    resolve(msg);
+                } catch (err) {
+                    reject(new Error(`Failed to parse sync message: ${err}`));
+                }
+            });
+        });
+    }
+
+    close(): void {
+        this.peer.close();
+    }
+}

--- a/web/ts/system-drawer.ts
+++ b/web/ts/system-drawer.ts
@@ -10,6 +10,7 @@ import type { SearchMatch, SearchResultsMessage } from './search-view.ts';
 import { spawnGlyphByCommand, getMatchingCommands, COMMAND_LABELS } from './components/glyph/canvas/spawn-menu.ts';
 import { uiState } from './state/ui.ts';
 import { Subcanvas } from '@generated/sym.js';
+import { openP2PSyncWindow } from './components/glyph/p2p-sync-glyph.ts';
 
 const DRAWER_HEIGHT_KEY = 'system-drawer-height';
 const DRAWER_MIN = 6;     // Hidden: just the grab bar
@@ -238,6 +239,24 @@ export function initSystemDrawer(): void {
 
         const controls = header.querySelector('.controls');
         if (controls) {
+            // Add P2P sync button to controls
+            const p2pBtn = document.createElement('button');
+            p2pBtn.textContent = 'P2P';
+            p2pBtn.title = 'Peer-to-Peer Sync';
+            p2pBtn.style.cssText = `
+                padding: 4px 8px;
+                margin-right: 8px;
+                background: #3b82f6;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-family: monospace;
+                font-size: 11px;
+            `;
+            p2pBtn.onclick = () => openP2PSyncWindow();
+            controls.prepend(p2pBtn);
+
             header.insertBefore(searchInput, controls);
         } else {
             header.appendChild(searchInput);

--- a/web/ts/webrtc-peer.dom.test.ts
+++ b/web/ts/webrtc-peer.dom.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'bun:test';
+import { WebRTCPeer } from './webrtc-peer';
+
+describe('WebRTCPeer', () => {
+    it('establishes connection and exchanges messages', async () => {
+        // Peer A (initiator)
+        const peerA = new WebRTCPeer();
+        const offer = await peerA.createOffer();
+
+        // Peer B (responder)
+        const peerB = new WebRTCPeer();
+        const answer = await peerB.createAnswer(offer);
+
+        // Complete handshake
+        await peerA.acceptAnswer(answer);
+
+        // Wait for channels to open
+        await Promise.all([peerA.waitForOpen(), peerB.waitForOpen()]);
+
+        // Exchange messages
+        const messagesA: string[] = [];
+        const messagesB: string[] = [];
+
+        peerA.onMessage((msg) => messagesA.push(msg));
+        peerB.onMessage((msg) => messagesB.push(msg));
+
+        peerA.send('Hello from A');
+        peerB.send('Hello from B');
+
+        // Wait a bit for messages to arrive
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        expect(messagesB).toContain('Hello from A');
+        expect(messagesA).toContain('Hello from B');
+
+        peerA.close();
+        peerB.close();
+    });
+
+    it('handles connection timeout', async () => {
+        const peer = new WebRTCPeer({ connectionTimeout: 100 });
+
+        // Create offer but don't complete handshake
+        await peer.createOffer();
+
+        // Should timeout waiting for open
+        await expect(peer.waitForOpen()).rejects.toThrow('timeout');
+
+        peer.close();
+    });
+});

--- a/web/ts/webrtc-peer.ts
+++ b/web/ts/webrtc-peer.ts
@@ -1,0 +1,217 @@
+/**
+ * WebRTC Peer Connection for Browser-to-Browser Sync
+ *
+ * Provides a WebSocket-like interface over WebRTC data channels.
+ * Reuses the same Merkle sync protocol as server sync — just different transport.
+ */
+
+import { log, SEG } from './logger';
+
+export interface PeerConnectionConfig {
+    /** ICE servers for NAT traversal (STUN/TURN) */
+    iceServers?: RTCIceServer[];
+    /** Timeout for connection establishment (ms) */
+    connectionTimeout?: number;
+}
+
+const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+    // Google's public STUN server
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:stun1.l.google.com:19302' },
+];
+
+const DEFAULT_CONNECTION_TIMEOUT = 30_000; // 30 seconds
+
+/**
+ * WebRTC peer connection wrapper with WebSocket-like interface.
+ *
+ * Creates a reliable, ordered data channel for sync protocol messages.
+ * Handles ICE candidate exchange, connection state, and message framing.
+ */
+export class WebRTCPeer {
+    private pc: RTCPeerConnection;
+    private channel: RTCDataChannel | null = null;
+    private onMessageCallback: ((data: string) => void) | null = null;
+    private onCloseCallback: (() => void) | null = null;
+    private pendingMessages: string[] = [];
+    private connectionTimeout: number;
+
+    constructor(config: PeerConnectionConfig = {}) {
+        this.connectionTimeout = config.connectionTimeout ?? DEFAULT_CONNECTION_TIMEOUT;
+
+        this.pc = new RTCPeerConnection({
+            iceServers: config.iceServers ?? DEFAULT_ICE_SERVERS,
+        });
+
+        // Log connection state changes
+        this.pc.onconnectionstatechange = () => {
+            log.debug(SEG.WS, `[WebRTC] Connection state: ${this.pc.connectionState}`);
+
+            if (this.pc.connectionState === 'failed' || this.pc.connectionState === 'closed') {
+                this.onCloseCallback?.();
+            }
+        };
+
+        this.pc.oniceconnectionstatechange = () => {
+            log.debug(SEG.WS, `[WebRTC] ICE connection state: ${this.pc.iceConnectionState}`);
+        };
+    }
+
+    /**
+     * Create offer (initiating peer).
+     * Returns SDP offer to be sent to remote peer via signaling channel.
+     */
+    async createOffer(): Promise<RTCSessionDescriptionInit> {
+        // Create data channel (initiator creates, responder receives)
+        this.channel = this.pc.createDataChannel('qntx-sync', {
+            ordered: true,    // Preserve message order
+            maxRetransmits: undefined, // Reliable delivery
+        });
+        this.setupDataChannel(this.channel);
+
+        const offer = await this.pc.createOffer();
+        await this.pc.setLocalDescription(offer);
+
+        // Wait for ICE gathering to complete
+        await this.waitForIceGathering();
+
+        return this.pc.localDescription!;
+    }
+
+    /**
+     * Create answer (responding peer).
+     * Takes remote offer, returns SDP answer.
+     */
+    async createAnswer(remoteOffer: RTCSessionDescriptionInit): Promise<RTCSessionDescriptionInit> {
+        await this.pc.setRemoteDescription(remoteOffer);
+
+        // Set up handler for incoming data channel
+        this.pc.ondatachannel = (event) => {
+            this.channel = event.channel;
+            this.setupDataChannel(this.channel);
+        };
+
+        const answer = await this.pc.createAnswer();
+        await this.pc.setLocalDescription(answer);
+
+        await this.waitForIceGathering();
+
+        return this.pc.localDescription!;
+    }
+
+    /**
+     * Complete connection (initiator receives answer).
+     */
+    async acceptAnswer(remoteAnswer: RTCSessionDescriptionInit): Promise<void> {
+        await this.pc.setRemoteDescription(remoteAnswer);
+    }
+
+    /**
+     * Send message over data channel (like WebSocket.send).
+     */
+    send(data: string): void {
+        if (!this.channel || this.channel.readyState !== 'open') {
+            // Queue message if channel not ready yet
+            this.pendingMessages.push(data);
+            return;
+        }
+
+        this.channel.send(data);
+    }
+
+    /**
+     * Set message handler (like WebSocket.onmessage).
+     */
+    onMessage(callback: (data: string) => void): void {
+        this.onMessageCallback = callback;
+    }
+
+    /**
+     * Set close handler (like WebSocket.onclose).
+     */
+    onClose(callback: () => void): void {
+        this.onCloseCallback = callback;
+    }
+
+    /**
+     * Close connection.
+     */
+    close(): void {
+        if (this.channel) {
+            this.channel.close();
+        }
+        this.pc.close();
+    }
+
+    /**
+     * Wait for channel to be open.
+     */
+    async waitForOpen(): Promise<void> {
+        if (this.channel?.readyState === 'open') {
+            return;
+        }
+
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(new Error(`WebRTC channel open timeout after ${this.connectionTimeout}ms`));
+            }, this.connectionTimeout);
+
+            const checkOpen = () => {
+                if (this.channel?.readyState === 'open') {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            // Poll every 100ms
+            const interval = setInterval(checkOpen, 100);
+            setTimeout(() => clearInterval(interval), this.connectionTimeout);
+        });
+    }
+
+    private setupDataChannel(channel: RTCDataChannel): void {
+        channel.onopen = () => {
+            log.debug(SEG.WS, '[WebRTC] Data channel opened');
+
+            // Flush pending messages
+            while (this.pendingMessages.length > 0) {
+                const msg = this.pendingMessages.shift()!;
+                channel.send(msg);
+            }
+        };
+
+        channel.onmessage = (event) => {
+            this.onMessageCallback?.(event.data);
+        };
+
+        channel.onclose = () => {
+            log.debug(SEG.WS, '[WebRTC] Data channel closed');
+            this.onCloseCallback?.();
+        };
+
+        channel.onerror = (error) => {
+            log.error(SEG.WS, '[WebRTC] Data channel error:', error);
+        };
+    }
+
+    private async waitForIceGathering(): Promise<void> {
+        // If already complete, return immediately
+        if (this.pc.iceGatheringState === 'complete') {
+            return;
+        }
+
+        return new Promise((resolve) => {
+            const timeout = setTimeout(() => {
+                log.warn(SEG.WS, '[WebRTC] ICE gathering timeout, proceeding with partial candidates');
+                resolve();
+            }, 5000); // 5 second timeout for ICE gathering
+
+            this.pc.onicegatheringstatechange = () => {
+                if (this.pc.iceGatheringState === 'complete') {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+        });
+    }
+}

--- a/web/ts/webrtc-peer.ts
+++ b/web/ts/webrtc-peer.ts
@@ -45,7 +45,7 @@ export class WebRTCPeer {
 
         // Log connection state changes
         this.pc.onconnectionstatechange = () => {
-            log.debug(SEG.WS, `[WebRTC] Connection state: ${this.pc.connectionState}`);
+            log.info(SEG.WS, `[WebRTC] Connection state: ${this.pc.connectionState}`);
 
             if (this.pc.connectionState === 'failed' || this.pc.connectionState === 'closed') {
                 this.onCloseCallback?.();
@@ -53,7 +53,19 @@ export class WebRTCPeer {
         };
 
         this.pc.oniceconnectionstatechange = () => {
-            log.debug(SEG.WS, `[WebRTC] ICE connection state: ${this.pc.iceConnectionState}`);
+            log.info(SEG.WS, `[WebRTC] ICE connection state: ${this.pc.iceConnectionState}`);
+        };
+
+        this.pc.onicegatheringstatechange = () => {
+            log.info(SEG.WS, `[WebRTC] ICE gathering state: ${this.pc.iceGatheringState}`);
+        };
+
+        this.pc.onicecandidate = (event) => {
+            if (event.candidate) {
+                log.debug(SEG.WS, `[WebRTC] ICE candidate: ${event.candidate.candidate}`);
+            } else {
+                log.info(SEG.WS, '[WebRTC] ICE gathering complete (null candidate)');
+            }
         };
     }
 


### PR DESCRIPTION
WebRTC P2P sync foundation with manual invite/answer exchange UI.

**Blocked: needs proper testing setup before merge.**

Localhost testing shows ICE connection failures — requires LAN or proper network testing environment to validate end-to-end flow. Once E2E works, consider feature flag for merge to main.

## What's Implemented
- WebRTC peer connection with data channels
- Merkle sync reconciliation over P2P (reuses server protocol)
- P2P sync window glyph with invite link UI
- Manual SDP offer/answer exchange (copy-paste)