### PR TITLE
Add qntx-imagegen plugin: local Stable Diffusion via ONNX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/qntx-proto",
     "crates/qntx-sqlite",
     "crates/qntx-wasm",
+    "qntx-imagegen",
     "qntx-python",
     "qntx-reduce",
     "web/src-tauri",

--- a/qntx-imagegen/Cargo.toml
+++ b/qntx-imagegen/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "qntx-imagegen-plugin"
+version = "0.1.0"
+edition.workspace = true
+description = "QNTX gRPC plugin for local Stable Diffusion image generation via ONNX Runtime"
+license.workspace = true
+authors = ["QNTX Contributors"]
+
+[[bin]]
+name = "qntx-imagegen-plugin"
+path = "src/main.rs"
+
+[dependencies]
+# QNTX gRPC infrastructure
+qntx-grpc = { path = "../crates/qntx-grpc", features = ["plugin"] }
+qntx-proto = { path = "../crates/qntx-proto" }
+
+# gRPC and async
+tonic.workspace = true
+prost.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+
+# ONNX Runtime for Stable Diffusion inference
+ort = { version = "2.0.0-rc.11", features = ["download-binaries", "copy-dylibs"] }
+ndarray = "0.16"
+
+# CLIP tokenizer
+tokenizers = "0.22.2"
+
+# Image encoding
+image = "0.25"
+
+# Random number generation for latent noise
+rand = "0.8"
+rand_distr = "0.4"
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Logging
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Utilities
+thiserror.workspace = true
+parking_lot.workspace = true
+sha2 = "0.10"

--- a/qntx-imagegen/TESTING.md
+++ b/qntx-imagegen/TESTING.md
@@ -1,0 +1,208 @@
+# qntx-imagegen Manual Testing
+
+## Model Setup (~4GB download)
+
+```bash
+brew install git-lfs
+git lfs install
+
+git clone --depth 1 --branch onnx \
+  https://huggingface.co/runwayml/stable-diffusion-v1-5 \
+  /tmp/sd15-onnx
+
+mkdir -p ~/.qntx/models/stable-diffusion-v1-5/{text_encoder,unet,vae_decoder,tokenizer}
+cp /tmp/sd15-onnx/text_encoder/model.onnx ~/.qntx/models/stable-diffusion-v1-5/text_encoder/
+cp /tmp/sd15-onnx/unet/model.onnx ~/.qntx/models/stable-diffusion-v1-5/unet/
+cp /tmp/sd15-onnx/vae_decoder/model.onnx ~/.qntx/models/stable-diffusion-v1-5/vae_decoder/
+cp /tmp/sd15-onnx/tokenizer/tokenizer.json ~/.qntx/models/stable-diffusion-v1-5/tokenizer/
+
+# Clean up clone
+rm -rf /tmp/sd15-onnx
+```
+
+Expected layout:
+```
+~/.qntx/models/stable-diffusion-v1-5/
+├── text_encoder/model.onnx     (~490MB)
+├── unet/model.onnx             (~3.4GB)
+├── vae_decoder/model.onnx      (~95MB)
+└── tokenizer/tokenizer.json    (~2MB)
+```
+
+## Start the Plugin
+
+Terminal 1:
+```bash
+cargo run -p qntx-imagegen-plugin -- --port 9876
+```
+
+Expected: `QNTX_PLUGIN_PORT=9876` on stdout, `Starting gRPC server on 0.0.0.0:9876` in logs.
+
+## Tests Without Models (skeleton verification)
+
+These work without downloading anything. Install `grpcurl` if needed: `brew install grpcurl`.
+
+### 1. Version flag
+```bash
+cargo run -p qntx-imagegen-plugin -- --version
+# Expect: qntx-imagegen-plugin 0.1.0
+```
+
+### 2. Metadata
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  localhost:9876 protocol.DomainPluginService/Metadata
+# Expect: name="imagegen", version="0.1.0"
+```
+
+### 3. Health (before init)
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  localhost:9876 protocol.DomainPluginService/Health
+# Expect: healthy=false, message="Not initialized"
+```
+
+### 4. Initialize
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"config":{}}' \
+  localhost:9876 protocol.DomainPluginService/Initialize
+# Expect: handler_names=["imagegen.generate"]
+# Logs warn about missing model files
+```
+
+### 5. Health (after init, no models)
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  localhost:9876 protocol.DomainPluginService/Health
+# Expect: healthy=true, pipeline_loaded=false
+```
+
+### 6. Models check
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"method":"POST","path":"/models/check"}' \
+  localhost:9876 protocol.DomainPluginService/HandleHTTP
+# Expect: JSON body with all_present=false, each file listed
+```
+
+### 7. Generate fails gracefully
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"handler_name":"imagegen.generate","job_id":"test-1","payload":"eyJwcm9tcHQiOiJhIGNhdCJ9"}' \
+  localhost:9876 protocol.DomainPluginService/ExecuteJob
+# Expect: success=false, error mentions missing models
+```
+
+### 8. Status endpoint
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"method":"GET","path":"/status"}' \
+  localhost:9876 protocol.DomainPluginService/HandleHTTP
+# Expect: initialized=true, pipeline_loaded=false, generating=false
+```
+
+### 9. Config schema
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  localhost:9876 protocol.DomainPluginService/ConfigSchema
+# Expect: 7 fields (models_dir, output_dir, num_inference_steps, etc.)
+```
+
+### 10. Unknown handler rejected
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"handler_name":"imagegen.bogus","job_id":"x","payload":"e30="}' \
+  localhost:9876 protocol.DomainPluginService/ExecuteJob
+# Expect: NOT_FOUND error
+```
+
+### 11. Port retry
+```bash
+# Start two instances on the same port:
+cargo run -p qntx-imagegen-plugin -- --port 9876 &
+cargo run -p qntx-imagegen-plugin -- --port 9876
+# Expect: second instance logs "Port 9876 in use, trying 9877"
+# and announces QNTX_PLUGIN_PORT=9877
+kill %1
+```
+
+## Tests With Models (full pipeline)
+
+Restart the plugin after placing models (or call Initialize again).
+
+### 12. Initialize loads pipeline
+```bash
+# Restart plugin, then:
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"config":{}}' \
+  localhost:9876 protocol.DomainPluginService/Initialize
+# Expect: logs show "Loading CLIP tokenizer...", "Loading UNet...", etc.
+# "Pipeline loaded successfully"
+```
+
+### 13. Health confirms pipeline
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  localhost:9876 protocol.DomainPluginService/Health
+# Expect: healthy=true, pipeline_loaded=true
+```
+
+### 14. Models check — all present
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"method":"POST","path":"/models/check"}' \
+  localhost:9876 protocol.DomainPluginService/HandleHTTP
+# Expect: all_present=true, each file with size_bytes
+```
+
+### 15. Generate an image via ExecuteJob
+```bash
+# payload: {"prompt":"a cat sitting on a mountain","steps":20,"seed":42}
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"handler_name":"imagegen.generate","job_id":"test-cat","payload":"eyJwcm9tcHQiOiJhIGNhdCBzaXR0aW5nIG9uIGEgbW91bnRhaW4iLCJzdGVwcyI6MjAsInNlZWQiOjQyfQ=="}' \
+  localhost:9876 protocol.DomainPluginService/ExecuteJob
+# Expect: success=true, result JSON with filename, sha256, duration_ms
+# Takes 30-120s on CPU
+# File at ~/.qntx/imagegen/output/test-cat.png
+open ~/.qntx/imagegen/output/test-cat.png
+```
+
+### 16. Generate via HTTP endpoint
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"method":"POST","path":"/generate","body":"eyJwcm9tcHQiOiJhIHN1bnNldCBvdmVyIHRoZSBvY2VhbiIsInN0ZXBzIjoxMCwic2VlZCI6MTIzfQ=="}' \
+  localhost:9876 protocol.DomainPluginService/HandleHTTP
+# Expect: status_code=200, JSON with filename and sha256
+```
+
+### 17. Serve generated image
+```bash
+# Use the filename from step 15
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"method":"GET","path":"/image/test-cat.png"}' \
+  localhost:9876 protocol.DomainPluginService/HandleHTTP
+# Expect: status_code=200, Content-Type=image/png
+```
+
+### 18. Path traversal rejected
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  -d '{"method":"GET","path":"/image/../../../etc/passwd"}' \
+  localhost:9876 protocol.DomainPluginService/HandleHTTP
+# Expect: 400 "Invalid filename"
+```
+
+### 19. Deterministic output (same seed = same image)
+```bash
+# Run step 15 twice with identical payload
+# Compare sha256 in both responses — should match
+```
+
+### 20. Shutdown
+```bash
+grpcurl -plaintext -import-path plugin/grpc/protocol -proto domain.proto \
+  localhost:9876 protocol.DomainPluginService/Shutdown
+# Expect: logs "Shutting down imagegen plugin"
+# Health now returns healthy=false
+```

--- a/qntx-imagegen/src/atsstore.rs
+++ b/qntx-imagegen/src/atsstore.rs
@@ -1,0 +1,173 @@
+//! ATSStore gRPC client for creating attestations on image generation completion.
+
+use crate::proto::{
+    ats_store_service_client::AtsStoreServiceClient, AttestationCommand,
+    GenerateAttestationRequest,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tonic::transport::Channel;
+use tracing::{error, info, warn};
+
+/// ATSStore client configuration
+#[derive(Debug, Clone)]
+pub struct AtsStoreConfig {
+    pub endpoint: String,
+    pub auth_token: String,
+}
+
+/// ATSStore client wrapper
+pub struct AtsStoreClient {
+    config: AtsStoreConfig,
+}
+
+impl AtsStoreClient {
+    pub fn new(config: AtsStoreConfig) -> Self {
+        Self { config }
+    }
+
+    /// Create an attestation for a generated image
+    pub fn attest(
+        &self,
+        subjects: Vec<String>,
+        predicates: Vec<String>,
+        contexts: Vec<String>,
+        actors: Vec<String>,
+        attributes: Option<HashMap<String, serde_json::Value>>,
+    ) -> Result<String, String> {
+        let endpoint = self.config.endpoint.clone();
+        let auth_token = self.config.auth_token.clone();
+
+        let attributes =
+            attributes.map(|attrs| qntx_proto::serde_struct::json_map_to_struct(&attrs));
+
+        let command = AttestationCommand {
+            subjects,
+            predicates,
+            contexts,
+            actors,
+            timestamp: None,
+            attributes,
+        };
+
+        let request = GenerateAttestationRequest {
+            auth_token,
+            command: Some(command),
+        };
+
+        // Spawn OS thread to avoid "runtime within runtime" error
+        let response = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| format!("failed to create runtime: {}", e))?;
+
+            rt.block_on(async {
+                let endpoint_uri =
+                    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+                        endpoint.clone()
+                    } else {
+                        format!("http://{}", endpoint)
+                    };
+
+                let channel = Channel::from_shared(endpoint_uri)
+                    .map_err(|e| format!("invalid endpoint: {}", e))?
+                    .connect()
+                    .await
+                    .map_err(|e| format!("connection to ATSStore failed: {}", e))?;
+
+                let mut client = AtsStoreServiceClient::new(channel);
+                client
+                    .generate_and_create_attestation(request)
+                    .await
+                    .map_err(|e| format!("gRPC error creating attestation: {}", e))
+            })
+        })
+        .join()
+        .map_err(|e| format!("attestation thread panicked: {:?}", e))??
+        .into_inner();
+
+        if !response.success {
+            return Err(format!("ATSStore returned error: {}", response.error));
+        }
+
+        let attestation = response
+            .attestation
+            .ok_or_else(|| "ATSStore returned success but no attestation".to_string())?;
+
+        info!("Created attestation for generated image: {}", attestation.id);
+        Ok(attestation.id)
+    }
+}
+
+/// Shared ATSStore client
+pub type SharedAtsStoreClient = Arc<parking_lot::Mutex<Option<AtsStoreClient>>>;
+
+/// Create a new shared ATSStore client (initially empty)
+pub fn new_shared_client() -> SharedAtsStoreClient {
+    Arc::new(parking_lot::Mutex::new(None))
+}
+
+/// Initialize the shared client with config
+pub fn init_shared_client(shared: &SharedAtsStoreClient, config: AtsStoreConfig) {
+    let mut guard = shared.lock();
+    *guard = Some(AtsStoreClient::new(config));
+}
+
+/// Create an attestation for a generated image (fire-and-forget).
+/// Logs warnings on failure but does not propagate errors.
+pub fn create_attestation(
+    client: &SharedAtsStoreClient,
+    sha256: &str,
+    prompt: &str,
+    steps: u32,
+    seed: u64,
+    duration_ms: u64,
+    output_path: &str,
+) {
+    let guard = client.lock();
+    let client = match guard.as_ref() {
+        Some(c) => c,
+        None => {
+            warn!("ATSStore client not initialized, skipping attestation");
+            return;
+        }
+    };
+
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "prompt".to_string(),
+        serde_json::Value::String(prompt.to_string()),
+    );
+    attrs.insert(
+        "model".to_string(),
+        serde_json::Value::String("stable-diffusion-v1-5".to_string()),
+    );
+    attrs.insert(
+        "steps".to_string(),
+        serde_json::json!(steps),
+    );
+    attrs.insert(
+        "seed".to_string(),
+        serde_json::json!(seed),
+    );
+    attrs.insert(
+        "duration_ms".to_string(),
+        serde_json::json!(duration_ms),
+    );
+    attrs.insert(
+        "output_path".to_string(),
+        serde_json::Value::String(output_path.to_string()),
+    );
+
+    match client.attest(
+        vec![format!("image:{}", sha256)],
+        vec!["generated".to_string()],
+        vec!["imagegen".to_string()],
+        vec!["imagegen-plugin".to_string()],
+        Some(attrs),
+    ) {
+        Ok(id) => info!("Attested generated image: {}", id),
+        Err(e) => error!("Failed to attest generated image: {}", e),
+    }
+}

--- a/qntx-imagegen/src/config.rs
+++ b/qntx-imagegen/src/config.rs
@@ -1,0 +1,209 @@
+//! Plugin configuration types
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Plugin configuration received during initialization
+#[derive(Debug, Clone, Default)]
+pub struct PluginConfig {
+    /// ATSStore gRPC endpoint
+    pub ats_store_endpoint: String,
+    /// Queue service gRPC endpoint
+    pub queue_endpoint: String,
+    /// Auth token for service calls
+    pub auth_token: String,
+    /// Custom configuration values
+    pub config: HashMap<String, String>,
+}
+
+/// Image generation configuration parsed from plugin config
+#[derive(Debug, Clone)]
+pub struct ImagegenConfig {
+    /// Path to model directory containing ONNX files
+    pub models_dir: PathBuf,
+    /// Output directory for generated images
+    pub output_dir: PathBuf,
+    /// Number of inference steps (default: 20)
+    pub num_inference_steps: u32,
+    /// Classifier-free guidance scale (default: 7.5)
+    pub guidance_scale: f32,
+    /// Output image width (default: 512)
+    pub image_width: u32,
+    /// Output image height (default: 512)
+    pub image_height: u32,
+    /// Number of ONNX inference threads (default: 4)
+    pub num_threads: usize,
+}
+
+impl Default for ImagegenConfig {
+    fn default() -> Self {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        Self {
+            models_dir: PathBuf::from(format!("{}/.qntx/models/stable-diffusion-v1-5", home)),
+            output_dir: PathBuf::from(format!("{}/.qntx/imagegen/output", home)),
+            num_inference_steps: 20,
+            guidance_scale: 7.5,
+            image_width: 512,
+            image_height: 512,
+            num_threads: 4,
+        }
+    }
+}
+
+impl ImagegenConfig {
+    /// Parse from plugin config map
+    pub fn from_config_map(config: &HashMap<String, String>) -> Self {
+        let mut result = Self::default();
+
+        if let Some(dir) = config.get("models_dir") {
+            result.models_dir = expand_home(dir);
+        }
+        if let Some(dir) = config.get("output_dir") {
+            result.output_dir = expand_home(dir);
+        }
+        if let Some(steps) = config.get("num_inference_steps") {
+            if let Ok(n) = steps.parse() {
+                result.num_inference_steps = n;
+            }
+        }
+        if let Some(scale) = config.get("guidance_scale") {
+            if let Ok(s) = scale.parse() {
+                result.guidance_scale = s;
+            }
+        }
+        if let Some(w) = config.get("image_width") {
+            if let Ok(n) = w.parse() {
+                result.image_width = n;
+            }
+        }
+        if let Some(h) = config.get("image_height") {
+            if let Ok(n) = h.parse() {
+                result.image_height = n;
+            }
+        }
+        if let Some(t) = config.get("num_threads") {
+            if let Ok(n) = t.parse() {
+                result.num_threads = n;
+            }
+        }
+
+        result
+    }
+}
+
+fn expand_home(path: &str) -> PathBuf {
+    if path.starts_with("~/") {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        PathBuf::from(path.replacen('~', &home, 1))
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+/// Build the configuration schema for the imagegen plugin
+pub fn build_schema() -> HashMap<String, crate::proto::ConfigFieldSchema> {
+    use crate::proto::ConfigFieldSchema;
+
+    let mut fields = HashMap::new();
+
+    fields.insert(
+        "models_dir".to_string(),
+        ConfigFieldSchema {
+            r#type: "string".to_string(),
+            description: "Path to directory containing Stable Diffusion ONNX model files"
+                .to_string(),
+            default_value: "~/.qntx/models/stable-diffusion-v1-5".to_string(),
+            required: false,
+            min_value: String::new(),
+            max_value: String::new(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields.insert(
+        "output_dir".to_string(),
+        ConfigFieldSchema {
+            r#type: "string".to_string(),
+            description: "Directory where generated images are saved".to_string(),
+            default_value: "~/.qntx/imagegen/output".to_string(),
+            required: false,
+            min_value: String::new(),
+            max_value: String::new(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields.insert(
+        "num_inference_steps".to_string(),
+        ConfigFieldSchema {
+            r#type: "number".to_string(),
+            description: "Number of denoising steps".to_string(),
+            default_value: "20".to_string(),
+            required: false,
+            min_value: "1".to_string(),
+            max_value: "100".to_string(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields.insert(
+        "guidance_scale".to_string(),
+        ConfigFieldSchema {
+            r#type: "number".to_string(),
+            description: "Classifier-free guidance scale".to_string(),
+            default_value: "7.5".to_string(),
+            required: false,
+            min_value: "1.0".to_string(),
+            max_value: "30.0".to_string(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields.insert(
+        "image_width".to_string(),
+        ConfigFieldSchema {
+            r#type: "number".to_string(),
+            description: "Output image width in pixels (must be divisible by 8)".to_string(),
+            default_value: "512".to_string(),
+            required: false,
+            min_value: "256".to_string(),
+            max_value: "1024".to_string(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields.insert(
+        "image_height".to_string(),
+        ConfigFieldSchema {
+            r#type: "number".to_string(),
+            description: "Output image height in pixels (must be divisible by 8)".to_string(),
+            default_value: "512".to_string(),
+            required: false,
+            min_value: "256".to_string(),
+            max_value: "1024".to_string(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields.insert(
+        "num_threads".to_string(),
+        ConfigFieldSchema {
+            r#type: "number".to_string(),
+            description: "Number of threads for ONNX Runtime inference".to_string(),
+            default_value: "4".to_string(),
+            required: false,
+            min_value: "1".to_string(),
+            max_value: "32".to_string(),
+            pattern: String::new(),
+            element_type: String::new(),
+        },
+    );
+
+    fields
+}

--- a/qntx-imagegen/src/handlers.rs
+++ b/qntx-imagegen/src/handlers.rs
@@ -1,0 +1,227 @@
+//! HTTP endpoint handlers for the imagegen plugin
+
+use crate::proto::{HttpHeader, HttpResponse};
+use crate::service::PluginState;
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::sync::Arc;
+use tonic::Status;
+
+/// Handler context providing access to plugin state
+pub struct HandlerContext {
+    pub(crate) state: Arc<RwLock<PluginState>>,
+}
+
+impl HandlerContext {
+    pub fn new(state: Arc<RwLock<PluginState>>) -> Self {
+        Self { state }
+    }
+
+    /// POST /generate — synchronous image generation (blocks until done)
+    pub async fn handle_generate(
+        &self,
+        body: serde_json::Value,
+    ) -> Result<HttpResponse, Status> {
+        #[derive(serde::Deserialize)]
+        struct GenerateRequest {
+            prompt: String,
+            #[serde(default)]
+            negative_prompt: Option<String>,
+            #[serde(default)]
+            steps: Option<u32>,
+            #[serde(default)]
+            guidance_scale: Option<f32>,
+            #[serde(default)]
+            seed: Option<u64>,
+            #[serde(default)]
+            width: Option<u32>,
+            #[serde(default)]
+            height: Option<u32>,
+        }
+
+        let req: GenerateRequest = serde_json::from_value(body)
+            .map_err(|e| Status::invalid_argument(format!("Invalid request: {}", e)))?;
+
+        if req.prompt.is_empty() {
+            return Err(Status::invalid_argument("Missing 'prompt' field"));
+        }
+
+        let (imagegen_config, has_pipeline) = {
+            let state = self.state.read();
+            (state.imagegen_config.clone(), state.pipeline.is_some())
+        };
+
+        if !has_pipeline {
+            return Err(Status::unavailable(format!(
+                "Pipeline not loaded — model files missing from '{}'",
+                imagegen_config.models_dir.display()
+            )));
+        }
+
+        // Mark as generating
+        {
+            let mut state = self.state.write();
+            state.generating = true;
+        }
+
+        let prompt = req.prompt.clone();
+        let negative_prompt = req.negative_prompt.unwrap_or_default();
+        let steps = req
+            .steps
+            .unwrap_or(imagegen_config.num_inference_steps);
+        let guidance_scale = req
+            .guidance_scale
+            .unwrap_or(imagegen_config.guidance_scale);
+        let seed = req.seed.unwrap_or(42);
+        let width = req.width.unwrap_or(imagegen_config.image_width);
+        let height = req.height.unwrap_or(imagegen_config.image_height);
+        let output_dir = imagegen_config.output_dir.clone();
+
+        let state_clone = self.state.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let start = std::time::Instant::now();
+
+            let generate_result = {
+                let state = state_clone.read();
+                let pipeline = state.pipeline.as_ref().unwrap();
+                pipeline.generate(
+                    &prompt,
+                    &negative_prompt,
+                    steps,
+                    guidance_scale,
+                    seed,
+                    width,
+                    height,
+                )
+            };
+
+            let duration_ms = start.elapsed().as_millis() as u64;
+
+            match generate_result {
+                Ok(image_data) => {
+                    use sha2::{Digest, Sha256};
+                    let mut hasher = Sha256::new();
+                    hasher.update(&image_data);
+                    let hash = format!("{:x}", hasher.finalize());
+
+                    let filename = format!("{}.png", hash[..16].to_string());
+                    let output_path = output_dir.join(&filename);
+                    if let Err(e) = std::fs::write(&output_path, &image_data) {
+                        return Err(format!(
+                            "Failed to write image to '{}': {}",
+                            output_path.display(),
+                            e
+                        ));
+                    }
+
+                    Ok(serde_json::json!({
+                        "filename": filename,
+                        "output_path": output_path.display().to_string(),
+                        "sha256": hash,
+                        "duration_ms": duration_ms,
+                        "width": width,
+                        "height": height,
+                        "steps": steps,
+                        "guidance_scale": guidance_scale,
+                        "seed": seed,
+                    }))
+                }
+                Err(e) => Err(e),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| Err(format!("Generation task panicked: {:?}", e)));
+
+        // Clear generating flag
+        {
+            let mut state = self.state.write();
+            state.generating = false;
+        }
+
+        match result {
+            Ok(result_json) => json_response(200, &result_json),
+            Err(e) => Err(Status::internal(e)),
+        }
+    }
+
+    /// GET /status — pipeline state
+    pub async fn handle_status(&self) -> Result<HttpResponse, Status> {
+        let state = self.state.read();
+
+        #[derive(Serialize)]
+        struct StatusResponse {
+            initialized: bool,
+            pipeline_loaded: bool,
+            generating: bool,
+            models_dir: String,
+            output_dir: String,
+        }
+
+        let response = StatusResponse {
+            initialized: state.initialized,
+            pipeline_loaded: state.pipeline.is_some(),
+            generating: state.generating,
+            models_dir: state.imagegen_config.models_dir.display().to_string(),
+            output_dir: state.imagegen_config.output_dir.display().to_string(),
+        };
+
+        json_response(200, &response)
+    }
+
+    /// POST /models/check — report model file presence
+    pub async fn handle_models_check(&self) -> Result<HttpResponse, Status> {
+        let state = self.state.read();
+        let result = crate::models::check_models(&state.imagegen_config.models_dir);
+        json_response(200, &result)
+    }
+
+    /// GET /image/{filename} — serve generated PNG
+    pub async fn handle_serve_image(&self, filename: &str) -> Result<HttpResponse, Status> {
+        // Sanitize filename to prevent path traversal
+        if filename.contains("..") || filename.contains('/') || filename.contains('\\') {
+            return Err(Status::invalid_argument("Invalid filename"));
+        }
+
+        let state = self.state.read();
+        let image_path = state.imagegen_config.output_dir.join(filename);
+
+        let data = std::fs::read(&image_path).map_err(|e| {
+            Status::not_found(format!(
+                "Image '{}' not found: {}",
+                image_path.display(),
+                e
+            ))
+        })?;
+
+        Ok(HttpResponse {
+            status_code: 200,
+            headers: vec![
+                HttpHeader {
+                    name: "Content-Type".to_string(),
+                    values: vec!["image/png".to_string()],
+                },
+                HttpHeader {
+                    name: "Content-Length".to_string(),
+                    values: vec![data.len().to_string()],
+                },
+            ],
+            body: data,
+        })
+    }
+}
+
+/// Create a JSON HTTP response
+fn json_response<T: Serialize>(status_code: i32, data: &T) -> Result<HttpResponse, Status> {
+    let body = serde_json::to_vec(data)
+        .map_err(|e| Status::internal(format!("Failed to serialize response: {}", e)))?;
+
+    Ok(HttpResponse {
+        status_code,
+        headers: vec![HttpHeader {
+            name: "Content-Type".to_string(),
+            values: vec!["application/json".to_string()],
+        }],
+        body,
+    })
+}

--- a/qntx-imagegen/src/lib.rs
+++ b/qntx-imagegen/src/lib.rs
@@ -1,0 +1,15 @@
+//! QNTX Image Generation Plugin
+//!
+//! A gRPC plugin that runs Stable Diffusion 1.5 inference via ONNX Runtime.
+//! Local-first image generation — no cloud dependency.
+
+pub mod atsstore;
+pub mod config;
+mod handlers;
+pub mod models;
+pub mod pipeline;
+pub mod proto;
+pub mod service;
+
+pub use config::PluginConfig;
+pub use service::ImagegenPluginService;

--- a/qntx-imagegen/src/main.rs
+++ b/qntx-imagegen/src/main.rs
@@ -1,0 +1,166 @@
+//! QNTX Imagegen Plugin - Main Entry Point
+//!
+//! A gRPC plugin that runs Stable Diffusion 1.5 via ONNX Runtime.
+//!
+//! Usage:
+//!     qntx-imagegen-plugin --port 9000
+//!     qntx-imagegen-plugin --address localhost:9000
+
+use clap::Parser;
+use qntx_imagegen_plugin::proto::domain_plugin_service_server::DomainPluginServiceServer;
+use qntx_imagegen_plugin::ImagegenPluginService;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::signal;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+use tracing::{info, warn, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[derive(Parser, Debug)]
+#[command(name = "qntx-imagegen-plugin")]
+#[command(about = "QNTX image generation plugin (Stable Diffusion via ONNX)")]
+#[command(version)]
+struct Args {
+    /// gRPC server port
+    #[arg(short, long, default_value = "9000")]
+    port: u16,
+
+    /// gRPC server address (overrides port)
+    #[arg(short, long)]
+    address: Option<String>,
+
+    /// Log level (debug, info, warn, error)
+    #[arg(long, default_value = "info")]
+    log_level: String,
+}
+
+/// Max port retries when the requested port is occupied (multi-session conflicts).
+const MAX_PORT_RETRIES: u16 = 10;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Set up panic hook to log panics before they terminate the process
+    std::panic::set_hook(Box::new(|panic_info| {
+        eprintln!("PANIC: Plugin panicked during startup or execution");
+        eprintln!(
+            "  Location: {}",
+            panic_info
+                .location()
+                .map(|l| l.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        );
+        eprintln!(
+            "  Message: {}",
+            panic_info
+                .payload()
+                .downcast_ref::<&str>()
+                .unwrap_or(&"<no message>")
+        );
+    }));
+
+    let args = Args::parse();
+
+    // Set up logging
+    let log_level = match args.log_level.as_str() {
+        "debug" => Level::DEBUG,
+        "warn" => Level::WARN,
+        "error" => Level::ERROR,
+        _ => Level::INFO,
+    };
+
+    FmtSubscriber::builder()
+        .with_max_level(log_level)
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_file(false)
+        .with_line_number(false)
+        .init();
+
+    info!("Initializing QNTX Imagegen Plugin");
+    info!("  Version: {}", env!("CARGO_PKG_VERSION"));
+
+    // Bind with port retry to handle multi-session port conflicts.
+    let listener = if let Some(address) = args.address {
+        let addr: SocketAddr = address
+            .parse()
+            .map_err(|e| format!("Invalid address '{}': {}", address, e))?;
+        TcpListener::bind(addr).await?
+    } else {
+        let mut port = args.port;
+        let mut last_err = None;
+        let mut bound = None;
+        for _ in 0..MAX_PORT_RETRIES {
+            let addr: SocketAddr = format!("0.0.0.0:{}", port).parse()?;
+            match TcpListener::bind(addr).await {
+                Ok(l) => {
+                    bound = Some(l);
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                    warn!("Port {} in use, trying {}", port, port + 1);
+                    last_err = Some(e);
+                    port += 1;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        bound.ok_or_else(|| {
+            format!(
+                "failed to bind after {} attempts (last port {}): {}",
+                MAX_PORT_RETRIES,
+                port,
+                last_err.unwrap()
+            )
+        })?
+    };
+
+    let local_addr = listener.local_addr()?;
+
+    // Announce actual port to the plugin manager via stdout protocol.
+    println!("QNTX_PLUGIN_PORT={}", local_addr.port());
+
+    // Create the imagegen plugin service
+    info!("Creating imagegen plugin service...");
+    let service = ImagegenPluginService::new();
+    info!("Imagegen plugin service created");
+
+    info!("Starting gRPC server on {}", local_addr);
+
+    let incoming = TcpListenerStream::new(listener);
+    Server::builder()
+        .add_service(DomainPluginServiceServer::new(service))
+        .serve_with_incoming_shutdown(incoming, shutdown_signal())
+        .await?;
+
+    info!("Plugin shutdown complete");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("Failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {
+            info!("Received Ctrl+C, shutting down");
+        }
+        _ = terminate => {
+            info!("Received terminate signal, shutting down");
+        }
+    }
+}

--- a/qntx-imagegen/src/models.rs
+++ b/qntx-imagegen/src/models.rs
@@ -1,0 +1,69 @@
+//! Model file verification
+
+use std::path::{Path, PathBuf};
+
+/// Expected model files within the models directory
+const EXPECTED_FILES: &[&str] = &[
+    "text_encoder/model.onnx",
+    "unet/model.onnx",
+    "vae_decoder/model.onnx",
+    "tokenizer/tokenizer.json",
+];
+
+/// Result of checking model file presence
+#[derive(Debug, serde::Serialize)]
+pub struct ModelCheckResult {
+    pub models_dir: String,
+    pub all_present: bool,
+    pub files: Vec<ModelFileStatus>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct ModelFileStatus {
+    pub path: String,
+    pub present: bool,
+    pub size_bytes: Option<u64>,
+}
+
+/// Check if all required model files are present in the models directory
+pub fn check_models(models_dir: &Path) -> ModelCheckResult {
+    let mut files = Vec::new();
+    let mut all_present = true;
+
+    for &relative_path in EXPECTED_FILES {
+        let full_path = models_dir.join(relative_path);
+        let present = full_path.exists();
+        let size_bytes = if present {
+            std::fs::metadata(&full_path).ok().map(|m| m.len())
+        } else {
+            None
+        };
+
+        if !present {
+            all_present = false;
+        }
+
+        files.push(ModelFileStatus {
+            path: relative_path.to_string(),
+            present,
+            size_bytes,
+        });
+    }
+
+    ModelCheckResult {
+        models_dir: models_dir.display().to_string(),
+        all_present,
+        files,
+    }
+}
+
+/// Get the path to a specific model file
+pub fn model_path(models_dir: &Path, component: &str) -> PathBuf {
+    match component {
+        "text_encoder" => models_dir.join("text_encoder/model.onnx"),
+        "unet" => models_dir.join("unet/model.onnx"),
+        "vae_decoder" => models_dir.join("vae_decoder/model.onnx"),
+        "tokenizer" => models_dir.join("tokenizer/tokenizer.json"),
+        _ => models_dir.join(component),
+    }
+}

--- a/qntx-imagegen/src/pipeline/clip.rs
+++ b/qntx-imagegen/src/pipeline/clip.rs
@@ -1,0 +1,69 @@
+//! CLIP text encoder — converts token IDs to text embeddings via ONNX
+
+use ndarray::Array3;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::Value;
+use parking_lot::Mutex;
+use std::path::Path;
+
+/// CLIP text encoder ONNX session
+pub struct ClipEncoder {
+    session: Mutex<Session>,
+}
+
+impl ClipEncoder {
+    /// Load CLIP text encoder from ONNX model file
+    pub fn load(model_path: impl AsRef<Path>, num_threads: usize) -> Result<Self, String> {
+        let path = model_path.as_ref();
+        let session = Session::builder()
+            .map_err(|e| format!("Failed to create ONNX session builder: {}", e))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| format!("Failed to set optimization level: {}", e))?
+            .with_intra_threads(num_threads)
+            .map_err(|e| format!("Failed to set thread count: {}", e))?
+            .commit_from_file(path)
+            .map_err(|e| format!("Failed to load CLIP model from '{}': {}", path.display(), e))?;
+
+        Ok(Self {
+            session: Mutex::new(session),
+        })
+    }
+
+    /// Encode token IDs to text embeddings.
+    ///
+    /// # Arguments
+    /// * `input_ids` - Token IDs [1, 77]
+    ///
+    /// # Returns
+    /// Text embeddings as [1, 77, 768]
+    pub fn encode(&self, input_ids: &[i64]) -> Result<Array3<f32>, String> {
+        let seq_len = input_ids.len();
+        let shape = vec![1i64, seq_len as i64];
+
+        let input_value = Value::from_array((shape.as_slice(), input_ids.to_vec()))
+            .map_err(|e| format!("Failed to create input tensor: {}", e))?;
+
+        let mut session = self.session.lock();
+        let outputs = session
+            .run(ort::inputs![input_value])
+            .map_err(|e| format!("CLIP inference failed: {}", e))?;
+
+        // Output shape: [1, 77, 768]
+        let (out_shape, data) = outputs[0]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("Failed to extract CLIP output tensor: {}", e))?;
+
+        let shape_vec: Vec<usize> = out_shape.iter().map(|&x| x as usize).collect();
+        if shape_vec.len() != 3 {
+            return Err(format!(
+                "Expected 3D CLIP output, got {}D: {:?}",
+                shape_vec.len(),
+                shape_vec
+            ));
+        }
+
+        Array3::from_shape_vec((shape_vec[0], shape_vec[1], shape_vec[2]), data.to_vec())
+            .map_err(|e| format!("Failed to reshape CLIP output: {}", e))
+    }
+}

--- a/qntx-imagegen/src/pipeline/mod.rs
+++ b/qntx-imagegen/src/pipeline/mod.rs
@@ -1,0 +1,223 @@
+//! Stable Diffusion 1.5 diffusion pipeline
+//!
+//! Orchestrates CLIP tokenizer, CLIP text encoder, UNet, DDIM scheduler,
+//! and VAE decoder to generate images from text prompts.
+
+mod clip;
+mod scheduler;
+mod tokenizer;
+mod unet;
+mod vae;
+
+use crate::config::ImagegenConfig;
+use crate::models;
+use clip::ClipEncoder;
+use scheduler::DdimScheduler;
+use tokenizer::ClipTokenizer;
+use unet::UNet;
+use vae::VaeDecoder;
+
+use ndarray::{Array3, Array4};
+use rand::SeedableRng;
+use rand_distr::{Distribution, StandardNormal};
+use tracing::info;
+
+/// Maximum CLIP sequence length
+const MAX_SEQ_LEN: usize = 77;
+
+/// CLIP embedding dimension for SD 1.5
+const CLIP_HIDDEN_DIM: usize = 768;
+
+/// Full Stable Diffusion pipeline
+pub struct DiffusionPipeline {
+    tokenizer: ClipTokenizer,
+    text_encoder: ClipEncoder,
+    unet: UNet,
+    vae_decoder: VaeDecoder,
+}
+
+// ONNX sessions are thread-safe behind Mutex
+unsafe impl Send for DiffusionPipeline {}
+unsafe impl Sync for DiffusionPipeline {}
+
+impl DiffusionPipeline {
+    /// Load all pipeline components from the model directory.
+    pub fn load(config: &ImagegenConfig) -> Result<Self, String> {
+        let models_dir = &config.models_dir;
+        let threads = config.num_threads;
+
+        info!("Loading CLIP tokenizer...");
+        let tokenizer_path = models::model_path(models_dir, "tokenizer");
+        let tokenizer = ClipTokenizer::from_file(&tokenizer_path, MAX_SEQ_LEN)?;
+
+        info!("Loading CLIP text encoder...");
+        let text_encoder_path = models::model_path(models_dir, "text_encoder");
+        let text_encoder = ClipEncoder::load(&text_encoder_path, threads)?;
+
+        info!("Loading UNet...");
+        let unet_path = models::model_path(models_dir, "unet");
+        let unet = UNet::load(&unet_path, threads)?;
+
+        info!("Loading VAE decoder...");
+        let vae_path = models::model_path(models_dir, "vae_decoder");
+        let vae_decoder = VaeDecoder::load(&vae_path, threads)?;
+
+        info!("Pipeline loaded successfully");
+        Ok(Self {
+            tokenizer,
+            text_encoder,
+            unet,
+            vae_decoder,
+        })
+    }
+
+    /// Generate an image from a text prompt.
+    ///
+    /// Returns PNG-encoded image bytes.
+    #[allow(clippy::too_many_arguments)]
+    pub fn generate(
+        &self,
+        prompt: &str,
+        negative_prompt: &str,
+        num_inference_steps: u32,
+        guidance_scale: f32,
+        seed: u64,
+        width: u32,
+        height: u32,
+    ) -> Result<Vec<u8>, String> {
+        let latent_h = (height / 8) as usize;
+        let latent_w = (width / 8) as usize;
+
+        // 1. Tokenize prompt and negative prompt
+        info!("Tokenizing prompt...");
+        let (prompt_ids, _) = self.tokenizer.encode(prompt)?;
+        let (neg_ids, _) = self.tokenizer.encode(if negative_prompt.is_empty() {
+            ""
+        } else {
+            negative_prompt
+        })?;
+
+        // 2. Text encode — get embeddings for both prompts
+        info!("Encoding text...");
+        let prompt_embeds = self.text_encoder.encode(&prompt_ids)?;
+        let neg_embeds = self.text_encoder.encode(&neg_ids)?;
+
+        // Concatenate [negative, positive] for classifier-free guidance → [2, 77, 768]
+        let text_embeddings = concat_embeddings(&neg_embeds, &prompt_embeds)?;
+
+        // 3. Initialize latents with Gaussian noise
+        info!("Initializing latents (seed={})...", seed);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let latent_size = 4 * latent_h * latent_w;
+        let mut latents: Vec<f32> = (0..latent_size)
+            .map(|_| StandardNormal.sample(&mut rng))
+            .collect();
+
+        // 4. Set up scheduler
+        let mut scheduler = DdimScheduler::new(1000);
+        scheduler.set_timesteps(num_inference_steps);
+
+        let latent_shape = [1i64, 4, latent_h as i64, latent_w as i64];
+        let encoder_shape = [2i64, MAX_SEQ_LEN as i64, CLIP_HIDDEN_DIM as i64];
+        let text_embed_flat: Vec<f32> = text_embeddings.iter().cloned().collect();
+
+        // 5. Denoising loop
+        let timesteps = scheduler.timesteps().to_vec();
+        for (step_idx, &timestep) in timesteps.iter().enumerate() {
+            info!(
+                "Denoising step {}/{} (timestep={})",
+                step_idx + 1,
+                num_inference_steps,
+                timestep
+            );
+
+            // UNet predicts noise for [uncond, cond] batch
+            let noise_pred_batch = self.unet.predict_noise(
+                &latents,
+                &latent_shape,
+                timestep as f32,
+                &text_embed_flat,
+                &encoder_shape,
+            )?;
+
+            // Apply classifier-free guidance
+            let noise_pred =
+                apply_cfg(&noise_pred_batch, guidance_scale, latent_size);
+
+            // Scheduler step
+            latents = scheduler.step(&noise_pred, timestep, &latents);
+        }
+
+        // 6. VAE decode
+        info!("Decoding latents to image...");
+        let (pixels, pixel_shape) = self.vae_decoder.decode(&latents, &latent_shape)?;
+
+        // 7. Convert to PNG
+        info!("Encoding PNG...");
+        let png_data = pixels_to_png(&pixels, &pixel_shape)?;
+
+        info!(
+            "Image generated: {}x{}, {} bytes",
+            width,
+            height,
+            png_data.len()
+        );
+        Ok(png_data)
+    }
+}
+
+/// Concatenate two [1, 77, 768] embeddings into [2, 77, 768]
+fn concat_embeddings(a: &Array3<f32>, b: &Array3<f32>) -> Result<Array3<f32>, String> {
+    ndarray::concatenate(ndarray::Axis(0), &[a.view(), b.view()])
+        .map_err(|e| format!("Failed to concatenate embeddings: {}", e))
+}
+
+/// Apply classifier-free guidance to the batched noise prediction.
+/// noise_pred_batch is [2, 4, H, W] where [0] is uncond and [1] is cond.
+fn apply_cfg(noise_pred_batch: &Array4<f32>, guidance_scale: f32, latent_size: usize) -> Vec<f32> {
+    let flat = noise_pred_batch.as_slice().unwrap_or(&[]);
+    let mut result = Vec::with_capacity(latent_size);
+
+    for i in 0..latent_size {
+        let uncond = flat[i];
+        let cond = flat[latent_size + i];
+        result.push(uncond + guidance_scale * (cond - uncond));
+    }
+
+    result
+}
+
+/// Convert CHW float pixels to PNG bytes
+fn pixels_to_png(pixels: &[f32], shape: &[usize]) -> Result<Vec<u8>, String> {
+    // shape = [1, 3, H, W]
+    if shape.len() != 4 || shape[0] != 1 || shape[1] != 3 {
+        return Err(format!("Unexpected pixel shape: {:?}", shape));
+    }
+
+    let height = shape[2] as u32;
+    let width = shape[3] as u32;
+    let hw = (height * width) as usize;
+
+    // Convert CHW to RGB8
+    let mut rgb = vec![0u8; hw * 3];
+    for i in 0..hw {
+        // Clamp to [0, 1] and convert to u8
+        let r = ((pixels[i].clamp(-1.0, 1.0) + 1.0) / 2.0 * 255.0) as u8;
+        let g = ((pixels[hw + i].clamp(-1.0, 1.0) + 1.0) / 2.0 * 255.0) as u8;
+        let b = ((pixels[2 * hw + i].clamp(-1.0, 1.0) + 1.0) / 2.0 * 255.0) as u8;
+        rgb[i * 3] = r;
+        rgb[i * 3 + 1] = g;
+        rgb[i * 3 + 2] = b;
+    }
+
+    // Encode as PNG
+    let img = image::RgbImage::from_raw(width, height, rgb)
+        .ok_or_else(|| "Failed to create image buffer".to_string())?;
+
+    let mut png_data = Vec::new();
+    let mut cursor = std::io::Cursor::new(&mut png_data);
+    img.write_to(&mut cursor, image::ImageFormat::Png)
+        .map_err(|e| format!("PNG encoding failed: {}", e))?;
+
+    Ok(png_data)
+}

--- a/qntx-imagegen/src/pipeline/scheduler.rs
+++ b/qntx-imagegen/src/pipeline/scheduler.rs
@@ -1,0 +1,155 @@
+//! DDIM scheduler — pure math, no ML dependencies
+//!
+//! Implements the Denoising Diffusion Implicit Models (DDIM) scheduler
+//! for the Stable Diffusion denoising loop.
+
+/// DDIM scheduler state
+pub struct DdimScheduler {
+    /// Total training timesteps (typically 1000)
+    num_train_timesteps: usize,
+    /// Cumulative product of alphas (noise schedule)
+    alphas_cumprod: Vec<f64>,
+    /// Timesteps for the current inference run
+    timesteps: Vec<usize>,
+}
+
+impl DdimScheduler {
+    /// Create a new DDIM scheduler with the SD 1.5 noise schedule.
+    ///
+    /// Uses a scaled linear beta schedule from beta_start=0.00085 to beta_end=0.012
+    /// over 1000 training timesteps.
+    pub fn new(num_train_timesteps: usize) -> Self {
+        let beta_start: f64 = 0.00085_f64.sqrt();
+        let beta_end: f64 = 0.012_f64.sqrt();
+
+        // Scaled linear schedule: betas = linspace(sqrt(beta_start), sqrt(beta_end), T)^2
+        let mut betas = Vec::with_capacity(num_train_timesteps);
+        for i in 0..num_train_timesteps {
+            let t = i as f64 / (num_train_timesteps - 1) as f64;
+            let beta_sqrt = beta_start + t * (beta_end - beta_start);
+            betas.push(beta_sqrt * beta_sqrt);
+        }
+
+        // alphas = 1 - betas
+        // alphas_cumprod = cumulative product of alphas
+        let mut alphas_cumprod = Vec::with_capacity(num_train_timesteps);
+        let mut cumprod = 1.0;
+        for beta in &betas {
+            cumprod *= 1.0 - beta;
+            alphas_cumprod.push(cumprod);
+        }
+
+        Self {
+            num_train_timesteps,
+            alphas_cumprod,
+            timesteps: Vec::new(),
+        }
+    }
+
+    /// Set the number of inference steps and compute the timestep schedule.
+    ///
+    /// Timesteps are evenly spaced across the training schedule.
+    pub fn set_timesteps(&mut self, num_inference_steps: u32) {
+        let step_ratio = self.num_train_timesteps / num_inference_steps as usize;
+        self.timesteps = (0..num_inference_steps as usize)
+            .rev()
+            .map(|i| i * step_ratio)
+            .collect();
+    }
+
+    /// Get the timestep schedule
+    pub fn timesteps(&self) -> &[usize] {
+        &self.timesteps
+    }
+
+    /// Perform a single DDIM step.
+    ///
+    /// # Arguments
+    /// * `noise_pred` - Predicted noise from UNet [N elements]
+    /// * `timestep` - Current timestep
+    /// * `sample` - Current noisy sample [N elements]
+    ///
+    /// # Returns
+    /// Denoised sample for the next step [N elements]
+    pub fn step(
+        &self,
+        noise_pred: &[f32],
+        timestep: usize,
+        sample: &[f32],
+    ) -> Vec<f32> {
+        let alpha_prod_t = self.alphas_cumprod[timestep];
+
+        // Previous timestep (or 0 if this is the last step)
+        let timestep_idx = self.timesteps.iter().position(|&t| t == timestep);
+        let prev_timestep = match timestep_idx {
+            Some(idx) if idx + 1 < self.timesteps.len() => self.timesteps[idx + 1],
+            _ => 0,
+        };
+        let alpha_prod_t_prev = if prev_timestep > 0 {
+            self.alphas_cumprod[prev_timestep]
+        } else {
+            1.0 // Final alpha
+        };
+
+        // DDIM formula:
+        // pred_x0 = (sample - sqrt(1 - alpha_t) * noise_pred) / sqrt(alpha_t)
+        // prev_sample = sqrt(alpha_t_prev) * pred_x0 + sqrt(1 - alpha_t_prev) * noise_pred
+        let sqrt_alpha_t = (alpha_prod_t as f32).sqrt();
+        let sqrt_one_minus_alpha_t = ((1.0 - alpha_prod_t) as f32).sqrt();
+        let sqrt_alpha_t_prev = (alpha_prod_t_prev as f32).sqrt();
+        let sqrt_one_minus_alpha_t_prev = ((1.0 - alpha_prod_t_prev) as f32).sqrt();
+
+        let mut result = Vec::with_capacity(sample.len());
+        for i in 0..sample.len() {
+            // Predict original sample (x0)
+            let pred_x0 = (sample[i] - sqrt_one_minus_alpha_t * noise_pred[i]) / sqrt_alpha_t;
+
+            // Compute previous sample
+            let prev_sample =
+                sqrt_alpha_t_prev * pred_x0 + sqrt_one_minus_alpha_t_prev * noise_pred[i];
+            result.push(prev_sample);
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scheduler_creation() {
+        let scheduler = DdimScheduler::new(1000);
+        assert_eq!(scheduler.alphas_cumprod.len(), 1000);
+        // First alpha_cumprod should be close to 1
+        assert!(scheduler.alphas_cumprod[0] > 0.99);
+        // Last should be much smaller
+        assert!(scheduler.alphas_cumprod[999] < 0.01);
+    }
+
+    #[test]
+    fn test_set_timesteps() {
+        let mut scheduler = DdimScheduler::new(1000);
+        scheduler.set_timesteps(20);
+        assert_eq!(scheduler.timesteps().len(), 20);
+        // First timestep should be the largest
+        assert_eq!(scheduler.timesteps()[0], 950);
+        // Last timestep should be 0
+        assert_eq!(scheduler.timesteps()[19], 0);
+    }
+
+    #[test]
+    fn test_step_reduces_noise() {
+        let scheduler = DdimScheduler::new(1000);
+        let sample = vec![1.0f32; 16];
+        let noise = vec![0.5f32; 16];
+
+        // Step at a high timestep should produce finite values
+        let result = scheduler.step(&noise, 500, &sample);
+        assert_eq!(result.len(), 16);
+        for val in &result {
+            assert!(val.is_finite());
+        }
+    }
+}

--- a/qntx-imagegen/src/pipeline/tokenizer.rs
+++ b/qntx-imagegen/src/pipeline/tokenizer.rs
@@ -1,0 +1,51 @@
+//! CLIP BPE tokenizer wrapper using the `tokenizers` crate
+
+use std::path::Path;
+
+/// CLIP tokenizer for text-to-token conversion
+pub struct ClipTokenizer {
+    tokenizer: tokenizers::Tokenizer,
+    max_length: usize,
+}
+
+impl ClipTokenizer {
+    /// Load CLIP tokenizer from a tokenizer.json file
+    pub fn from_file(path: impl AsRef<Path>, max_length: usize) -> Result<Self, String> {
+        let path = path.as_ref();
+        let tokenizer = tokenizers::Tokenizer::from_file(path)
+            .map_err(|e| format!("Failed to load tokenizer from '{}': {}", path.display(), e))?;
+
+        Ok(Self {
+            tokenizer,
+            max_length,
+        })
+    }
+
+    /// Encode text to token IDs with padding/truncation to max_length.
+    /// Returns (input_ids, attention_mask) each of shape [1, max_length].
+    pub fn encode(&self, text: &str) -> Result<(Vec<i64>, Vec<i64>), String> {
+        let encoding = self
+            .tokenizer
+            .encode(text, true)
+            .map_err(|e| format!("Tokenization failed: {}", e))?;
+
+        let ids = encoding.get_ids();
+
+        // Pad or truncate to max_length
+        let mut input_ids = vec![0i64; self.max_length];
+        let mut attention_mask = vec![0i64; self.max_length];
+
+        let len = ids.len().min(self.max_length);
+        for i in 0..len {
+            input_ids[i] = ids[i] as i64;
+            attention_mask[i] = 1;
+        }
+
+        // CLIP uses 49407 as EOS token. If truncated, force EOS at end.
+        if ids.len() > self.max_length {
+            input_ids[self.max_length - 1] = 49407;
+        }
+
+        Ok((input_ids, attention_mask))
+    }
+}

--- a/qntx-imagegen/src/pipeline/unet.rs
+++ b/qntx-imagegen/src/pipeline/unet.rs
@@ -1,0 +1,96 @@
+//! UNet denoising model — single DDIM step via ONNX
+
+use ndarray::Array4;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::Value;
+use parking_lot::Mutex;
+use std::path::Path;
+
+/// UNet ONNX session for denoising
+pub struct UNet {
+    session: Mutex<Session>,
+}
+
+impl UNet {
+    /// Load UNet from ONNX model file
+    pub fn load(model_path: impl AsRef<Path>, num_threads: usize) -> Result<Self, String> {
+        let path = model_path.as_ref();
+        let session = Session::builder()
+            .map_err(|e| format!("Failed to create ONNX session builder: {}", e))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| format!("Failed to set optimization level: {}", e))?
+            .with_intra_threads(num_threads)
+            .map_err(|e| format!("Failed to set thread count: {}", e))?
+            .commit_from_file(path)
+            .map_err(|e| format!("Failed to load UNet model from '{}': {}", path.display(), e))?;
+
+        Ok(Self {
+            session: Mutex::new(session),
+        })
+    }
+
+    /// Run a single denoising step.
+    ///
+    /// # Arguments
+    /// * `latent` - Noisy latent [1, 4, H/8, W/8]
+    /// * `timestep` - Current timestep (scalar)
+    /// * `encoder_hidden_states` - Text embeddings [2, 77, 768] (for classifier-free guidance)
+    ///
+    /// # Returns
+    /// Noise prediction [1, 4, H/8, W/8]
+    pub fn predict_noise(
+        &self,
+        latent: &[f32],
+        latent_shape: &[i64],
+        timestep: f32,
+        encoder_hidden_states: &[f32],
+        encoder_shape: &[i64],
+    ) -> Result<Array4<f32>, String> {
+        // Duplicate latent for classifier-free guidance: [2, 4, H/8, W/8]
+        let batch_latent: Vec<f32> = [latent, latent].concat();
+        let batch_shape = vec![2, latent_shape[1], latent_shape[2], latent_shape[3]];
+
+        let sample = Value::from_array((batch_shape.as_slice(), batch_latent))
+            .map_err(|e| format!("Failed to create latent tensor: {}", e))?;
+
+        // Timestep as [1] tensor
+        let timestep_value = Value::from_array(([1i64].as_slice(), vec![timestep as i64]))
+            .map_err(|e| format!("Failed to create timestep tensor: {}", e))?;
+
+        let encoder_hs =
+            Value::from_array((encoder_shape, encoder_hidden_states.to_vec()))
+                .map_err(|e| format!("Failed to create encoder hidden states tensor: {}", e))?;
+
+        let mut session = self.session.lock();
+
+        // SD 1.5 ONNX expects inputs: sample, timestep, encoder_hidden_states
+        let outputs = session
+            .run(ort::inputs![
+                "sample" => sample,
+                "timestep" => timestep_value,
+                "encoder_hidden_states" => encoder_hs
+            ])
+            .map_err(|e| format!("UNet inference failed: {}", e))?;
+
+        let (out_shape, data) = outputs[0]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("Failed to extract UNet output tensor: {}", e))?;
+
+        let shape_vec: Vec<usize> = out_shape.iter().map(|&x| x as usize).collect();
+        if shape_vec.len() != 4 || shape_vec[0] != 2 {
+            return Err(format!(
+                "Expected UNet output [2, 4, H, W], got {:?}",
+                shape_vec
+            ));
+        }
+
+        // Apply classifier-free guidance: noise_pred = uncond + guidance_scale * (cond - uncond)
+        // This is done by the caller — return the full [2, ...] output
+        Array4::from_shape_vec(
+            (shape_vec[0], shape_vec[1], shape_vec[2], shape_vec[3]),
+            data.to_vec(),
+        )
+        .map_err(|e| format!("Failed to reshape UNet output: {}", e))
+    }
+}

--- a/qntx-imagegen/src/pipeline/vae.rs
+++ b/qntx-imagegen/src/pipeline/vae.rs
@@ -1,0 +1,78 @@
+//! VAE decoder — converts latent representation to RGB pixels via ONNX
+
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::Value;
+use parking_lot::Mutex;
+use std::path::Path;
+
+/// VAE decoder ONNX session
+pub struct VaeDecoder {
+    session: Mutex<Session>,
+}
+
+impl VaeDecoder {
+    /// Load VAE decoder from ONNX model file
+    pub fn load(model_path: impl AsRef<Path>, num_threads: usize) -> Result<Self, String> {
+        let path = model_path.as_ref();
+        let session = Session::builder()
+            .map_err(|e| format!("Failed to create ONNX session builder: {}", e))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| format!("Failed to set optimization level: {}", e))?
+            .with_intra_threads(num_threads)
+            .map_err(|e| format!("Failed to set thread count: {}", e))?
+            .commit_from_file(path)
+            .map_err(|e| {
+                format!(
+                    "Failed to load VAE decoder model from '{}': {}",
+                    path.display(),
+                    e
+                )
+            })?;
+
+        Ok(Self {
+            session: Mutex::new(session),
+        })
+    }
+
+    /// Decode latent to RGB image data.
+    ///
+    /// # Arguments
+    /// * `latent` - Latent representation [1, 4, H/8, W/8]
+    /// * `latent_shape` - Shape of the latent tensor
+    ///
+    /// # Returns
+    /// RGB pixel data [1, 3, H, W] as flat f32 vector, plus output shape
+    pub fn decode(
+        &self,
+        latent: &[f32],
+        latent_shape: &[i64],
+    ) -> Result<(Vec<f32>, Vec<usize>), String> {
+        // Scale latent before decoding (SD uses 1/0.18215 scaling)
+        let scaled: Vec<f32> = latent.iter().map(|&x| x / 0.18215).collect();
+
+        let input = Value::from_array((latent_shape, scaled))
+            .map_err(|e| format!("Failed to create VAE input tensor: {}", e))?;
+
+        let mut session = self.session.lock();
+
+        // SD 1.5 ONNX VAE decoder expects input named "latent_sample"
+        let outputs = session
+            .run(ort::inputs!["latent_sample" => input])
+            .map_err(|e| format!("VAE decode failed: {}", e))?;
+
+        let (out_shape, data) = outputs[0]
+            .try_extract_tensor::<f32>()
+            .map_err(|e| format!("Failed to extract VAE output tensor: {}", e))?;
+
+        let shape_vec: Vec<usize> = out_shape.iter().map(|&x| x as usize).collect();
+        if shape_vec.len() != 4 || shape_vec[1] != 3 {
+            return Err(format!(
+                "Expected VAE output [1, 3, H, W], got {:?}",
+                shape_vec
+            ));
+        }
+
+        Ok((data.to_vec(), shape_vec))
+    }
+}

--- a/qntx-imagegen/src/proto/mod.rs
+++ b/qntx-imagegen/src/proto/mod.rs
@@ -1,0 +1,7 @@
+// Re-export proto definitions from qntx-grpc
+// Proto files are compiled in qntx-grpc's build.rs (when plugin feature is enabled)
+
+#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::enum_variant_names)]
+
+pub use qntx_grpc::plugin::proto::*;

--- a/qntx-imagegen/src/service.rs
+++ b/qntx-imagegen/src/service.rs
@@ -1,0 +1,499 @@
+//! gRPC service implementation for the imagegen plugin
+//!
+//! Implements the DomainPluginService interface for QNTX.
+
+use crate::atsstore::{self, AtsStoreConfig};
+use crate::config::{ImagegenConfig, PluginConfig};
+use crate::handlers::HandlerContext;
+use crate::pipeline::DiffusionPipeline;
+use crate::proto::{
+    domain_plugin_service_server::DomainPluginService, ConfigSchemaResponse, Empty,
+    ExecuteJobRequest, ExecuteJobResponse, HealthResponse, HttpHeader, HttpRequest, HttpResponse,
+    InitializeRequest, InitializeResponse, MetadataResponse, WebSocketMessage,
+};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status, Streaming};
+use tracing::{debug, error, info, warn};
+
+/// Shared plugin state
+pub(crate) struct PluginState {
+    pub config: Option<PluginConfig>,
+    pub imagegen_config: ImagegenConfig,
+    pub pipeline: Option<DiffusionPipeline>,
+    pub initialized: bool,
+    pub ats_client: atsstore::SharedAtsStoreClient,
+    /// True while a generation is in progress
+    pub generating: bool,
+}
+
+/// Imagegen plugin gRPC service
+pub struct ImagegenPluginService {
+    pub(crate) handlers: HandlerContext,
+}
+
+impl ImagegenPluginService {
+    pub fn new() -> Self {
+        let state = Arc::new(RwLock::new(PluginState {
+            config: None,
+            imagegen_config: ImagegenConfig::default(),
+            pipeline: None,
+            initialized: false,
+            ats_client: atsstore::new_shared_client(),
+            generating: false,
+        }));
+
+        Self {
+            handlers: HandlerContext::new(state),
+        }
+    }
+}
+
+impl Default for ImagegenPluginService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[tonic::async_trait]
+impl DomainPluginService for ImagegenPluginService {
+    async fn metadata(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<MetadataResponse>, Status> {
+        debug!("Metadata request received");
+        Ok(Response::new(MetadataResponse {
+            name: "imagegen".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            qntx_version: ">=0.1.0".to_string(),
+            description: "Stable Diffusion image generation via ONNX Runtime".to_string(),
+            author: "QNTX Contributors".to_string(),
+            license: "MIT".to_string(),
+        }))
+    }
+
+    async fn initialize(
+        &self,
+        request: Request<InitializeRequest>,
+    ) -> Result<Response<InitializeResponse>, Status> {
+        let req = request.into_inner();
+        info!("Initializing imagegen plugin");
+        info!("ATSStore endpoint: {}", req.ats_store_endpoint);
+
+        let imagegen_config = ImagegenConfig::from_config_map(&req.config);
+        info!("Models dir: {}", imagegen_config.models_dir.display());
+        info!("Output dir: {}", imagegen_config.output_dir.display());
+
+        // Ensure output directory exists
+        if let Err(e) = std::fs::create_dir_all(&imagegen_config.output_dir) {
+            error!(
+                "Failed to create output directory '{}': {}",
+                imagegen_config.output_dir.display(),
+                e
+            );
+            return Err(Status::internal(format!(
+                "Failed to create output directory '{}': {}",
+                imagegen_config.output_dir.display(),
+                e
+            )));
+        }
+
+        // Check model files
+        let model_check = crate::models::check_models(&imagegen_config.models_dir);
+        if !model_check.all_present {
+            let missing: Vec<_> = model_check
+                .files
+                .iter()
+                .filter(|f| !f.present)
+                .map(|f| f.path.as_str())
+                .collect();
+            warn!(
+                "Missing model files in '{}': {:?} — pipeline will not load until models are present",
+                imagegen_config.models_dir.display(),
+                missing
+            );
+        }
+
+        // Try to load the pipeline
+        let pipeline = if model_check.all_present {
+            match DiffusionPipeline::load(&imagegen_config) {
+                Ok(p) => {
+                    info!("Diffusion pipeline loaded successfully");
+                    Some(p)
+                }
+                Err(e) => {
+                    error!("Failed to load diffusion pipeline: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        {
+            let mut state = self.handlers.state.write();
+
+            state.config = Some(PluginConfig {
+                ats_store_endpoint: req.ats_store_endpoint.clone(),
+                queue_endpoint: req.queue_endpoint,
+                auth_token: req.auth_token.clone(),
+                config: req.config,
+            });
+
+            // Initialize ATSStore client if endpoint is provided
+            if !req.ats_store_endpoint.is_empty() {
+                info!("Initializing ATSStore client for attestation support");
+                atsstore::init_shared_client(
+                    &state.ats_client,
+                    AtsStoreConfig {
+                        endpoint: req.ats_store_endpoint,
+                        auth_token: req.auth_token,
+                    },
+                );
+            }
+
+            state.imagegen_config = imagegen_config;
+            state.pipeline = pipeline;
+            state.initialized = true;
+        }
+
+        let handler_names = vec!["imagegen.generate".to_string()];
+        info!("Announcing async handlers: {:?}", handler_names);
+
+        Ok(Response::new(InitializeResponse { handler_names }))
+    }
+
+    async fn shutdown(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
+        info!("Shutting down imagegen plugin");
+        let mut state = self.handlers.state.write();
+        state.initialized = false;
+        state.pipeline = None;
+        state.config = None;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn handle_http(
+        &self,
+        request: Request<HttpRequest>,
+    ) -> Result<Response<HttpResponse>, Status> {
+        let req = request.into_inner();
+        let path = &req.path;
+        let method = &req.method;
+
+        debug!("HTTP request: {} {}", method, path);
+
+        let body: serde_json::Value = if req.body.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&req.body)
+                .map_err(|e| Status::invalid_argument(format!("Invalid JSON body: {}", e)))?
+        };
+
+        let result = match (method.as_str(), path.as_str()) {
+            ("POST", "/generate") => self.handlers.handle_generate(body).await,
+            ("GET", "/status") => self.handlers.handle_status().await,
+            ("POST", "/models/check") => self.handlers.handle_models_check().await,
+            ("GET", path) if path.starts_with("/image/") => {
+                let filename = &path["/image/".len()..];
+                self.handlers.handle_serve_image(filename).await
+            }
+            _ => Err(Status::not_found(format!(
+                "Unknown endpoint: {} {}",
+                method, path
+            ))),
+        };
+
+        match result {
+            Ok(response) => Ok(Response::new(response)),
+            Err(status) => {
+                let error_body = serde_json::json!({
+                    "error": status.message()
+                });
+                Ok(Response::new(HttpResponse {
+                    status_code: match status.code() {
+                        tonic::Code::NotFound => 404,
+                        tonic::Code::InvalidArgument => 400,
+                        tonic::Code::Internal => 500,
+                        tonic::Code::Unavailable => 503,
+                        _ => 500,
+                    },
+                    headers: vec![HttpHeader {
+                        name: "Content-Type".to_string(),
+                        values: vec!["application/json".to_string()],
+                    }],
+                    body: serde_json::to_vec(&error_body).unwrap_or_default(),
+                }))
+            }
+        }
+    }
+
+    type HandleWebSocketStream =
+        Pin<Box<dyn Stream<Item = Result<WebSocketMessage, Status>> + Send>>;
+
+    async fn handle_web_socket(
+        &self,
+        _request: Request<Streaming<WebSocketMessage>>,
+    ) -> Result<Response<Self::HandleWebSocketStream>, Status> {
+        warn!("WebSocket not supported by imagegen plugin");
+        Err(Status::unimplemented(
+            "WebSocket not supported by imagegen plugin",
+        ))
+    }
+
+    async fn health(&self, _request: Request<Empty>) -> Result<Response<HealthResponse>, Status> {
+        let state = self.handlers.state.read();
+        let healthy = state.initialized;
+
+        let mut details = HashMap::new();
+        details.insert("initialized".to_string(), state.initialized.to_string());
+        details.insert(
+            "pipeline_loaded".to_string(),
+            state.pipeline.is_some().to_string(),
+        );
+        details.insert("generating".to_string(), state.generating.to_string());
+        details.insert(
+            "models_dir".to_string(),
+            state.imagegen_config.models_dir.display().to_string(),
+        );
+
+        if let Ok(exe_path) = std::env::current_exe() {
+            if let Ok(metadata) = std::fs::metadata(&exe_path) {
+                if let Ok(modified) = metadata.modified() {
+                    if let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH) {
+                        details.insert("binary_built".to_string(), duration.as_secs().to_string());
+                    }
+                }
+            }
+        }
+
+        Ok(Response::new(HealthResponse {
+            healthy,
+            message: if healthy {
+                if state.pipeline.is_some() {
+                    "OK — pipeline loaded".to_string()
+                } else {
+                    "OK — pipeline not loaded (models missing)".to_string()
+                }
+            } else {
+                "Not initialized".to_string()
+            },
+            details,
+        }))
+    }
+
+    async fn config_schema(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<ConfigSchemaResponse>, Status> {
+        debug!("ConfigSchema request received");
+        Ok(Response::new(ConfigSchemaResponse {
+            fields: crate::config::build_schema(),
+        }))
+    }
+
+    async fn execute_job(
+        &self,
+        request: Request<ExecuteJobRequest>,
+    ) -> Result<Response<ExecuteJobResponse>, Status> {
+        let req = request.into_inner();
+
+        debug!(
+            "ExecuteJob request: job_id={}, handler={}",
+            req.job_id, req.handler_name
+        );
+
+        if req.handler_name != "imagegen.generate" {
+            return Err(Status::not_found(format!(
+                "Unknown handler: {}",
+                req.handler_name
+            )));
+        }
+
+        self.execute_generate_job(req).await
+    }
+}
+
+impl ImagegenPluginService {
+    async fn execute_generate_job(
+        &self,
+        req: ExecuteJobRequest,
+    ) -> Result<Response<ExecuteJobResponse>, Status> {
+        #[derive(serde::Deserialize)]
+        struct GeneratePayload {
+            prompt: String,
+            #[serde(default)]
+            negative_prompt: Option<String>,
+            #[serde(default)]
+            steps: Option<u32>,
+            #[serde(default)]
+            guidance_scale: Option<f32>,
+            #[serde(default)]
+            seed: Option<u64>,
+            #[serde(default)]
+            width: Option<u32>,
+            #[serde(default)]
+            height: Option<u32>,
+        }
+
+        let payload: GeneratePayload = serde_json::from_slice(&req.payload)
+            .map_err(|e| Status::invalid_argument(format!("Invalid payload JSON: {}", e)))?;
+
+        if payload.prompt.is_empty() {
+            return Err(Status::invalid_argument("Missing prompt in payload"));
+        }
+
+        // Grab config and pipeline availability
+        let (imagegen_config, has_pipeline) = {
+            let state = self.handlers.state.read();
+            (state.imagegen_config.clone(), state.pipeline.is_some())
+        };
+
+        if !has_pipeline {
+            return Ok(Response::new(ExecuteJobResponse {
+                success: false,
+                error: format!(
+                    "Pipeline not loaded — model files missing from '{}'",
+                    imagegen_config.models_dir.display()
+                ),
+                result: vec![],
+                progress_current: 0,
+                progress_total: 0,
+                cost_actual: 0.0,
+            }));
+        }
+
+        // Mark as generating
+        {
+            let mut state = self.handlers.state.write();
+            state.generating = true;
+        }
+
+        let prompt = payload.prompt.clone();
+        let prompt_for_attest = prompt.clone();
+        let negative_prompt = payload.negative_prompt.unwrap_or_default();
+        let steps = payload
+            .steps
+            .unwrap_or(imagegen_config.num_inference_steps);
+        let guidance_scale = payload
+            .guidance_scale
+            .unwrap_or(imagegen_config.guidance_scale);
+        let seed = payload.seed.unwrap_or(42);
+        let width = payload.width.unwrap_or(imagegen_config.image_width);
+        let height = payload.height.unwrap_or(imagegen_config.image_height);
+        let output_dir = imagegen_config.output_dir.clone();
+        let job_id = req.job_id.clone();
+
+        let state_clone = self.handlers.state.clone();
+
+        // Run inference in a blocking task to keep gRPC responsive
+        let result = tokio::task::spawn_blocking(move || {
+            let start = std::time::Instant::now();
+
+            let generate_result = {
+                let state = state_clone.read();
+                let pipeline = state.pipeline.as_ref().unwrap();
+                pipeline.generate(
+                    &prompt,
+                    &negative_prompt,
+                    steps,
+                    guidance_scale,
+                    seed,
+                    width,
+                    height,
+                )
+            };
+
+            let duration_ms = start.elapsed().as_millis() as u64;
+
+            match generate_result {
+                Ok(image_data) => {
+                    // Compute SHA256
+                    use sha2::{Digest, Sha256};
+                    let mut hasher = Sha256::new();
+                    hasher.update(&image_data);
+                    let hash = format!("{:x}", hasher.finalize());
+
+                    // Save to output directory
+                    let filename = format!("{}.png", job_id);
+                    let output_path = output_dir.join(&filename);
+                    if let Err(e) = std::fs::write(&output_path, &image_data) {
+                        return Err(format!(
+                            "Failed to write image to '{}': {}",
+                            output_path.display(),
+                            e
+                        ));
+                    }
+
+                    Ok(serde_json::json!({
+                        "filename": filename,
+                        "output_path": output_path.display().to_string(),
+                        "sha256": hash,
+                        "duration_ms": duration_ms,
+                        "width": width,
+                        "height": height,
+                        "steps": steps,
+                        "guidance_scale": guidance_scale,
+                        "seed": seed,
+                    }))
+                }
+                Err(e) => Err(e),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| Err(format!("Generation task panicked: {:?}", e)));
+
+        // Clear generating flag
+        {
+            let mut state = self.handlers.state.write();
+            state.generating = false;
+        }
+
+        match result {
+            Ok(result_json) => {
+                // Create attestation if ATSStore is available
+                let sha256 = result_json["sha256"].as_str().unwrap_or("").to_string();
+                let output_path = result_json["output_path"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string();
+                let duration_ms = result_json["duration_ms"].as_u64().unwrap_or(0);
+
+                {
+                    let state = self.handlers.state.read();
+                    atsstore::create_attestation(
+                        &state.ats_client,
+                        &sha256,
+                        &prompt_for_attest,
+                        steps,
+                        seed,
+                        duration_ms,
+                        &output_path,
+                    );
+                }
+
+                let result_bytes = serde_json::to_vec(&result_json).unwrap_or_default();
+
+                Ok(Response::new(ExecuteJobResponse {
+                    success: true,
+                    error: String::new(),
+                    result: result_bytes,
+                    progress_current: steps as i32,
+                    progress_total: steps as i32,
+                    cost_actual: 0.0,
+                }))
+            }
+            Err(e) => Ok(Response::new(ExecuteJobResponse {
+                success: false,
+                error: e,
+                result: vec![],
+                progress_current: 0,
+                progress_total: 0,
+                cost_actual: 0.0,
+            })),
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Standalone Rust gRPC plugin running Stable Diffusion 1.5 inference via ONNX Runtime — local-first, no cloud dependency
- Full pipeline: CLIP tokenizer → text encoder → UNet denoise (DDIM) → VAE decode → PNG
- Follows qntx-python plugin pattern: port retry, health checks, ATSStore attestation, HTTP endpoints
- Manual testing handover in `qntx-imagegen/TESTING.md` (20 steps, split by with/without models)

## Test plan
- [x] `cargo build -p qntx-imagegen-plugin` compiles clean
- [x] `make test` passes (668 tests, no regressions)
- [x] `--version` and `--port` flags work
- [ ] Steps 1–11 in TESTING.md (no models needed)
- [ ] Steps 12–20 in TESTING.md (requires ~4GB SD 1.5 ONNX download)