### PR TITLE
Fix typegen: map protocol.Attestation to As

### DIFF
--- a/typegen/typescript/generator.go
+++ b/typegen/typescript/generator.go
@@ -96,6 +96,8 @@ var TypeMapping = map[string]string{
 	"NullString":     "string | null",
 	"NullInt64":      "number | null",
 	"NullTime":       "string | null",
+	// Cross-package struct references
+	"protocol.Attestation": "As",
 }
 
 // typeConverterConfig is the TypeScript-specific type conversion configuration

--- a/types/generated/typescript/server.ts
+++ b/types/generated/typescript/server.ts
@@ -387,7 +387,7 @@ export interface PromptDirectResponse {
   /**
    * Full attestation with signature
    */
-  attestation?: Attestation | null;
+  attestation?: As | null;
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;


### PR DESCRIPTION
## Summary

- Add `protocol.Attestation` → `As` to TypeScript type mapping in typegen
- Regenerated `server.ts` — `attestation` fields now correctly typed as `As | null`

Closes #601

## Test plan

- [x] `bun run typecheck` — clean
- [x] `make test` — 668 pass, 0 fail