### PR TITLE
Add canvas export and publish to IPFS + git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ demo: web cli ## Start QNTX with persistent demo canvas for editing and publishi
 		test -n \"\$$FRONTEND_PID\" && kill -9 -\$$FRONTEND_PID 2>/dev/null || true; \
 		echo '✓ Demo servers stopped'" EXIT INT TERM; \
 	set -m; \
-	./bin/qntx server --dev --no-browser --db-path demo.db -vvv & \
+	QNTX_DEMO=1 ./bin/qntx server --dev --no-browser --db-path demo.db -vvv & \
 	BACKEND_PID=$$!; \
 	cd web && QNTX_DEMO=1 bun run dev & \
 	FRONTEND_PID=$$!; \

--- a/am/am.go
+++ b/am/am.go
@@ -13,6 +13,7 @@ type Config struct {
 	Plugin         PluginConfig         `mapstructure:"plugin"`
 	Embeddings     EmbeddingsConfig     `mapstructure:"embeddings"`
 	Sync           SyncConfig           `mapstructure:"sync"`
+	Pinata         PinataConfig         `mapstructure:"pinata"`
 }
 
 // AuthConfig configures biometric authentication (WebAuthn)
@@ -159,6 +160,12 @@ type EmbeddingsConfig struct {
 	ClusterLabelCooldownDays    int    `mapstructure:"cluster_label_cooldown_days"`    // Min days between re-labels
 	ClusterLabelMaxTokens       int    `mapstructure:"cluster_label_max_tokens"`       // LLM max_tokens
 	ClusterLabelModel           string `mapstructure:"cluster_label_model"`            // Model override (empty = system default)
+}
+
+// PinataConfig configures Pinata IPFS pinning for canvas publish
+type PinataConfig struct {
+	JWT     string `mapstructure:"jwt"`     // Pinata JWT token for authentication
+	Gateway string `mapstructure:"gateway"` // IPFS gateway URL (default: https://gateway.pinata.cloud)
 }
 
 // File system constants

--- a/am/defaults.go
+++ b/am/defaults.go
@@ -78,6 +78,10 @@ func SetDefaults(v *viper.Viper) {
 	v.SetDefault("embeddings.cluster_label_max_tokens", 2000)
 	v.SetDefault("embeddings.cluster_label_model", "") // empty = system default
 
+	// Pinata IPFS pinning defaults
+	v.SetDefault("pinata.gateway", "https://gateway.pinata.cloud")
+	// jwt: no default — must be set via config or QNTX_PINATA_JWT
+
 	// Plugin configuration defaults
 	v.SetDefault("plugin.enabled", []string{}) // No plugins enabled by default (explicit opt-in via am.toml)
 	v.SetDefault("plugin.paths", []string{
@@ -100,6 +104,9 @@ func BindSensitiveEnvVars(v *viper.Viper) {
 	v.BindEnv("local_inference.enabled", "QNTX_LOCAL_INFERENCE_ENABLED")
 	v.BindEnv("local_inference.base_url", "QNTX_LOCAL_INFERENCE_BASE_URL")
 	v.BindEnv("local_inference.model", "QNTX_LOCAL_INFERENCE_MODEL")
+
+	// Pinata IPFS pinning
+	v.BindEnv("pinata.jwt", "QNTX_PINATA_JWT")
 }
 
 // GetServerPort returns the configured QNTX server port

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>QNTX Canvas</title>
+<style>
+
+/* Reset */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #1a1b1a;
+    color: #dfe1e0;
+}
+
+/* Canvas workspace */
+.canvas-workspace {
+    width: 100%;
+    min-height: 100vh;
+    position: relative;
+    overflow: auto;
+    background-color: #2d2e36;
+    background-image:
+        repeating-linear-gradient(0deg, transparent, transparent 23px, #2f353c 23px, #2f353c 24px),
+        repeating-linear-gradient(90deg, transparent, transparent 23px, #2f353c 23px, #2f353c 24px);
+}
+
+.canvas-content-layer {
+    position: relative;
+    min-height: 100vh;
+}
+
+/* Glyph base */
+.canvas-glyph {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    background-color: #252625;
+    border: 1px solid #3f4140;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+/* Title bar */
+.canvas-glyph-title-bar {
+    height: 32px;
+    background-color: #2e2f2e;
+    border-bottom: 1px solid #3f4140;
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    gap: 8px;
+    flex-shrink: 0;
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Content */
+.glyph-content {
+    flex: 1;
+    padding: 8px;
+    overflow: auto;
+    font-size: 13px;
+}
+
+.glyph-content pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Fira Code', 'Consolas', monospace;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #d4d4d4;
+}
+
+.glyph-content code {
+    font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Fira Code', 'Consolas', monospace;
+    font-size: 13px;
+}
+
+/* Query glyphs (AX, SE) */
+.glyph-query {
+    display: flex;
+    align-items: center;
+    padding: 6px 8px;
+    font-family: 'JetBrains Mono', 'SF Mono', monospace;
+    font-size: 13px;
+    color: #d4d4d4;
+}
+
+/* Note glyph (post-it) */
+.note-content {
+    padding: 4px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.2;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+/* Attestation glyph */
+.canvas-attestation-glyph {
+    background: #1a1b1a;
+    border: 1px solid #3f4140;
+    border-radius: 3px;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.2);
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.attestation-content {
+    font-family: monospace;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+/* Document glyph */
+.canvas-doc-glyph {
+    border: 1px solid #3f4140;
+    border-radius: 3px;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.2);
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.doc-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #999;
+    font-size: 14px;
+}
+
+/* Subcanvas glyph */
+.canvas-subcanvas-glyph .canvas-glyph-title-bar {
+    background: #3a2d5a;
+    color: #c0a0e8;
+}
+
+.subcanvas-preview {
+    flex: 1;
+    overflow: hidden;
+    background-color: #2d2e36;
+    background-image:
+        repeating-linear-gradient(0deg, transparent, transparent 9px, rgba(160, 120, 200, 0.08) 9px, rgba(160, 120, 200, 0.08) 10px),
+        repeating-linear-gradient(90deg, transparent, transparent 9px, rgba(160, 120, 200, 0.08) 9px, rgba(160, 120, 200, 0.08) 10px);
+    min-height: 60px;
+}
+
+/* Python glyph title bar accent */
+.canvas-py-glyph .canvas-glyph-title-bar {
+    background: #2a5578;
+}
+
+/* TypeScript glyph title bar accent */
+.canvas-ts-glyph .canvas-glyph-title-bar {
+    background: #2d4f7c;
+}
+
+/* Prompt glyph title bar accent */
+.canvas-prompt-glyph .canvas-glyph-title-bar {
+    background: #3d2e2e;
+}
+
+/* Melded composition */
+.melded-composition {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: auto;
+    gap: 0;
+    position: absolute;
+    background: transparent;
+}
+
+.melded-composition .canvas-glyph {
+    position: relative;
+}
+
+/* Responsive: scroll on small screens */
+@media (max-width: 768px) {
+    .canvas-workspace {
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+</style>
+</head>
+<body>
+<div class="canvas-workspace">
+<div class="canvas-content-layer">
+<div class="canvas-note-glyph canvas-glyph" data-glyph-id="note-b4677847-0f6d-49b1-bfa8-6d3d4907ebd3" style="left:562px;top:278px;width:321px;min-height:281px;background-color:#f5edb8;border:1px solid #d4c59a;border-radius:2px;box-shadow:2px 2px 8px rgba(0,0,0,0.15);color:#2a2a2a;">
+<div class="glyph-content note-content"># A new Note
+
+Start typing...
+
+for the canvas id test.</div>
+</div>
+
+</div>
+</div>
+</body>
+</html>

--- a/glyph/handlers/canvas.go
+++ b/glyph/handlers/canvas.go
@@ -17,9 +17,11 @@ import (
 
 // CanvasHandler handles HTTP requests for canvas state
 type CanvasHandler struct {
-	store         *glyphstorage.CanvasStore
-	watcherEngine *watcher.Engine
-	logger        *zap.SugaredLogger
+	store          *glyphstorage.CanvasStore
+	watcherEngine  *watcher.Engine
+	logger         *zap.SugaredLogger
+	pinataJWT      string
+	pinataGateway  string
 }
 
 // NewCanvasHandler creates a new canvas handler
@@ -41,6 +43,14 @@ func WithWatcherEngine(engine *watcher.Engine, logger *zap.SugaredLogger) Canvas
 	return func(h *CanvasHandler) {
 		h.watcherEngine = engine
 		h.logger = logger
+	}
+}
+
+// WithPinata enables IPFS publishing via Pinata
+func WithPinata(jwt, gateway string) CanvasHandlerOption {
+	return func(h *CanvasHandler) {
+		h.pinataJWT = jwt
+		h.pinataGateway = gateway
 	}
 }
 

--- a/glyph/handlers/canvas_export.go
+++ b/glyph/handlers/canvas_export.go
@@ -1,0 +1,507 @@
+package handlers
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+
+	"github.com/teranos/QNTX/errors"
+	"github.com/teranos/QNTX/glyph/storage"
+	"github.com/teranos/QNTX/sym"
+)
+
+// HandleExportStatic renders the canvas as a self-contained static HTML page.
+// GET /api/canvas/export/static — returns text/html with Content-Disposition attachment.
+func (h *CanvasHandler) HandleExportStatic(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, errors.New("method not allowed"), http.StatusMethodNotAllowed)
+		return
+	}
+
+	glyphs, err := h.store.ListGlyphs(r.Context())
+	if err != nil {
+		h.writeError(w, errors.Wrap(err, "failed to list glyphs for export"), http.StatusInternalServerError)
+		return
+	}
+
+	compositions, err := h.store.ListCompositions(r.Context())
+	if err != nil {
+		h.writeError(w, errors.Wrap(err, "failed to list compositions for export"), http.StatusInternalServerError)
+		return
+	}
+
+	htmlContent := renderStaticCanvas(glyphs, compositions)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="canvas.html"`)
+	fmt.Fprint(w, htmlContent)
+}
+
+// renderStaticCanvas produces a self-contained HTML document from canvas state.
+func renderStaticCanvas(glyphs []*storage.CanvasGlyph, compositions []*storage.CanvasComposition) string {
+	// Build glyph ID → composition membership map
+	glyphToComp := make(map[string]*storage.CanvasComposition)
+	for _, comp := range compositions {
+		for _, edge := range comp.Edges {
+			glyphToComp[edge.From] = comp
+			glyphToComp[edge.To] = comp
+		}
+	}
+
+	// Track which compositions we've already rendered
+	renderedComps := make(map[string]bool)
+
+	var glyphsHTML strings.Builder
+	for _, g := range glyphs {
+		// Skip glyphs that belong to a composition — they'll be rendered inside it
+		if comp, ok := glyphToComp[g.ID]; ok {
+			if renderedComps[comp.ID] {
+				continue
+			}
+			renderedComps[comp.ID] = true
+			glyphsHTML.WriteString(renderComposition(comp, glyphs))
+			continue
+		}
+		glyphsHTML.WriteString(renderGlyph(g))
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>QNTX Canvas</title>
+<style>
+%s
+</style>
+</head>
+<body>
+<div class="canvas-workspace">
+<div class="canvas-content-layer">
+%s
+</div>
+</div>
+</body>
+</html>`, staticCSS, glyphsHTML.String())
+}
+
+// renderComposition renders a melded composition container with its member glyphs.
+func renderComposition(comp *storage.CanvasComposition, allGlyphs []*storage.CanvasGlyph) string {
+	glyphMap := make(map[string]*storage.CanvasGlyph)
+	for _, g := range allGlyphs {
+		glyphMap[g.ID] = g
+	}
+
+	// Collect unique glyph IDs from edges, preserving order
+	var memberIDs []string
+	seen := make(map[string]bool)
+	for _, edge := range comp.Edges {
+		if !seen[edge.From] {
+			memberIDs = append(memberIDs, edge.From)
+			seen[edge.From] = true
+		}
+		if !seen[edge.To] {
+			memberIDs = append(memberIDs, edge.To)
+			seen[edge.To] = true
+		}
+	}
+
+	var members strings.Builder
+	for _, id := range memberIDs {
+		if g, ok := glyphMap[id]; ok {
+			// Render member glyphs without absolute positioning (grid handles layout)
+			members.WriteString(renderGlyphInline(g))
+		}
+	}
+
+	return fmt.Sprintf(`<div class="melded-composition" style="left:%dpx;top:%dpx;">
+%s
+</div>`, comp.X, comp.Y, members.String())
+}
+
+// renderGlyph renders a single glyph with absolute positioning.
+func renderGlyph(g *storage.CanvasGlyph) string {
+	className := glyphClassName(g.Symbol)
+	title := glyphTitle(g.Symbol)
+	style := glyphStyle(g)
+
+	content := renderGlyphContent(g)
+
+	var titleBarHTML string
+	if title != "" && !isNoteGlyph(g.Symbol) {
+		titleBarHTML = fmt.Sprintf(`<div class="canvas-glyph-title-bar"><span>%s</span></div>`, html.EscapeString(title))
+	}
+
+	var extraStyle string
+	if isNoteGlyph(g.Symbol) {
+		extraStyle = noteInlineStyle()
+	}
+
+	return fmt.Sprintf(`<div class="%s canvas-glyph" data-glyph-id="%s" style="%s%s">
+%s%s
+</div>
+`, className, html.EscapeString(g.ID), style, extraStyle, titleBarHTML, content)
+}
+
+// renderGlyphInline renders a glyph without absolute positioning (for use inside compositions).
+func renderGlyphInline(g *storage.CanvasGlyph) string {
+	className := glyphClassName(g.Symbol)
+	title := glyphTitle(g.Symbol)
+	content := renderGlyphContent(g)
+
+	var titleBarHTML string
+	if title != "" && !isNoteGlyph(g.Symbol) {
+		titleBarHTML = fmt.Sprintf(`<div class="canvas-glyph-title-bar"><span>%s</span></div>`, html.EscapeString(title))
+	}
+
+	sizeStyle := ""
+	if g.Width != nil {
+		sizeStyle += fmt.Sprintf("width:%dpx;", *g.Width)
+	}
+	if g.Height != nil {
+		sizeStyle += fmt.Sprintf("min-height:%dpx;", *g.Height)
+	}
+
+	return fmt.Sprintf(`<div class="%s canvas-glyph" data-glyph-id="%s" style="position:relative;%s">
+%s%s
+</div>
+`, className, html.EscapeString(g.ID), sizeStyle, titleBarHTML, content)
+}
+
+// renderGlyphContent returns the inner HTML for a glyph's content based on its symbol type.
+func renderGlyphContent(g *storage.CanvasGlyph) string {
+	content := ""
+	if g.Content != nil {
+		content = *g.Content
+	}
+
+	switch g.Symbol {
+	case "py":
+		return renderCodeContent(content, "python")
+	case "ts":
+		return renderCodeContent(content, "typescript")
+	case sym.SO: // Prompt
+		return renderCodeContent(content, "yaml")
+	case sym.AX: // AX query
+		return renderQueryContent(content)
+	case sym.SE: // Semantic search
+		return renderQueryContent(content)
+	case sym.IX: // Ingest
+		return renderCodeContent(content, "text")
+	case sym.Prose: // Note
+		return renderNoteContent(content)
+	case sym.Doc: // Document
+		return renderDocContent(content)
+	case sym.Subcanvas: // Subcanvas
+		return `<div class="subcanvas-preview"></div>`
+	case sym.AS: // Attestation
+		return renderAttestationContent(content)
+	default:
+		// result, error, or unknown — render as preformatted text
+		if content != "" {
+			return fmt.Sprintf(`<div class="glyph-content"><pre>%s</pre></div>`, html.EscapeString(content))
+		}
+		return `<div class="glyph-content"></div>`
+	}
+}
+
+func renderCodeContent(content, lang string) string {
+	if content == "" {
+		content = "// empty"
+	}
+	return fmt.Sprintf(`<div class="glyph-content"><pre><code class="language-%s">%s</code></pre></div>`,
+		html.EscapeString(lang), html.EscapeString(content))
+}
+
+func renderQueryContent(content string) string {
+	return fmt.Sprintf(`<div class="glyph-content glyph-query"><code>%s</code></div>`,
+		html.EscapeString(content))
+}
+
+func renderNoteContent(content string) string {
+	// Markdown is stored as plain text — render as-is with whitespace preserved
+	if content == "" {
+		return `<div class="glyph-content note-content"></div>`
+	}
+	return fmt.Sprintf(`<div class="glyph-content note-content">%s</div>`,
+		html.EscapeString(content))
+}
+
+func renderDocContent(content string) string {
+	if content == "" {
+		return `<div class="glyph-content doc-placeholder">Document</div>`
+	}
+	return fmt.Sprintf(`<div class="glyph-content doc-placeholder">%s</div>`,
+		html.EscapeString(content))
+}
+
+func renderAttestationContent(content string) string {
+	if content == "" {
+		return `<div class="glyph-content attestation-content">+</div>`
+	}
+	return fmt.Sprintf(`<div class="glyph-content attestation-content"><pre>%s</pre></div>`,
+		html.EscapeString(content))
+}
+
+// glyphClassName maps symbol to CSS class name.
+func glyphClassName(symbol string) string {
+	switch symbol {
+	case sym.AX:
+		return "canvas-ax-glyph"
+	case sym.SE:
+		return "canvas-se-glyph"
+	case "py":
+		return "canvas-py-glyph"
+	case sym.IX:
+		return "canvas-ix-glyph"
+	case sym.SO:
+		return "canvas-prompt-glyph"
+	case "ts":
+		return "canvas-ts-glyph"
+	case sym.Prose:
+		return "canvas-note-glyph"
+	case sym.Doc:
+		return "canvas-doc-glyph"
+	case sym.Subcanvas:
+		return "canvas-subcanvas-glyph"
+	case sym.AS:
+		return "canvas-attestation-glyph"
+	default:
+		return "canvas-glyph-unknown"
+	}
+}
+
+// glyphTitle returns the human-readable title for a glyph symbol.
+func glyphTitle(symbol string) string {
+	switch symbol {
+	case sym.AX:
+		return sym.AX + " Query"
+	case sym.SE:
+		return sym.SE + " Semantic"
+	case "py":
+		return "Python"
+	case sym.IX:
+		return sym.IX + " Ingest"
+	case sym.SO:
+		return sym.SO + " Prompt"
+	case "ts":
+		return "TypeScript"
+	case sym.Prose:
+		return ""
+	case sym.Doc:
+		return "Document"
+	case sym.Subcanvas:
+		return sym.Subcanvas + " Subcanvas"
+	case sym.AS:
+		return sym.AS + " Attestation"
+	default:
+		return symbol
+	}
+}
+
+func isNoteGlyph(symbol string) bool {
+	return symbol == sym.Prose
+}
+
+func glyphStyle(g *storage.CanvasGlyph) string {
+	s := fmt.Sprintf("left:%dpx;top:%dpx;", g.X, g.Y)
+	if g.Width != nil {
+		s += fmt.Sprintf("width:%dpx;", *g.Width)
+	}
+	if g.Height != nil {
+		s += fmt.Sprintf("min-height:%dpx;", *g.Height)
+	}
+	return s
+}
+
+func noteInlineStyle() string {
+	return "background-color:#f5edb8;border:1px solid #d4c59a;border-radius:2px;box-shadow:2px 2px 8px rgba(0,0,0,0.15);color:#2a2a2a;"
+}
+
+// staticCSS contains all styles needed to render the canvas snapshot.
+// Inlined to produce a fully self-contained HTML file.
+const staticCSS = `
+/* Reset */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #1a1b1a;
+    color: #dfe1e0;
+}
+
+/* Canvas workspace */
+.canvas-workspace {
+    width: 100%;
+    min-height: 100vh;
+    position: relative;
+    overflow: auto;
+    background-color: #2d2e36;
+    background-image:
+        repeating-linear-gradient(0deg, transparent, transparent 23px, #2f353c 23px, #2f353c 24px),
+        repeating-linear-gradient(90deg, transparent, transparent 23px, #2f353c 23px, #2f353c 24px);
+}
+
+.canvas-content-layer {
+    position: relative;
+    min-height: 100vh;
+}
+
+/* Glyph base */
+.canvas-glyph {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    background-color: #252625;
+    border: 1px solid #3f4140;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+/* Title bar */
+.canvas-glyph-title-bar {
+    height: 32px;
+    background-color: #2e2f2e;
+    border-bottom: 1px solid #3f4140;
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    gap: 8px;
+    flex-shrink: 0;
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Content */
+.glyph-content {
+    flex: 1;
+    padding: 8px;
+    overflow: auto;
+    font-size: 13px;
+}
+
+.glyph-content pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Fira Code', 'Consolas', monospace;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #d4d4d4;
+}
+
+.glyph-content code {
+    font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Fira Code', 'Consolas', monospace;
+    font-size: 13px;
+}
+
+/* Query glyphs (AX, SE) */
+.glyph-query {
+    display: flex;
+    align-items: center;
+    padding: 6px 8px;
+    font-family: 'JetBrains Mono', 'SF Mono', monospace;
+    font-size: 13px;
+    color: #d4d4d4;
+}
+
+/* Note glyph (post-it) */
+.note-content {
+    padding: 4px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.2;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+/* Attestation glyph */
+.canvas-attestation-glyph {
+    background: #1a1b1a;
+    border: 1px solid #3f4140;
+    border-radius: 3px;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.2);
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.attestation-content {
+    font-family: monospace;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+/* Document glyph */
+.canvas-doc-glyph {
+    border: 1px solid #3f4140;
+    border-radius: 3px;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.2);
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.doc-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #999;
+    font-size: 14px;
+}
+
+/* Subcanvas glyph */
+.canvas-subcanvas-glyph .canvas-glyph-title-bar {
+    background: #3a2d5a;
+    color: #c0a0e8;
+}
+
+.subcanvas-preview {
+    flex: 1;
+    overflow: hidden;
+    background-color: #2d2e36;
+    background-image:
+        repeating-linear-gradient(0deg, transparent, transparent 9px, rgba(160, 120, 200, 0.08) 9px, rgba(160, 120, 200, 0.08) 10px),
+        repeating-linear-gradient(90deg, transparent, transparent 9px, rgba(160, 120, 200, 0.08) 9px, rgba(160, 120, 200, 0.08) 10px);
+    min-height: 60px;
+}
+
+/* Python glyph title bar accent */
+.canvas-py-glyph .canvas-glyph-title-bar {
+    background: #2a5578;
+}
+
+/* TypeScript glyph title bar accent */
+.canvas-ts-glyph .canvas-glyph-title-bar {
+    background: #2d4f7c;
+}
+
+/* Prompt glyph title bar accent */
+.canvas-prompt-glyph .canvas-glyph-title-bar {
+    background: #3d2e2e;
+}
+
+/* Melded composition */
+.melded-composition {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: auto;
+    gap: 0;
+    position: absolute;
+    background: transparent;
+}
+
+.melded-composition .canvas-glyph {
+    position: relative;
+}
+
+/* Responsive: scroll on small screens */
+@media (max-width: 768px) {
+    .canvas-workspace {
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+`

--- a/glyph/handlers/canvas_export.go
+++ b/glyph/handlers/canvas_export.go
@@ -1,14 +1,12 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"html"
 	"net/http"
 	"strings"
 
 	"github.com/teranos/QNTX/errors"
-	"github.com/teranos/QNTX/glyph/ipfs"
 	"github.com/teranos/QNTX/glyph/storage"
 	"github.com/teranos/QNTX/sym"
 )
@@ -38,54 +36,6 @@ func (h *CanvasHandler) HandleExportStatic(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="canvas.html"`)
 	fmt.Fprint(w, htmlContent)
-}
-
-// HandlePublish renders the canvas as static HTML, pins it to IPFS via Pinata,
-// and returns the CID.
-// POST /api/canvas/publish — returns {"cid": "...", "url": "..."}.
-func (h *CanvasHandler) HandlePublish(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		h.writeError(w, errors.New("method not allowed"), http.StatusMethodNotAllowed)
-		return
-	}
-
-	if h.pinataJWT == "" {
-		h.writeError(w, errors.New("pinata.jwt not configured — set QNTX_PINATA_JWT or pinata.jwt in am.toml"), http.StatusServiceUnavailable)
-		return
-	}
-
-	glyphs, err := h.store.ListGlyphs(r.Context())
-	if err != nil {
-		h.writeError(w, errors.Wrap(err, "failed to list glyphs for publish"), http.StatusInternalServerError)
-		return
-	}
-
-	compositions, err := h.store.ListCompositions(r.Context())
-	if err != nil {
-		h.writeError(w, errors.Wrap(err, "failed to list compositions for publish"), http.StatusInternalServerError)
-		return
-	}
-
-	htmlContent := renderStaticCanvas(glyphs, compositions)
-
-	pinResp, err := ipfs.PinFile(h.pinataJWT, "canvas.html", []byte(htmlContent))
-	if err != nil {
-		h.writeError(w, errors.Wrap(err, "failed to pin canvas to IPFS"), http.StatusBadGateway)
-		return
-	}
-
-	gateway := h.pinataGateway
-	if gateway == "" {
-		gateway = "https://gateway.pinata.cloud"
-	}
-
-	resp := map[string]string{
-		"cid": pinResp.IpfsHash,
-		"url": gateway + "/ipfs/" + pinResp.IpfsHash,
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
 }
 
 // renderStaticCanvas produces a self-contained HTML document from canvas state.

--- a/glyph/handlers/canvas_export.go
+++ b/glyph/handlers/canvas_export.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/teranos/QNTX/errors"
@@ -11,17 +13,29 @@ import (
 	"github.com/teranos/QNTX/sym"
 )
 
-// HandleExportStatic renders the canvas as a self-contained static HTML page.
-// GET /api/canvas/export/static — returns text/html with Content-Disposition attachment.
+// HandleExportStatic renders a subcanvas as a self-contained static HTML page.
+// GET /api/canvas/export/static?canvas_id=<id> — returns text/html with Content-Disposition attachment.
+// Only available in demo mode (QNTX_DEMO=1).
 func (h *CanvasHandler) HandleExportStatic(w http.ResponseWriter, r *http.Request) {
+	if os.Getenv("QNTX_DEMO") != "1" {
+		h.writeError(w, errors.New("canvas export only available in demo mode (make demo)"), http.StatusForbidden)
+		return
+	}
+
 	if r.Method != http.MethodGet {
 		h.writeError(w, errors.New("method not allowed"), http.StatusMethodNotAllowed)
 		return
 	}
 
-	glyphs, err := h.store.ListGlyphs(r.Context())
+	canvasID := r.URL.Query().Get("canvas_id")
+	if canvasID == "" {
+		h.writeError(w, errors.New("canvas_id query parameter is required"), http.StatusBadRequest)
+		return
+	}
+
+	glyphs, err := h.store.ListGlyphsByCanvas(r.Context(), canvasID)
 	if err != nil {
-		h.writeError(w, errors.Wrap(err, "failed to list glyphs for export"), http.StatusInternalServerError)
+		h.writeError(w, errors.Wrapf(err, "failed to list glyphs for canvas %s", canvasID), http.StatusInternalServerError)
 		return
 	}
 
@@ -31,7 +45,30 @@ func (h *CanvasHandler) HandleExportStatic(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	htmlContent := renderStaticCanvas(glyphs, compositions)
+	// Filter compositions to only those whose members all belong to this canvas
+	glyphIDs := make(map[string]bool, len(glyphs))
+	for _, g := range glyphs {
+		glyphIDs[g.ID] = true
+	}
+	var canvasComps []*storage.CanvasComposition
+	for _, comp := range compositions {
+		allLocal := true
+		for _, edge := range comp.Edges {
+			if !glyphIDs[edge.From] || !glyphIDs[edge.To] {
+				allLocal = false
+				break
+			}
+		}
+		if allLocal {
+			canvasComps = append(canvasComps, comp)
+		}
+	}
+
+	htmlContent, err := renderStaticCanvas(glyphs, canvasComps)
+	if err != nil {
+		h.writeError(w, errors.Wrap(err, "failed to render static canvas"), http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="canvas.html"`)
@@ -39,7 +76,18 @@ func (h *CanvasHandler) HandleExportStatic(w http.ResponseWriter, r *http.Reques
 }
 
 // renderStaticCanvas produces a self-contained HTML document from canvas state.
-func renderStaticCanvas(glyphs []*storage.CanvasGlyph, compositions []*storage.CanvasComposition) string {
+func renderStaticCanvas(glyphs []*storage.CanvasGlyph, compositions []*storage.CanvasComposition) (string, error) {
+	// Read CSS files from web directory
+	coreCSS, err := os.ReadFile(filepath.Join("web", "css", "core.css"))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read core.css")
+	}
+	canvasCSS, err := os.ReadFile(filepath.Join("web", "css", "canvas.css"))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read canvas.css")
+	}
+	combinedCSS := string(coreCSS) + "\n" + string(canvasCSS)
+
 	// Build glyph ID → composition membership map
 	glyphToComp := make(map[string]*storage.CanvasComposition)
 	for _, comp := range compositions {
@@ -83,7 +131,7 @@ func renderStaticCanvas(glyphs []*storage.CanvasGlyph, compositions []*storage.C
 </div>
 </div>
 </body>
-</html>`, staticCSS, glyphsHTML.String())
+</html>`, combinedCSS, glyphsHTML.String()), nil
 }
 
 // renderComposition renders a melded composition container with its member glyphs.
@@ -321,187 +369,3 @@ func noteInlineStyle() string {
 
 // staticCSS contains all styles needed to render the canvas snapshot.
 // Inlined to produce a fully self-contained HTML file.
-const staticCSS = `
-/* Reset */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-body {
-    font-family: system-ui, -apple-system, sans-serif;
-    margin: 0;
-    padding: 0;
-    background: #1a1b1a;
-    color: #dfe1e0;
-}
-
-/* Canvas workspace */
-.canvas-workspace {
-    width: 100%;
-    min-height: 100vh;
-    position: relative;
-    overflow: auto;
-    background-color: #2d2e36;
-    background-image:
-        repeating-linear-gradient(0deg, transparent, transparent 23px, #2f353c 23px, #2f353c 24px),
-        repeating-linear-gradient(90deg, transparent, transparent 23px, #2f353c 23px, #2f353c 24px);
-}
-
-.canvas-content-layer {
-    position: relative;
-    min-height: 100vh;
-}
-
-/* Glyph base */
-.canvas-glyph {
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    background-color: #252625;
-    border: 1px solid #3f4140;
-    border-radius: 4px;
-    overflow: hidden;
-}
-
-/* Title bar */
-.canvas-glyph-title-bar {
-    height: 32px;
-    background-color: #2e2f2e;
-    border-bottom: 1px solid #3f4140;
-    display: flex;
-    align-items: center;
-    padding: 0 8px;
-    gap: 8px;
-    flex-shrink: 0;
-    font-size: 13px;
-    color: rgba(255, 255, 255, 0.7);
-}
-
-/* Content */
-.glyph-content {
-    flex: 1;
-    padding: 8px;
-    overflow: auto;
-    font-size: 13px;
-}
-
-.glyph-content pre {
-    margin: 0;
-    white-space: pre-wrap;
-    word-break: break-word;
-    overflow-wrap: break-word;
-    font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Fira Code', 'Consolas', monospace;
-    font-size: 13px;
-    line-height: 1.5;
-    color: #d4d4d4;
-}
-
-.glyph-content code {
-    font-family: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Fira Code', 'Consolas', monospace;
-    font-size: 13px;
-}
-
-/* Query glyphs (AX, SE) */
-.glyph-query {
-    display: flex;
-    align-items: center;
-    padding: 6px 8px;
-    font-family: 'JetBrains Mono', 'SF Mono', monospace;
-    font-size: 13px;
-    color: #d4d4d4;
-}
-
-/* Note glyph (post-it) */
-.note-content {
-    padding: 4px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    font-size: 14px;
-    line-height: 1.2;
-    white-space: pre-wrap;
-    word-break: break-word;
-    overflow-wrap: break-word;
-}
-
-/* Attestation glyph */
-.canvas-attestation-glyph {
-    background: #1a1b1a;
-    border: 1px solid #3f4140;
-    border-radius: 3px;
-    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.2);
-    color: rgba(255, 255, 255, 0.85);
-}
-
-.attestation-content {
-    font-family: monospace;
-    font-size: 12px;
-    color: rgba(255, 255, 255, 0.85);
-}
-
-/* Document glyph */
-.canvas-doc-glyph {
-    border: 1px solid #3f4140;
-    border-radius: 3px;
-    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.2);
-    color: rgba(255, 255, 255, 0.85);
-}
-
-.doc-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    color: #999;
-    font-size: 14px;
-}
-
-/* Subcanvas glyph */
-.canvas-subcanvas-glyph .canvas-glyph-title-bar {
-    background: #3a2d5a;
-    color: #c0a0e8;
-}
-
-.subcanvas-preview {
-    flex: 1;
-    overflow: hidden;
-    background-color: #2d2e36;
-    background-image:
-        repeating-linear-gradient(0deg, transparent, transparent 9px, rgba(160, 120, 200, 0.08) 9px, rgba(160, 120, 200, 0.08) 10px),
-        repeating-linear-gradient(90deg, transparent, transparent 9px, rgba(160, 120, 200, 0.08) 9px, rgba(160, 120, 200, 0.08) 10px);
-    min-height: 60px;
-}
-
-/* Python glyph title bar accent */
-.canvas-py-glyph .canvas-glyph-title-bar {
-    background: #2a5578;
-}
-
-/* TypeScript glyph title bar accent */
-.canvas-ts-glyph .canvas-glyph-title-bar {
-    background: #2d4f7c;
-}
-
-/* Prompt glyph title bar accent */
-.canvas-prompt-glyph .canvas-glyph-title-bar {
-    background: #3d2e2e;
-}
-
-/* Melded composition */
-.melded-composition {
-    display: grid;
-    grid-auto-flow: column;
-    grid-auto-columns: auto;
-    gap: 0;
-    position: absolute;
-    background: transparent;
-}
-
-.melded-composition .canvas-glyph {
-    position: relative;
-}
-
-/* Responsive: scroll on small screens */
-@media (max-width: 768px) {
-    .canvas-workspace {
-        overflow: auto;
-        -webkit-overflow-scrolling: touch;
-    }
-}
-`

--- a/glyph/handlers/canvas_export_test.go
+++ b/glyph/handlers/canvas_export_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	glyphstorage "github.com/teranos/QNTX/glyph/storage"
+	qntxtest "github.com/teranos/QNTX/internal/testing"
+	"github.com/teranos/QNTX/sym"
+)
+
+func TestCanvasHandler_HandleExportStatic_Empty(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	store := glyphstorage.NewCanvasStore(db)
+	handler := NewCanvasHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleExportStatic(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "<!DOCTYPE html>") {
+		t.Fatal("response should be an HTML document")
+	}
+	if !strings.Contains(body, "canvas-workspace") {
+		t.Fatal("response should contain canvas-workspace class")
+	}
+	if w.Header().Get("Content-Type") != "text/html; charset=utf-8" {
+		t.Fatalf("expected text/html content type, got %s", w.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(w.Header().Get("Content-Disposition"), "canvas.html") {
+		t.Fatalf("expected attachment disposition, got %s", w.Header().Get("Content-Disposition"))
+	}
+}
+
+func TestCanvasHandler_HandleExportStatic_WithGlyphs(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	store := glyphstorage.NewCanvasStore(db)
+	handler := NewCanvasHandler(store)
+
+	// Create glyphs of various types
+	pyContent := "print('hello')"
+	noteContent := "# My Note"
+	glyphs := []*glyphstorage.CanvasGlyph{
+		{ID: "py-1", Symbol: "py", X: 100, Y: 200, Content: &pyContent},
+		{ID: "ax-1", Symbol: sym.AX, X: 400, Y: 200},
+		{ID: "note-1", Symbol: sym.Prose, X: 100, Y: 500, Content: &noteContent},
+	}
+
+	ctx := t.Context()
+	for _, g := range glyphs {
+		if err := store.UpsertGlyph(ctx, g); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleExportStatic(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+
+	// Verify glyphs appear in output
+	if !strings.Contains(body, "canvas-py-glyph") {
+		t.Fatal("should contain Python glyph class")
+	}
+	if !strings.Contains(body, "canvas-ax-glyph") {
+		t.Fatal("should contain AX glyph class")
+	}
+	if !strings.Contains(body, "canvas-note-glyph") {
+		t.Fatal("should contain Note glyph class")
+	}
+	if !strings.Contains(body, "print(&#39;hello&#39;)") {
+		t.Fatal("should contain escaped Python content")
+	}
+	if !strings.Contains(body, "# My Note") {
+		t.Fatal("should contain note content")
+	}
+	if !strings.Contains(body, "left:100px") {
+		t.Fatal("should contain glyph position")
+	}
+}
+
+func TestCanvasHandler_HandleExportStatic_MethodNotAllowed(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	store := glyphstorage.NewCanvasStore(db)
+	handler := NewCanvasHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/canvas/export/static", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleExportStatic(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}

--- a/glyph/handlers/canvas_export_test.go
+++ b/glyph/handlers/canvas_export_test.go
@@ -16,7 +16,7 @@ func TestCanvasHandler_HandleExportStatic_Empty(t *testing.T) {
 	store := glyphstorage.NewCanvasStore(db)
 	handler := NewCanvasHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static?canvas_id=subcanvas-1", nil)
 	w := httptest.NewRecorder()
 
 	handler.HandleExportStatic(w, req)
@@ -45,13 +45,15 @@ func TestCanvasHandler_HandleExportStatic_WithGlyphs(t *testing.T) {
 	store := glyphstorage.NewCanvasStore(db)
 	handler := NewCanvasHandler(store)
 
-	// Create glyphs of various types
+	canvasID := "subcanvas-abc"
+
+	// Create glyphs belonging to the target subcanvas
 	pyContent := "print('hello')"
 	noteContent := "# My Note"
 	glyphs := []*glyphstorage.CanvasGlyph{
-		{ID: "py-1", Symbol: "py", X: 100, Y: 200, Content: &pyContent},
-		{ID: "ax-1", Symbol: sym.AX, X: 400, Y: 200},
-		{ID: "note-1", Symbol: sym.Prose, X: 100, Y: 500, Content: &noteContent},
+		{ID: "py-1", Symbol: "py", X: 100, Y: 200, Content: &pyContent, CanvasID: canvasID},
+		{ID: "ax-1", Symbol: sym.AX, X: 400, Y: 200, CanvasID: canvasID},
+		{ID: "note-1", Symbol: sym.Prose, X: 100, Y: 500, Content: &noteContent, CanvasID: canvasID},
 	}
 
 	ctx := t.Context()
@@ -61,7 +63,7 @@ func TestCanvasHandler_HandleExportStatic_WithGlyphs(t *testing.T) {
 		}
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static?canvas_id="+canvasID, nil)
 	w := httptest.NewRecorder()
 
 	handler.HandleExportStatic(w, req)
@@ -90,6 +92,79 @@ func TestCanvasHandler_HandleExportStatic_WithGlyphs(t *testing.T) {
 	}
 	if !strings.Contains(body, "left:100px") {
 		t.Fatal("should contain glyph position")
+	}
+}
+
+func TestCanvasHandler_HandleExportStatic_MissingCanvasID(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	store := glyphstorage.NewCanvasStore(db)
+	handler := NewCanvasHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleExportStatic(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCanvasHandler_HandleExportStatic_CanvasIsolation(t *testing.T) {
+	db := qntxtest.CreateTestDB(t)
+	store := glyphstorage.NewCanvasStore(db)
+	handler := NewCanvasHandler(store)
+
+	ctx := t.Context()
+
+	// Glyph on root canvas
+	rootContent := "root glyph content"
+	if err := store.UpsertGlyph(ctx, &glyphstorage.CanvasGlyph{
+		ID: "root-1", Symbol: "py", X: 10, Y: 10, Content: &rootContent, CanvasID: "",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Glyph on target subcanvas
+	subContent := "sub glyph content"
+	if err := store.UpsertGlyph(ctx, &glyphstorage.CanvasGlyph{
+		ID: "sub-1", Symbol: sym.AX, X: 20, Y: 20, Content: &subContent, CanvasID: "subcanvas-target",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Glyph on a different subcanvas
+	otherContent := "other glyph content"
+	if err := store.UpsertGlyph(ctx, &glyphstorage.CanvasGlyph{
+		ID: "other-1", Symbol: sym.Prose, X: 30, Y: 30, Content: &otherContent, CanvasID: "subcanvas-other",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/canvas/export/static?canvas_id=subcanvas-target", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleExportStatic(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+
+	// Target canvas glyph should appear
+	if !strings.Contains(body, "sub glyph content") {
+		t.Fatal("should contain target subcanvas glyph content")
+	}
+
+	// Root canvas glyph should NOT appear
+	if strings.Contains(body, "root glyph content") {
+		t.Fatal("should NOT contain root canvas glyph content")
+	}
+
+	// Other subcanvas glyph should NOT appear
+	if strings.Contains(body, "other glyph content") {
+		t.Fatal("should NOT contain other subcanvas glyph content")
 	}
 }
 

--- a/glyph/handlers/canvas_publish.go
+++ b/glyph/handlers/canvas_publish.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/teranos/QNTX/errors"
+	"github.com/teranos/QNTX/glyph/ipfs"
+)
+
+// PublishResponse is returned by HandlePublish.
+type PublishResponse struct {
+	CID        string `json:"cid,omitempty"`
+	IPFSURL    string `json:"url,omitempty"`
+	GitPath    string `json:"git_path,omitempty"`
+	GitCommit  string `json:"git_commit,omitempty"`
+}
+
+// HandlePublish renders the canvas as static HTML and publishes it.
+// Publishes to IPFS (if Pinata configured) and to git (docs/demo/index.html).
+// POST /api/canvas/publish — returns PublishResponse.
+func (h *CanvasHandler) HandlePublish(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, errors.New("method not allowed"), http.StatusMethodNotAllowed)
+		return
+	}
+
+	glyphs, err := h.store.ListGlyphs(r.Context())
+	if err != nil {
+		h.writeError(w, errors.Wrap(err, "failed to list glyphs for publish"), http.StatusInternalServerError)
+		return
+	}
+
+	compositions, err := h.store.ListCompositions(r.Context())
+	if err != nil {
+		h.writeError(w, errors.Wrap(err, "failed to list compositions for publish"), http.StatusInternalServerError)
+		return
+	}
+
+	htmlContent := renderStaticCanvas(glyphs, compositions)
+
+	resp := PublishResponse{}
+
+	// Pin to IPFS via Pinata (if configured)
+	if h.pinataJWT != "" {
+		pinResp, err := ipfs.PinFile(h.pinataJWT, "canvas.html", []byte(htmlContent))
+		if err != nil {
+			h.writeError(w, errors.Wrap(err, "failed to pin canvas to IPFS"), http.StatusBadGateway)
+			return
+		}
+
+		gateway := h.pinataGateway
+		if gateway == "" {
+			gateway = "https://gateway.pinata.cloud"
+		}
+
+		resp.CID = pinResp.IpfsHash
+		resp.IPFSURL = gateway + "/ipfs/" + pinResp.IpfsHash
+	}
+
+	// Commit to git — write docs/demo/index.html and commit
+	gitPath, gitCommit, err := commitDemoToGit(htmlContent)
+	if err != nil {
+		// Git publish is best-effort — log but don't fail if IPFS succeeded
+		if resp.CID == "" {
+			h.writeError(w, errors.Wrap(err, "failed to publish demo canvas to git"), http.StatusInternalServerError)
+			return
+		}
+		// IPFS succeeded, git failed — include error info but still 200
+	} else {
+		resp.GitPath = gitPath
+		resp.GitCommit = gitCommit
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// commitDemoToGit writes the rendered HTML to docs/demo/index.html,
+// commits, and returns the relative path and commit hash.
+func commitDemoToGit(htmlContent string) (string, string, error) {
+	// Find git root
+	gitRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", "", errors.Wrap(err, "not in a git repository")
+	}
+	root := filepath.Clean(string(gitRoot[:len(gitRoot)-1])) // trim newline
+
+	demoDir := filepath.Join(root, "docs", "demo")
+	if err := os.MkdirAll(demoDir, 0755); err != nil {
+		return "", "", errors.Wrapf(err, "failed to create %s", demoDir)
+	}
+
+	demoPath := filepath.Join(demoDir, "index.html")
+	if err := os.WriteFile(demoPath, []byte(htmlContent), 0644); err != nil {
+		return "", "", errors.Wrapf(err, "failed to write %s", demoPath)
+	}
+
+	relPath := "docs/demo/index.html"
+
+	// Stage the file
+	addCmd := exec.Command("git", "add", relPath)
+	addCmd.Dir = root
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return "", "", errors.Wrapf(err, "git add failed: %s", string(out))
+	}
+
+	// Check if there are staged changes
+	diffCmd := exec.Command("git", "diff", "--cached", "--quiet", relPath)
+	diffCmd.Dir = root
+	if err := diffCmd.Run(); err == nil {
+		// No changes — file is identical to HEAD
+		// Return current HEAD hash
+		headCmd := exec.Command("git", "rev-parse", "HEAD")
+		headCmd.Dir = root
+		headOut, _ := headCmd.Output()
+		return relPath, string(headOut[:len(headOut)-1]), nil
+	}
+
+	// Commit
+	commitCmd := exec.Command("git", "commit", "-m", "Publish demo canvas")
+	commitCmd.Dir = root
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		return "", "", errors.Wrapf(err, "git commit failed: %s", string(out))
+	}
+
+	// Get commit hash
+	hashCmd := exec.Command("git", "rev-parse", "HEAD")
+	hashCmd.Dir = root
+	hashOut, err := hashCmd.Output()
+	if err != nil {
+		return relPath, "", errors.Wrap(err, "failed to get commit hash")
+	}
+
+	return relPath, string(hashOut[:len(hashOut)-1]), nil
+}

--- a/glyph/handlers/canvas_publish.go
+++ b/glyph/handlers/canvas_publish.go
@@ -4,33 +4,51 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/glyph/ipfs"
+	"github.com/teranos/QNTX/glyph/storage"
 )
 
 // PublishResponse is returned by HandlePublish.
 type PublishResponse struct {
-	CID        string `json:"cid,omitempty"`
-	IPFSURL    string `json:"url,omitempty"`
-	GitPath    string `json:"git_path,omitempty"`
-	GitCommit  string `json:"git_commit,omitempty"`
+	CID     string `json:"cid,omitempty"`
+	IPFSURL string `json:"url,omitempty"`
+	Path    string `json:"path,omitempty"`
 }
 
-// HandlePublish renders the canvas as static HTML and publishes it.
-// Publishes to IPFS (if Pinata configured) and to git (docs/demo/index.html).
-// POST /api/canvas/publish — returns PublishResponse.
+// HandlePublish renders a subcanvas as static HTML and publishes it.
+// Publishes to IPFS (if Pinata configured) and writes docs/demo/index.html.
+// POST /api/canvas/publish — requires canvas_id in JSON body, returns PublishResponse.
+// Only available in demo mode (QNTX_DEMO=1).
 func (h *CanvasHandler) HandlePublish(w http.ResponseWriter, r *http.Request) {
+	if os.Getenv("QNTX_DEMO") != "1" {
+		h.writeError(w, errors.New("canvas publish only available in demo mode (make demo)"), http.StatusForbidden)
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		h.writeError(w, errors.New("method not allowed"), http.StatusMethodNotAllowed)
 		return
 	}
 
-	glyphs, err := h.store.ListGlyphs(r.Context())
+	var body struct {
+		CanvasID string `json:"canvas_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.writeError(w, errors.Wrap(err, "invalid request body"), http.StatusBadRequest)
+		return
+	}
+	if body.CanvasID == "" {
+		h.writeError(w, errors.New("canvas_id is required"), http.StatusBadRequest)
+		return
+	}
+
+	glyphs, err := h.store.ListGlyphsByCanvas(r.Context(), body.CanvasID)
 	if err != nil {
-		h.writeError(w, errors.Wrap(err, "failed to list glyphs for publish"), http.StatusInternalServerError)
+		h.writeError(w, errors.Wrapf(err, "failed to list glyphs for canvas %s", body.CanvasID), http.StatusInternalServerError)
 		return
 	}
 
@@ -40,7 +58,30 @@ func (h *CanvasHandler) HandlePublish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	htmlContent := renderStaticCanvas(glyphs, compositions)
+	// Filter compositions to only those whose members all belong to this canvas
+	glyphIDs := make(map[string]bool, len(glyphs))
+	for _, g := range glyphs {
+		glyphIDs[g.ID] = true
+	}
+	var canvasComps []*storage.CanvasComposition
+	for _, comp := range compositions {
+		allLocal := true
+		for _, edge := range comp.Edges {
+			if !glyphIDs[edge.From] || !glyphIDs[edge.To] {
+				allLocal = false
+				break
+			}
+		}
+		if allLocal {
+			canvasComps = append(canvasComps, comp)
+		}
+	}
+
+	htmlContent, err := renderStaticCanvas(glyphs, canvasComps)
+	if err != nil {
+		h.writeError(w, errors.Wrap(err, "failed to render static canvas"), http.StatusInternalServerError)
+		return
+	}
 
 	resp := PublishResponse{}
 
@@ -61,79 +102,45 @@ func (h *CanvasHandler) HandlePublish(w http.ResponseWriter, r *http.Request) {
 		resp.IPFSURL = gateway + "/ipfs/" + pinResp.IpfsHash
 	}
 
-	// Commit to git — write docs/demo/index.html and commit
-	gitPath, gitCommit, err := commitDemoToGit(htmlContent)
+	// Write rendered HTML to docs/demo/index.html
+	demoPath, err := writeDemoHTML(htmlContent)
 	if err != nil {
-		// Git publish is best-effort — log but don't fail if IPFS succeeded
 		if resp.CID == "" {
-			h.writeError(w, errors.Wrap(err, "failed to publish demo canvas to git"), http.StatusInternalServerError)
+			h.writeError(w, errors.Wrap(err, "failed to write demo canvas"), http.StatusInternalServerError)
 			return
 		}
-		// IPFS succeeded, git failed — include error info but still 200
+		// IPFS succeeded, file write failed — still return 200
 	} else {
-		resp.GitPath = gitPath
-		resp.GitCommit = gitCommit
+		resp.Path = demoPath
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
 }
 
-// commitDemoToGit writes the rendered HTML to docs/demo/index.html,
-// commits, and returns the relative path and commit hash.
-func commitDemoToGit(htmlContent string) (string, string, error) {
-	// Find git root
-	gitRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+// writeDemoHTML writes the rendered HTML to docs/demo/index.html relative to
+// the working directory. Returns the path written.
+func writeDemoHTML(htmlContent string) (string, error) {
+	// Use working directory — no git dependency
+	wd, err := os.Getwd()
 	if err != nil {
-		return "", "", errors.Wrap(err, "not in a git repository")
+		return "", errors.Wrap(err, "failed to get working directory")
 	}
-	root := filepath.Clean(string(gitRoot[:len(gitRoot)-1])) // trim newline
 
-	demoDir := filepath.Join(root, "docs", "demo")
+	demoDir := filepath.Join(wd, "docs", "demo")
 	if err := os.MkdirAll(demoDir, 0755); err != nil {
-		return "", "", errors.Wrapf(err, "failed to create %s", demoDir)
+		return "", errors.Wrapf(err, "failed to create %s", demoDir)
 	}
 
 	demoPath := filepath.Join(demoDir, "index.html")
 	if err := os.WriteFile(demoPath, []byte(htmlContent), 0644); err != nil {
-		return "", "", errors.Wrapf(err, "failed to write %s", demoPath)
+		return "", errors.Wrapf(err, "failed to write %s", demoPath)
 	}
 
-	relPath := "docs/demo/index.html"
-
-	// Stage the file
-	addCmd := exec.Command("git", "add", relPath)
-	addCmd.Dir = root
-	if out, err := addCmd.CombinedOutput(); err != nil {
-		return "", "", errors.Wrapf(err, "git add failed: %s", string(out))
-	}
-
-	// Check if there are staged changes
-	diffCmd := exec.Command("git", "diff", "--cached", "--quiet", relPath)
-	diffCmd.Dir = root
-	if err := diffCmd.Run(); err == nil {
-		// No changes — file is identical to HEAD
-		// Return current HEAD hash
-		headCmd := exec.Command("git", "rev-parse", "HEAD")
-		headCmd.Dir = root
-		headOut, _ := headCmd.Output()
-		return relPath, string(headOut[:len(headOut)-1]), nil
-	}
-
-	// Commit
-	commitCmd := exec.Command("git", "commit", "-m", "Publish demo canvas")
-	commitCmd.Dir = root
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		return "", "", errors.Wrapf(err, "git commit failed: %s", string(out))
-	}
-
-	// Get commit hash
-	hashCmd := exec.Command("git", "rev-parse", "HEAD")
-	hashCmd.Dir = root
-	hashOut, err := hashCmd.Output()
+	// Return relative path for display
+	rel, err := filepath.Rel(wd, demoPath)
 	if err != nil {
-		return relPath, "", errors.Wrap(err, "failed to get commit hash")
+		rel = demoPath
 	}
-
-	return relPath, string(hashOut[:len(hashOut)-1]), nil
+	return filepath.ToSlash(strings.TrimPrefix(rel, "./")), nil
 }

--- a/glyph/ipfs/pin.go
+++ b/glyph/ipfs/pin.go
@@ -1,0 +1,82 @@
+package ipfs
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/teranos/QNTX/errors"
+)
+
+const pinataURL = "https://api.pinata.cloud/pinning/pinFileToIPFS"
+
+// PinResponse is the response from Pinata's pinFileToIPFS endpoint.
+type PinResponse struct {
+	IpfsHash    string `json:"IpfsHash"`
+	PinSize     int    `json:"PinSize"`
+	Timestamp   string `json:"Timestamp"`
+	IsDuplicate bool   `json:"isDuplicate"`
+}
+
+// PinFile pins a file to IPFS via Pinata and returns the CID.
+func PinFile(jwt string, filename string, content []byte) (*PinResponse, error) {
+	if jwt == "" {
+		return nil, errors.New("pinata.jwt not configured — set QNTX_PINATA_JWT or pinata.jwt in am.toml")
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create multipart file field")
+	}
+	if _, err := part.Write(content); err != nil {
+		return nil, errors.Wrap(err, "failed to write content to multipart form")
+	}
+
+	metadata, _ := json.Marshal(map[string]any{
+		"name": filename,
+	})
+	_ = writer.WriteField("pinataMetadata", string(metadata))
+
+	options, _ := json.Marshal(map[string]any{
+		"cidVersion": 1,
+	})
+	_ = writer.WriteField("pinataOptions", string(options))
+
+	if err := writer.Close(); err != nil {
+		return nil, errors.Wrap(err, "failed to close multipart writer")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, pinataURL, body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Pinata HTTP request")
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "Pinata pin request failed")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read Pinata response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Newf("Pinata returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var pinResp PinResponse
+	if err := json.Unmarshal(respBody, &pinResp); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse Pinata response: %s", string(respBody))
+	}
+
+	return &pinResp, nil
+}

--- a/glyph/storage/canvas_store.go
+++ b/glyph/storage/canvas_store.go
@@ -22,6 +22,7 @@ type CanvasGlyph struct {
 	Width     *int32    `json:"width,omitempty"`
 	Height    *int32    `json:"height,omitempty"`
 	Content   *string   `json:"content,omitempty"`
+	CanvasID  string    `json:"canvas_id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
@@ -88,8 +89,8 @@ func (s *CanvasStore) UpsertGlyph(ctx context.Context, glyph *CanvasGlyph) error
 	glyph.UpdatedAt = now
 
 	query := `
-		INSERT INTO canvas_glyphs (id, symbol, x, y, width, height, content, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO canvas_glyphs (id, symbol, x, y, width, height, content, canvas_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			symbol = excluded.symbol,
 			x = excluded.x,
@@ -97,12 +98,14 @@ func (s *CanvasStore) UpsertGlyph(ctx context.Context, glyph *CanvasGlyph) error
 			width = excluded.width,
 			height = excluded.height,
 			content = excluded.content,
+			canvas_id = excluded.canvas_id,
 			updated_at = excluded.updated_at
 	`
 
 	_, err := s.db.ExecContext(ctx, query,
 		glyph.ID, glyph.Symbol, glyph.X, glyph.Y,
 		glyph.Width, glyph.Height, glyph.Content,
+		glyph.CanvasID,
 		glyph.CreatedAt.Format(time.RFC3339Nano),
 		glyph.UpdatedAt.Format(time.RFC3339Nano),
 	)
@@ -115,7 +118,7 @@ func (s *CanvasStore) UpsertGlyph(ctx context.Context, glyph *CanvasGlyph) error
 
 // GetGlyph retrieves a glyph by ID
 func (s *CanvasStore) GetGlyph(ctx context.Context, id string) (*CanvasGlyph, error) {
-	query := `SELECT id, symbol, x, y, width, height, content, created_at, updated_at
+	query := `SELECT id, symbol, x, y, width, height, content, canvas_id, created_at, updated_at
 	          FROM canvas_glyphs WHERE id = ?`
 
 	var glyph CanvasGlyph
@@ -124,6 +127,7 @@ func (s *CanvasStore) GetGlyph(ctx context.Context, id string) (*CanvasGlyph, er
 	err := s.db.QueryRowContext(ctx, query, id).Scan(
 		&glyph.ID, &glyph.Symbol, &glyph.X, &glyph.Y,
 		&glyph.Width, &glyph.Height, &glyph.Content,
+		&glyph.CanvasID,
 		&createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -148,7 +152,7 @@ func (s *CanvasStore) GetGlyph(ctx context.Context, id string) (*CanvasGlyph, er
 
 // ListGlyphs returns all glyphs
 func (s *CanvasStore) ListGlyphs(ctx context.Context) ([]*CanvasGlyph, error) {
-	query := `SELECT id, symbol, x, y, width, height, content, created_at, updated_at
+	query := `SELECT id, symbol, x, y, width, height, content, canvas_id, created_at, updated_at
 	          FROM canvas_glyphs ORDER BY created_at ASC`
 
 	rows, err := s.db.QueryContext(ctx, query)
@@ -165,6 +169,7 @@ func (s *CanvasStore) ListGlyphs(ctx context.Context) ([]*CanvasGlyph, error) {
 		if err := rows.Scan(
 			&glyph.ID, &glyph.Symbol, &glyph.X, &glyph.Y,
 			&glyph.Width, &glyph.Height, &glyph.Content,
+			&glyph.CanvasID,
 			&createdAt, &updatedAt,
 		); err != nil {
 			return nil, errors.Wrap(err, "failed to scan canvas glyph")
@@ -185,6 +190,51 @@ func (s *CanvasStore) ListGlyphs(ctx context.Context) ([]*CanvasGlyph, error) {
 
 	if err := rows.Err(); err != nil {
 		return nil, errors.Wrap(err, "error iterating canvas glyphs")
+	}
+
+	return glyphs, nil
+}
+
+// ListGlyphsByCanvas returns glyphs belonging to a specific canvas
+func (s *CanvasStore) ListGlyphsByCanvas(ctx context.Context, canvasID string) ([]*CanvasGlyph, error) {
+	query := `SELECT id, symbol, x, y, width, height, content, canvas_id, created_at, updated_at
+	          FROM canvas_glyphs WHERE canvas_id = ? ORDER BY created_at ASC`
+
+	rows, err := s.db.QueryContext(ctx, query, canvasID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list canvas glyphs for canvas %s", canvasID)
+	}
+	defer rows.Close()
+
+	var glyphs []*CanvasGlyph
+	for rows.Next() {
+		var glyph CanvasGlyph
+		var createdAt, updatedAt string
+
+		if err := rows.Scan(
+			&glyph.ID, &glyph.Symbol, &glyph.X, &glyph.Y,
+			&glyph.Width, &glyph.Height, &glyph.Content,
+			&glyph.CanvasID,
+			&createdAt, &updatedAt,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to scan canvas glyph")
+		}
+
+		var parseErr error
+		glyph.CreatedAt, parseErr = time.Parse(time.RFC3339Nano, createdAt)
+		if parseErr != nil {
+			return nil, errors.Wrapf(parseErr, "invalid created_at timestamp for glyph %s: %s", glyph.ID, createdAt)
+		}
+		glyph.UpdatedAt, parseErr = time.Parse(time.RFC3339Nano, updatedAt)
+		if parseErr != nil {
+			return nil, errors.Wrapf(parseErr, "invalid updated_at timestamp for glyph %s: %s", glyph.ID, updatedAt)
+		}
+
+		glyphs = append(glyphs, &glyph)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error iterating canvas glyphs for canvas %s", canvasID)
 	}
 
 	return glyphs, nil

--- a/server/init.go
+++ b/server/init.go
@@ -324,6 +324,9 @@ func NewQNTXServer(db *sql.DB, dbPath string, verbosity int, initialQuery ...str
 	if server.watcherEngine != nil {
 		canvasOpts = append(canvasOpts, handlers.WithWatcherEngine(server.watcherEngine, serverLogger))
 	}
+	if deps.config.Pinata.JWT != "" {
+		canvasOpts = append(canvasOpts, handlers.WithPinata(deps.config.Pinata.JWT, deps.config.Pinata.Gateway))
+	}
 	server.canvasHandler = handlers.NewCanvasHandler(canvasStore, canvasOpts...)
 	serverLogger.Infow("Canvas state handlers initialized")
 

--- a/server/routing.go
+++ b/server/routing.go
@@ -95,6 +95,7 @@ func (s *QNTXServer) setupHTTPRoutes() {
 	http.HandleFunc("/api/watchers/", wrap(s.HandleWatchers))                                       // Watcher CRUD (GET/PUT/DELETE /api/watchers/{id})
 	http.HandleFunc("/api/watchers", wrap(s.HandleWatchers))                                        // List/create watchers (GET/POST)
 	http.HandleFunc("/api/attestations", wrap(s.HandleCreateAttestation))                           // Sync browser-created attestations (POST)
+	http.HandleFunc("/api/canvas/export/static", wrap(s.canvasHandler.HandleExportStatic))           // Static HTML export (GET)
 	http.HandleFunc("/api/canvas/glyphs/", wrap(s.canvasHandler.HandleGlyphs))                      // Glyph CRUD (GET/POST/DELETE /api/canvas/glyphs/{id})
 	http.HandleFunc("/api/canvas/glyphs", wrap(s.canvasHandler.HandleGlyphs))                       // List/create glyphs (GET/POST)
 	http.HandleFunc("/api/canvas/compositions/", wrap(s.canvasHandler.HandleCompositions))          // Composition CRUD (GET/POST/DELETE /api/canvas/compositions/{id})

--- a/server/routing.go
+++ b/server/routing.go
@@ -96,6 +96,7 @@ func (s *QNTXServer) setupHTTPRoutes() {
 	http.HandleFunc("/api/watchers", wrap(s.HandleWatchers))                                        // List/create watchers (GET/POST)
 	http.HandleFunc("/api/attestations", wrap(s.HandleCreateAttestation))                           // Sync browser-created attestations (POST)
 	http.HandleFunc("/api/canvas/export/static", wrap(s.canvasHandler.HandleExportStatic))           // Static HTML export (GET)
+	http.HandleFunc("/api/canvas/publish", wrap(s.canvasHandler.HandlePublish))                     // Publish canvas to IPFS (POST)
 	http.HandleFunc("/api/canvas/glyphs/", wrap(s.canvasHandler.HandleGlyphs))                      // Glyph CRUD (GET/POST/DELETE /api/canvas/glyphs/{id})
 	http.HandleFunc("/api/canvas/glyphs", wrap(s.canvasHandler.HandleGlyphs))                       // List/create glyphs (GET/POST)
 	http.HandleFunc("/api/canvas/compositions/", wrap(s.canvasHandler.HandleCompositions))          // Composition CRUD (GET/POST/DELETE /api/canvas/compositions/{id})

--- a/web/css/canvas.css
+++ b/web/css/canvas.css
@@ -145,11 +145,45 @@
     transition: all 0.15s ease;
 }
 
-/* Inside breadcrumb bar: static positioning, right-aligned via auto margin */
+/* Inside breadcrumb bar: static positioning */
 .canvas-breadcrumb-bar .canvas-minimize-btn {
     position: static;
-    margin-left: auto;
     z-index: auto;
+}
+
+/* Breadcrumb action buttons (export, publish) — same appearance as minimize */
+.canvas-breadcrumb-action {
+    position: static;
+    z-index: auto;
+    width: 32px;
+    height: 32px;
+    background: var(--bg-tertiary);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    color: rgba(255, 255, 255, 0.85);
+    opacity: 0.95;
+    border-radius: 6px;
+    font-size: 16px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s ease;
+}
+
+.canvas-breadcrumb-action:first-of-type {
+    margin-left: auto;
+}
+
+.canvas-breadcrumb-action:hover {
+    background: #3a3b3a;
+    border-color: rgba(255, 255, 255, 0.45);
+    color: rgba(255, 255, 255, 1);
+    opacity: 1;
+}
+
+.canvas-breadcrumb-action:active {
+    background: rgba(255, 255, 255, 0.15);
+    transform: scale(0.95);
 }
 
 .canvas-minimize-btn:hover {

--- a/web/ts/api/canvas-sync.ts
+++ b/web/ts/api/canvas-sync.ts
@@ -208,6 +208,7 @@ class CanvasSyncQueueImpl {
                 width: glyph.width != null ? Math.round(glyph.width) : undefined,
                 height: glyph.height != null ? Math.round(glyph.height) : undefined,
                 content: glyph.content,
+                canvas_id: glyph.canvas_id ?? '',
             }),
         });
 

--- a/web/ts/api/canvas.ts
+++ b/web/ts/api/canvas.ts
@@ -146,6 +146,21 @@ export async function exportCanvasStatic(): Promise<void> {
 }
 
 /**
+ * Publish the canvas to IPFS via Pinata.
+ * Returns the CID and gateway URL.
+ */
+export async function publishCanvas(): Promise<{ cid: string; url: string }> {
+    const response = await apiFetch('/api/canvas/publish', { method: 'POST' });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to publish canvas');
+    }
+    const result = await response.json();
+    log.info(SEG.GLYPH, `[CanvasAPI] Published canvas to IPFS: ${result.cid}`);
+    return result;
+}
+
+/**
  * Load all canvas state from backend (glyphs + compositions + minimized windows)
  * Converts backend format to frontend state format
  */

--- a/web/ts/api/canvas.ts
+++ b/web/ts/api/canvas.ts
@@ -146,17 +146,32 @@ export async function exportCanvasStatic(): Promise<void> {
 }
 
 /**
- * Publish the canvas to IPFS via Pinata.
- * Returns the CID and gateway URL.
+ * Publish result from POST /api/canvas/publish.
  */
-export async function publishCanvas(): Promise<{ cid: string; url: string }> {
+export interface PublishResult {
+    cid?: string;
+    url?: string;
+    git_path?: string;
+    git_commit?: string;
+}
+
+/**
+ * Publish the canvas — renders static HTML, pins to IPFS (if Pinata configured),
+ * commits to docs/demo/index.html in git.
+ */
+export async function publishCanvas(): Promise<PublishResult> {
     const response = await apiFetch('/api/canvas/publish', { method: 'POST' });
     if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || 'Failed to publish canvas');
     }
-    const result = await response.json();
-    log.info(SEG.GLYPH, `[CanvasAPI] Published canvas to IPFS: ${result.cid}`);
+    const result: PublishResult = await response.json();
+    if (result.cid) {
+        log.info(SEG.GLYPH, `[CanvasAPI] Published canvas to IPFS: ${result.cid}`);
+    }
+    if (result.git_commit) {
+        log.info(SEG.GLYPH, `[CanvasAPI] Published canvas to git: ${result.git_path} (${result.git_commit.substring(0, 7)})`);
+    }
     return result;
 }
 

--- a/web/ts/api/canvas.ts
+++ b/web/ts/api/canvas.ts
@@ -120,6 +120,32 @@ export async function listCompositions(): Promise<Composition[]> {
 }
 
 /**
+ * Export the canvas as a self-contained static HTML page.
+ * Triggers a file download in the browser.
+ */
+export async function exportCanvasStatic(): Promise<void> {
+    const response = await apiFetch('/api/canvas/export/static');
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to export canvas');
+    }
+
+    const htmlContent = await response.text();
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'canvas.html';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    log.info(SEG.GLYPH, '[CanvasAPI] Exported canvas as static HTML');
+}
+
+/**
  * Load all canvas state from backend (glyphs + compositions + minimized windows)
  * Converts backend format to frontend state format
  */

--- a/web/ts/api/canvas.ts
+++ b/web/ts/api/canvas.ts
@@ -120,11 +120,11 @@ export async function listCompositions(): Promise<Composition[]> {
 }
 
 /**
- * Export the canvas as a self-contained static HTML page.
+ * Export a subcanvas as a self-contained static HTML page.
  * Triggers a file download in the browser.
  */
-export async function exportCanvasStatic(): Promise<void> {
-    const response = await apiFetch('/api/canvas/export/static');
+export async function exportCanvasStatic(canvasId: string): Promise<void> {
+    const response = await apiFetch(`/api/canvas/export/static?canvas_id=${encodeURIComponent(canvasId)}`);
     if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || 'Failed to export canvas');
@@ -142,7 +142,7 @@ export async function exportCanvasStatic(): Promise<void> {
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
 
-    log.info(SEG.GLYPH, '[CanvasAPI] Exported canvas as static HTML');
+    log.info(SEG.GLYPH, `[CanvasAPI] Exported canvas ${canvasId} as static HTML`);
 }
 
 /**
@@ -151,26 +151,29 @@ export async function exportCanvasStatic(): Promise<void> {
 export interface PublishResult {
     cid?: string;
     url?: string;
-    git_path?: string;
-    git_commit?: string;
+    path?: string;
 }
 
 /**
- * Publish the canvas — renders static HTML, pins to IPFS (if Pinata configured),
- * commits to docs/demo/index.html in git.
+ * Publish a subcanvas — renders static HTML, pins to IPFS (if Pinata configured),
+ * writes docs/demo/index.html.
  */
-export async function publishCanvas(): Promise<PublishResult> {
-    const response = await apiFetch('/api/canvas/publish', { method: 'POST' });
+export async function publishCanvas(canvasId: string): Promise<PublishResult> {
+    const response = await apiFetch('/api/canvas/publish', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ canvas_id: canvasId }),
+    });
     if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || 'Failed to publish canvas');
     }
     const result: PublishResult = await response.json();
     if (result.cid) {
-        log.info(SEG.GLYPH, `[CanvasAPI] Published canvas to IPFS: ${result.cid}`);
+        log.info(SEG.GLYPH, `[CanvasAPI] Published canvas ${canvasId} to IPFS: ${result.cid}`);
     }
-    if (result.git_commit) {
-        log.info(SEG.GLYPH, `[CanvasAPI] Published canvas to git: ${result.git_path} (${result.git_commit.substring(0, 7)})`);
+    if (result.path) {
+        log.info(SEG.GLYPH, `[CanvasAPI] Published canvas ${canvasId} to ${result.path}`);
     }
     return result;
 }

--- a/web/ts/components/glyph/canvas/canvas-workspace-builder.ts
+++ b/web/ts/components/glyph/canvas/canvas-workspace-builder.ts
@@ -237,6 +237,8 @@ export function buildCanvasWorkspace(
     canvasId: string,
     glyphs: Glyph[]
 ): HTMLElement {
+    log.debug(SEG.GLYPH, `[Canvas] buildCanvasWorkspace called with canvasId: "${canvasId}", ${glyphs.length} glyphs`);
+
     const container = document.createElement('div');
     container.className = 'canvas-workspace';
     container.dataset.canvasId = canvasId;

--- a/web/ts/components/glyph/canvas/spawn-menu.ts
+++ b/web/ts/components/glyph/canvas/spawn-menu.ts
@@ -18,7 +18,7 @@ import { createNoteGlyph } from '../note-glyph';
 import { createTsGlyph, TS_DEFAULT_CODE } from '../ts-glyph';
 import { createSubcanvasGlyph } from '../subcanvas-glyph';
 import { uiState } from '../../../state/ui';
-import { exportCanvasStatic } from '../../../api/canvas';
+import { exportCanvasStatic, publishCanvas } from '../../../api/canvas';
 import { toast } from '../../../toast';
 
 /** Duration multiplier for spawn menu animation */
@@ -233,6 +233,30 @@ export function showSpawnMenu(
     });
 
     menu.appendChild(exportBtn);
+
+    // Publish button (IPFS)
+    const publishBtn = document.createElement('button');
+    publishBtn.className = 'canvas-spawn-button';
+    publishBtn.textContent = '⧉';
+    publishBtn.title = 'Publish canvas to IPFS';
+    publishBtn.style.fontSize = '16px';
+
+    publishBtn.addEventListener('click', () => {
+        publishBtn.textContent = '…';
+        publishBtn.disabled = true;
+        publishCanvas().then(result => {
+            toast.success(`Published: ${result.cid}`);
+            navigator.clipboard.writeText(result.url).catch(() => {});
+        }).catch(err => {
+            const message = err instanceof Error ? err.message : String(err);
+            log.error(SEG.GLYPH, `[Canvas] Publish failed: ${message}`);
+            toast.error(`Publish failed: ${message}`);
+        }).finally(() => {
+            removeMenu();
+        });
+    });
+
+    menu.appendChild(publishBtn);
 
     document.body.appendChild(menu);
 

--- a/web/ts/components/glyph/canvas/spawn-menu.ts
+++ b/web/ts/components/glyph/canvas/spawn-menu.ts
@@ -245,8 +245,13 @@ export function showSpawnMenu(
         publishBtn.textContent = '…';
         publishBtn.disabled = true;
         publishCanvas().then(result => {
-            toast.success(`Published: ${result.cid}`);
-            navigator.clipboard.writeText(result.url).catch(() => {});
+            const parts: string[] = [];
+            if (result.cid) parts.push(result.cid);
+            if (result.git_commit) parts.push(`git:${result.git_commit.substring(0, 7)}`);
+            toast.success(`Published: ${parts.join(' + ')}`);
+            if (result.url) {
+                navigator.clipboard.writeText(result.url).catch(() => {});
+            }
         }).catch(err => {
             const message = err instanceof Error ? err.message : String(err);
             log.error(SEG.GLYPH, `[Canvas] Publish failed: ${message}`);

--- a/web/ts/components/glyph/canvas/spawn-menu.ts
+++ b/web/ts/components/glyph/canvas/spawn-menu.ts
@@ -18,6 +18,8 @@ import { createNoteGlyph } from '../note-glyph';
 import { createTsGlyph, TS_DEFAULT_CODE } from '../ts-glyph';
 import { createSubcanvasGlyph } from '../subcanvas-glyph';
 import { uiState } from '../../../state/ui';
+import { exportCanvasStatic } from '../../../api/canvas';
+import { toast } from '../../../toast';
 
 /** Duration multiplier for spawn menu animation */
 const SPAWN_MENU_ANIMATION_SPEED = 0.5;
@@ -206,6 +208,31 @@ export function showSpawnMenu(
     });
 
     menu.appendChild(subcanvasBtn);
+
+    // Separator
+    const separator = document.createElement('div');
+    separator.style.width = '1px';
+    separator.style.background = 'rgba(255, 255, 255, 0.15)';
+    separator.style.alignSelf = 'stretch';
+    menu.appendChild(separator);
+
+    // Export button
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'canvas-spawn-button';
+    exportBtn.textContent = '↓';
+    exportBtn.title = 'Export canvas as static HTML';
+    exportBtn.style.fontSize = '16px';
+
+    exportBtn.addEventListener('click', () => {
+        exportCanvasStatic().catch(err => {
+            const message = err instanceof Error ? err.message : String(err);
+            log.error(SEG.GLYPH, `[Canvas] Export failed: ${message}`);
+            toast.error(`Export failed: ${message}`);
+        });
+        removeMenu();
+    });
+
+    menu.appendChild(exportBtn);
 
     document.body.appendChild(menu);
 

--- a/web/ts/components/glyph/canvas/spawn-menu.ts
+++ b/web/ts/components/glyph/canvas/spawn-menu.ts
@@ -18,8 +18,6 @@ import { createNoteGlyph } from '../note-glyph';
 import { createTsGlyph, TS_DEFAULT_CODE } from '../ts-glyph';
 import { createSubcanvasGlyph } from '../subcanvas-glyph';
 import { uiState } from '../../../state/ui';
-import { exportCanvasStatic, publishCanvas } from '../../../api/canvas';
-import { toast } from '../../../toast';
 
 /** Duration multiplier for spawn menu animation */
 const SPAWN_MENU_ANIMATION_SPEED = 0.5;
@@ -56,6 +54,8 @@ export function showSpawnMenu(
     glyphs: Glyph[],
     canvasId: string = 'canvas-workspace'
 ): void {
+    log.debug(SEG.GLYPH, `[Canvas] showSpawnMenu called with canvasId: "${canvasId}"`);
+
     // Remove any existing menu
     const existingMenu = document.querySelector('.canvas-spawn-menu');
     if (existingMenu) {
@@ -208,60 +208,6 @@ export function showSpawnMenu(
     });
 
     menu.appendChild(subcanvasBtn);
-
-    // Separator
-    const separator = document.createElement('div');
-    separator.style.width = '1px';
-    separator.style.background = 'rgba(255, 255, 255, 0.15)';
-    separator.style.alignSelf = 'stretch';
-    menu.appendChild(separator);
-
-    // Export button
-    const exportBtn = document.createElement('button');
-    exportBtn.className = 'canvas-spawn-button';
-    exportBtn.textContent = '↓';
-    exportBtn.title = 'Export canvas as static HTML';
-    exportBtn.style.fontSize = '16px';
-
-    exportBtn.addEventListener('click', () => {
-        exportCanvasStatic().catch(err => {
-            const message = err instanceof Error ? err.message : String(err);
-            log.error(SEG.GLYPH, `[Canvas] Export failed: ${message}`);
-            toast.error(`Export failed: ${message}`);
-        });
-        removeMenu();
-    });
-
-    menu.appendChild(exportBtn);
-
-    // Publish button (IPFS)
-    const publishBtn = document.createElement('button');
-    publishBtn.className = 'canvas-spawn-button';
-    publishBtn.textContent = '⧉';
-    publishBtn.title = 'Publish canvas to IPFS';
-    publishBtn.style.fontSize = '16px';
-
-    publishBtn.addEventListener('click', () => {
-        publishBtn.textContent = '…';
-        publishBtn.disabled = true;
-        publishCanvas().then(result => {
-            const parts: string[] = [];
-            if (result.cid) parts.push(result.cid);
-            if (result.git_commit) parts.push(`git:${result.git_commit.substring(0, 7)}`);
-            toast.success(`Published: ${parts.join(' + ')}`);
-            if (result.url) {
-                navigator.clipboard.writeText(result.url).catch(() => {});
-            }
-        }).catch(err => {
-            const message = err instanceof Error ? err.message : String(err);
-            log.error(SEG.GLYPH, `[Canvas] Publish failed: ${message}`);
-            toast.error(`Publish failed: ${message}`);
-        }).finally(() => {
-            removeMenu();
-        });
-    });
-
-    menu.appendChild(publishBtn);
 
     document.body.appendChild(menu);
 
@@ -638,6 +584,9 @@ async function spawnNoteGlyph(
     const width = Math.round(rect.width);
     const height = Math.round(rect.height);
 
+    const finalCanvasId = storageCanvasId(canvasId);
+    log.debug(SEG.GLYPH, `[Canvas] Spawning Note glyph - canvasId: "${canvasId}" → storageCanvasId: "${finalCanvasId}"`);
+
     uiState.addCanvasGlyph({
         id: noteGlyph.id,
         symbol: Prose,
@@ -646,10 +595,10 @@ async function spawnNoteGlyph(
         width,
         height,
         content: 'Write here — select and click ⟶ to convert to a prompt glyph.',
-        canvas_id: storageCanvasId(canvasId),
+        canvas_id: finalCanvasId,
     });
 
-    log.debug(SEG.GLYPH, `[Canvas] Spawned Note glyph at (${x}, ${y}) with size ${width}x${height}`);
+    log.debug(SEG.GLYPH, `[Canvas] Spawned Note glyph at (${x}, ${y}) with size ${width}x${height} with canvas_id="${finalCanvasId}"`);
 }
 
 /**

--- a/web/ts/components/glyph/manifestations/canvas-expanded.ts
+++ b/web/ts/components/glyph/manifestations/canvas-expanded.ts
@@ -24,6 +24,8 @@ import { uiState } from '../../../state/ui';
 import { getGlyphTypeBySymbol } from '../glyph-registry';
 import { destroyCanvasSelection } from '../canvas/selection';
 import { pushBreadcrumb, popBreadcrumb, buildBreadcrumbBar } from '../canvas/breadcrumb';
+import { exportCanvasStatic, publishCanvas } from '../../../api/canvas';
+import { toast } from '../../../toast';
 
 /**
  * Morph a canvas-placed glyph to fullscreen workspace
@@ -107,6 +109,47 @@ export function morphCanvasPlacedToFullscreen(
 
             // Build breadcrumb bar with minimize button inside it
             const breadcrumbBar = buildBreadcrumbBar();
+
+            // Export button — download subcanvas as static HTML
+            const exportBtn = document.createElement('button');
+            exportBtn.textContent = '↓';
+            exportBtn.className = 'canvas-breadcrumb-action';
+            exportBtn.title = 'Export subcanvas as static HTML';
+            exportBtn.onclick = () => {
+                exportCanvasStatic(glyph.id).catch(err => {
+                    const message = err instanceof Error ? err.message : String(err);
+                    log.error(SEG.GLYPH, `[Canvas] Export failed: ${message}`);
+                    toast.error(`Export failed: ${message}`);
+                });
+            };
+            breadcrumbBar.appendChild(exportBtn);
+
+            // Publish button — pin to IPFS + write demo HTML
+            const publishBtn = document.createElement('button');
+            publishBtn.textContent = '⧉';
+            publishBtn.className = 'canvas-breadcrumb-action';
+            publishBtn.title = 'Publish subcanvas';
+            publishBtn.onclick = () => {
+                publishBtn.textContent = '…';
+                publishBtn.disabled = true;
+                publishCanvas(glyph.id).then(result => {
+                    const parts: string[] = [];
+                    if (result.cid) parts.push(result.cid);
+                    if (result.path) parts.push(result.path);
+                    toast.success(`Published: ${parts.join(' + ')}`);
+                    if (result.url) {
+                        navigator.clipboard.writeText(result.url).catch(() => {});
+                    }
+                }).catch(err => {
+                    const message = err instanceof Error ? err.message : String(err);
+                    log.error(SEG.GLYPH, `[Canvas] Publish failed: ${message}`);
+                    toast.error(`Publish failed: ${message}`);
+                }).finally(() => {
+                    publishBtn.textContent = '⧉';
+                    publishBtn.disabled = false;
+                });
+            };
+            breadcrumbBar.appendChild(publishBtn);
 
             const minimizeBtn = document.createElement('button');
             minimizeBtn.textContent = '−';


### PR DESCRIPTION
## Use Cases

### 1. Provenance/Verification
Show someone on Bluesky where their automatically generated comment/post came from. When QNTX generates a post, export the canvas that created it as verifiable proof of the generation process.

### 2. Storefront/Showcase  
Demonstrate QNTX capabilities by publishing example canvases (IPFS + docs/demo/). Show what's possible with the tool.

### 3. Static Site Generation
Canvas export as part of static site generation workflow. Publish canvases as static HTML pages.

---

## What Works

✅ **Canvas_id tracking** - Glyphs correctly store parent canvas ID, validated in demo.db  
✅ **Export backend** - Generates static HTML from canvas state  
✅ **Demo mode gating** - Feature isolated to `make demo` via QNTX_DEMO=1  
✅ **Basic rendering** - Notes, queries, code glyphs render  
✅ **IPFS publishing** - Code exists (untested)

## What's Broken/Incomplete

❌ **CSS quality** - Reads from web/css/ but doesn't match live app polish  
❌ **Python glyph** - Visual rendering issues  
❌ **Premature composition code** - Meld export not ready (feature incomplete in main app)  
❌ **Overall appearance** - Exported HTML looks "cheap" vs live canvas

## Architecture Issues

The static HTML reconstruction approach fights an uphill battle - we're rebuilding the entire canvas rendering in a different context. 

**For verification use case:** Screenshot-based export might be simpler and more trustworthy (harder to tamper with).

**For storefront/site-gen use cases:** Need near-perfect visual fidelity, which means solving CSS parity completely.

## Next Steps (if continuing)

1. Fix CSS to exactly match live app (variables, glyph-specific styles)
2. Remove premature composition code
3. Consider hybrid: screenshot for verification, styled HTML for showcase/site-gen
4. Or: Abandon HTML reconstruction, use screenshot + metadata approach

---

**Validates:** Canvas_id system works end-to-end ✅  
**Question:** Is HTML reconstruction the right approach for these use cases?