### PR TITLE
Live plugin activity stream

### DIFF
--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -70,6 +70,7 @@ type managedPlugin struct {
 	port         int
 	stdoutLogger *pluginLogger
 	stderrLogger *pluginLogger
+	logBuffer    *LogBuffer
 }
 
 const (
@@ -151,6 +152,7 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 	var port int
 	var stdoutLogger *pluginLogger
 	var stderrLogger *pluginLogger
+	var logBuf *LogBuffer
 
 	if config.Address != "" {
 		// Plugin is already running at the specified address
@@ -164,7 +166,7 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 
 		var err error
 		var actualPort int
-		process, actualPort, stdoutLogger, stderrLogger, err = m.launchPlugin(ctx, config, port)
+		process, actualPort, stdoutLogger, stderrLogger, logBuf, err = m.launchPlugin(ctx, config, port)
 		if err != nil {
 			return errors.Wrapf(err, "failed to launch plugin %s (binary=%s, port=%d)",
 				config.Name, config.Binary, port)
@@ -235,6 +237,7 @@ func (m *PluginManager) loadPlugin(ctx context.Context, config PluginConfig) err
 		port:         port,
 		stdoutLogger: stdoutLogger,
 		stderrLogger: stderrLogger,
+		logBuffer:    logBuf,
 	}
 
 	m.logger.Infof("Plugin '%s' v%s loaded and ready - %s",
@@ -276,16 +279,16 @@ func (m *PluginManager) allocatePort() int {
 	return port
 }
 
-// launchPlugin starts a plugin binary and returns the process, actual port, and loggers.
+// launchPlugin starts a plugin binary and returns the process, actual port, loggers, and log buffer.
 // If the plugin outputs QNTX_PLUGIN_PORT=XXXX, that port is returned instead of the requested port.
-func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, port int) (*os.Process, int, *pluginLogger, *pluginLogger, error) {
+func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, port int) (*os.Process, int, *pluginLogger, *pluginLogger, *LogBuffer, error) {
 	binary := config.Binary
 
 	// Resolve relative paths
 	if !filepath.IsAbs(binary) {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return nil, 0, nil, nil, errors.Wrapf(err, "failed to get home directory for plugin %s", config.Name)
+			return nil, 0, nil, nil, nil, errors.Wrapf(err, "failed to get home directory for plugin %s", config.Name)
 		}
 		binary = filepath.Join(home, ".qntx", "plugins", binary)
 	}
@@ -293,7 +296,7 @@ func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, p
 	// Check if binary exists
 	if _, err := os.Stat(binary); os.IsNotExist(err) {
 		err := errors.Newf("plugin binary not found for %s: %s", config.Name, binary)
-		return nil, 0, nil, nil, errors.WithHint(err, "install the plugin binary to ~/.qntx/plugins/ or specify the full path in config")
+		return nil, 0, nil, nil, nil, errors.WithHint(err, "install the plugin binary to ~/.qntx/plugins/ or specify the full path in config")
 	}
 
 	// Build command arguments
@@ -317,17 +320,22 @@ func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, p
 	// Create a channel to receive the actual port from plugin output
 	portChan := make(chan int, 1)
 
+	// Create shared log buffer for live streaming
+	logBuf := NewLogBuffer(200)
+
 	// Capture output for debugging and port discovery
 	stdoutLogger := &pluginLogger{
-		logger:   m.logger,
-		name:     config.Name,
-		level:    "info",
-		portChan: portChan,
+		logger:    m.logger,
+		name:      config.Name,
+		level:     "info",
+		portChan:  portChan,
+		logBuffer: logBuf,
 	}
 	stderrLogger := &pluginLogger{
-		logger: m.logger,
-		name:   config.Name,
-		level:  "error",
+		logger:    m.logger,
+		name:      config.Name,
+		level:     "error",
+		logBuffer: logBuf,
 		// Don't pass portChan to stderr - port announcement should be on stdout
 	}
 
@@ -335,7 +343,7 @@ func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, p
 	cmd.Stderr = stderrLogger
 
 	if err := cmd.Start(); err != nil {
-		return nil, 0, nil, nil, errors.Wrapf(err, "failed to start plugin %s (binary=%s, args=%v)",
+		return nil, 0, nil, nil, nil, errors.Wrapf(err, "failed to start plugin %s (binary=%s, args=%v)",
 			config.Name, binary, args)
 	}
 
@@ -357,7 +365,7 @@ func (m *PluginManager) launchPlugin(ctx context.Context, config PluginConfig, p
 			"port", port)
 	}
 
-	return cmd.Process, actualPort, stdoutLogger, stderrLogger, nil
+	return cmd.Process, actualPort, stdoutLogger, stderrLogger, logBuf, nil
 }
 
 // waitForPlugin waits for a plugin's gRPC server to become ready.
@@ -423,6 +431,18 @@ func (m *PluginManager) GetPlugin(name string) (plugin.DomainPlugin, bool) {
 		return p.client, true
 	}
 	return nil, false
+}
+
+// GetLogBuffer returns the log buffer for a managed plugin.
+// Returns nil if the plugin doesn't exist or has no log buffer (e.g., remote plugins).
+func (m *PluginManager) GetLogBuffer(name string) *LogBuffer {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if p, ok := m.plugins[name]; ok {
+		return p.logBuffer
+	}
+	return nil
 }
 
 // GetAllPlugins returns all connected plugins as DomainPlugin instances.
@@ -511,12 +531,13 @@ func (m *PluginManager) Shutdown(ctx context.Context) error {
 
 // pluginLogger logs plugin output and captures port announcements.
 type pluginLogger struct {
-	logger   *zap.SugaredLogger
-	name     string
-	level    string
-	buf      strings.Builder
-	portChan chan int     // Optional channel to send discovered port
-	mu       sync.RWMutex // Protects name field for dynamic updates
+	logger    *zap.SugaredLogger
+	name      string
+	level     string
+	buf       strings.Builder
+	portChan  chan int     // Optional channel to send discovered port
+	logBuffer *LogBuffer   // Optional ring buffer for log streaming
+	mu        sync.RWMutex // Protects name field for dynamic updates
 }
 
 // updateName safely updates the logger's name with version info
@@ -566,6 +587,20 @@ func (l *pluginLogger) Write(p []byte) (n int, err error) {
 			actualLevel := l.level // Default to configured level (stdout=info, stderr=error)
 			if err := json.Unmarshal([]byte(line), &logEntry); err == nil && logEntry.Level != "" {
 				actualLevel = logEntry.Level
+			}
+
+			// Write to log buffer for live streaming
+			if l.logBuffer != nil {
+				source := "stdout"
+				if l.level == "error" {
+					source = "stderr"
+				}
+				l.logBuffer.Write(LogEntry{
+					Timestamp: time.Now(),
+					Level:     actualLevel,
+					Line:      line,
+					Source:    source,
+				})
 			}
 
 			// Log at the actual level from JSON, or fallback to configured level for non-JSON

--- a/plugin/grpc/logbuffer.go
+++ b/plugin/grpc/logbuffer.go
@@ -1,0 +1,98 @@
+package grpc
+
+import (
+	"sync"
+	"time"
+)
+
+// LogEntry represents a single log line from a plugin process.
+type LogEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Level     string    `json:"level"`
+	Line      string    `json:"line"`
+	Source    string    `json:"source"` // "stdout" or "stderr"
+}
+
+// LogBuffer is a fixed-size ring buffer that captures recent plugin log entries
+// and supports pub/sub for live streaming.
+type LogBuffer struct {
+	mu          sync.RWMutex
+	entries     []LogEntry
+	capacity    int
+	head        int // next write position
+	count       int // entries currently stored
+	subscribers map[chan LogEntry]struct{}
+}
+
+// NewLogBuffer creates a ring buffer with the given capacity.
+func NewLogBuffer(capacity int) *LogBuffer {
+	return &LogBuffer{
+		entries:     make([]LogEntry, capacity),
+		capacity:    capacity,
+		subscribers: make(map[chan LogEntry]struct{}),
+	}
+}
+
+// Write appends an entry to the ring and fans out to all subscribers.
+func (b *LogBuffer) Write(entry LogEntry) {
+	b.mu.Lock()
+	b.entries[b.head] = entry
+	b.head = (b.head + 1) % b.capacity
+	if b.count < b.capacity {
+		b.count++
+	}
+
+	// Snapshot subscribers under lock to avoid holding lock during send
+	subs := make([]chan LogEntry, 0, len(b.subscribers))
+	for ch := range b.subscribers {
+		subs = append(subs, ch)
+	}
+	b.mu.Unlock()
+
+	// Non-blocking fan-out — drop if subscriber is slow
+	for _, ch := range subs {
+		select {
+		case ch <- entry:
+		default:
+		}
+	}
+}
+
+// Recent returns the last n entries in chronological order.
+func (b *LogBuffer) Recent(n int) []LogEntry {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if n > b.count {
+		n = b.count
+	}
+	if n == 0 {
+		return nil
+	}
+
+	result := make([]LogEntry, n)
+	// Start position: oldest of the n entries we want
+	start := (b.head - n + b.capacity) % b.capacity
+	for i := 0; i < n; i++ {
+		result[i] = b.entries[(start+i)%b.capacity]
+	}
+	return result
+}
+
+// Subscribe returns a channel that receives new log entries.
+// The channel is buffered to absorb short bursts without blocking writers.
+func (b *LogBuffer) Subscribe() chan LogEntry {
+	ch := make(chan LogEntry, 64)
+	b.mu.Lock()
+	b.subscribers[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel and closes it.
+func (b *LogBuffer) Unsubscribe(ch chan LogEntry) {
+	b.mu.Lock()
+	delete(b.subscribers, ch)
+	b.mu.Unlock()
+	close(ch)
+}

--- a/plugin/grpc/logbuffer_test.go
+++ b/plugin/grpc/logbuffer_test.go
@@ -1,0 +1,240 @@
+package grpc
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func makeEntry(i int) LogEntry {
+	return LogEntry{
+		Timestamp: time.Now(),
+		Level:     "info",
+		Line:      fmt.Sprintf("line-%d", i),
+		Source:    "stdout",
+	}
+}
+
+func TestLogBuffer_RecentOnEmpty(t *testing.T) {
+	buf := NewLogBuffer(10)
+	assert.Nil(t, buf.Recent(10))
+	assert.Nil(t, buf.Recent(0))
+}
+
+func TestLogBuffer_WriteAndRecent(t *testing.T) {
+	buf := NewLogBuffer(10)
+
+	for i := 0; i < 3; i++ {
+		buf.Write(makeEntry(i))
+	}
+
+	entries := buf.Recent(3)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "line-0", entries[0].Line)
+	assert.Equal(t, "line-1", entries[1].Line)
+	assert.Equal(t, "line-2", entries[2].Line)
+}
+
+func TestLogBuffer_RecentCapsAtCount(t *testing.T) {
+	buf := NewLogBuffer(10)
+
+	for i := 0; i < 3; i++ {
+		buf.Write(makeEntry(i))
+	}
+
+	entries := buf.Recent(100)
+	assert.Len(t, entries, 3)
+}
+
+func TestLogBuffer_RingWraparound(t *testing.T) {
+	capacity := 5
+	buf := NewLogBuffer(capacity)
+
+	// Write capacity + 5 entries — first 5 should be evicted
+	total := capacity + 5
+	for i := 0; i < total; i++ {
+		buf.Write(makeEntry(i))
+	}
+
+	entries := buf.Recent(capacity)
+	require.Len(t, entries, capacity)
+
+	// Should contain the last `capacity` entries in order
+	for i := 0; i < capacity; i++ {
+		expected := fmt.Sprintf("line-%d", total-capacity+i)
+		assert.Equal(t, expected, entries[i].Line)
+	}
+}
+
+func TestLogBuffer_SubscribeReceivesNewEntries(t *testing.T) {
+	buf := NewLogBuffer(10)
+	ch := buf.Subscribe()
+	defer buf.Unsubscribe(ch)
+
+	entry := makeEntry(42)
+	buf.Write(entry)
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, "line-42", got.Line)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for entry on subscriber channel")
+	}
+}
+
+func TestLogBuffer_UnsubscribeStopsDelivery(t *testing.T) {
+	buf := NewLogBuffer(10)
+	ch := buf.Subscribe()
+	buf.Unsubscribe(ch)
+
+	buf.Write(makeEntry(0))
+
+	// Channel should be closed
+	_, ok := <-ch
+	assert.False(t, ok, "channel should be closed after unsubscribe")
+}
+
+func TestLogBuffer_MultipleSubscribers(t *testing.T) {
+	buf := NewLogBuffer(10)
+
+	subs := make([]chan LogEntry, 3)
+	for i := range subs {
+		subs[i] = buf.Subscribe()
+		defer buf.Unsubscribe(subs[i])
+	}
+
+	buf.Write(makeEntry(7))
+
+	for i, ch := range subs {
+		select {
+		case got := <-ch:
+			assert.Equal(t, "line-7", got.Line, "subscriber %d", i)
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timeout", i)
+		}
+	}
+}
+
+func TestLogBuffer_NonBlockingFanOut(t *testing.T) {
+	buf := NewLogBuffer(10)
+
+	// Subscriber with tiny buffer — will fill up immediately
+	slow := buf.Subscribe()
+	defer buf.Unsubscribe(slow)
+
+	// Fast subscriber
+	fast := buf.Subscribe()
+	defer buf.Unsubscribe(fast)
+
+	// Fill slow subscriber's buffer (64 capacity)
+	for i := 0; i < 70; i++ {
+		buf.Write(makeEntry(i))
+	}
+
+	// Fast subscriber should have received entries (drain to verify)
+	drained := 0
+	for {
+		select {
+		case <-fast:
+			drained++
+		default:
+			goto done
+		}
+	}
+done:
+	assert.Greater(t, drained, 0, "fast subscriber should have received entries despite slow subscriber")
+}
+
+func TestLogBuffer_ConcurrentWrites(t *testing.T) {
+	capacity := 100
+	buf := NewLogBuffer(capacity)
+
+	var wg sync.WaitGroup
+	writers := 10
+	perWriter := 100
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				buf.Write(LogEntry{
+					Timestamp: time.Now(),
+					Level:     "info",
+					Line:      fmt.Sprintf("w%d-%d", workerID, i),
+					Source:    "stdout",
+				})
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	entries := buf.Recent(capacity)
+	assert.Len(t, entries, capacity, "should have exactly capacity entries after overflow")
+
+	// All lines should be non-empty (no zero-value entries)
+	for i, e := range entries {
+		assert.NotEmpty(t, e.Line, "entry %d should not be empty", i)
+	}
+}
+
+// --- pluginLogger → LogBuffer integration ---
+
+func TestPluginLogger_WritesToLogBuffer(t *testing.T) {
+	buf := NewLogBuffer(10)
+	logger := &pluginLogger{
+		logger:    zap.NewNop().Sugar(),
+		name:      "test-plugin",
+		level:     "info",
+		logBuffer: buf,
+	}
+
+	n, err := logger.Write([]byte("hello world\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 12, n)
+
+	entries := buf.Recent(1)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "hello world", entries[0].Line)
+	assert.Equal(t, "info", entries[0].Level)
+	assert.Equal(t, "stdout", entries[0].Source)
+}
+
+func TestPluginLogger_JSONLevelExtraction(t *testing.T) {
+	buf := NewLogBuffer(10)
+	logger := &pluginLogger{
+		logger:    zap.NewNop().Sugar(),
+		name:      "test-plugin",
+		level:     "info",
+		logBuffer: buf,
+	}
+
+	logger.Write([]byte(`{"level":"warn","msg":"something happened"}` + "\n"))
+
+	entries := buf.Recent(1)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "warn", entries[0].Level)
+}
+
+func TestPluginLogger_StderrSource(t *testing.T) {
+	buf := NewLogBuffer(10)
+	logger := &pluginLogger{
+		logger:    zap.NewNop().Sugar(),
+		name:      "test-plugin",
+		level:     "error", // stderr logger has level "error"
+		logBuffer: buf,
+	}
+
+	logger.Write([]byte("panic: something broke\n"))
+
+	entries := buf.Recent(1)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "stderr", entries[0].Source)
+	assert.Equal(t, "error", entries[0].Level)
+}

--- a/qntx-python/src/service.rs
+++ b/qntx-python/src/service.rs
@@ -21,8 +21,9 @@ use crate::engine::PythonEngine;
 use crate::handlers::{HandlerContext, PluginState};
 use crate::proto::{
     domain_plugin_service_server::DomainPluginService, ConfigSchemaResponse, Empty,
-    ExecuteJobRequest, ExecuteJobResponse, HealthResponse, HttpHeader, HttpRequest, HttpResponse,
-    InitializeRequest, InitializeResponse, MetadataResponse, WebSocketMessage,
+    ExecuteJobRequest, ExecuteJobResponse, GlyphDefResponse, HealthResponse, HttpHeader,
+    HttpRequest, HttpResponse, InitializeRequest, InitializeResponse, MetadataResponse,
+    WebSocketMessage,
 };
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -466,6 +467,14 @@ impl DomainPluginService for PythonPluginService {
         }))
     }
 
+    /// Register custom glyph types (none for Python plugin)
+    async fn register_glyphs(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<GlyphDefResponse>, Status> {
+        Ok(Response::new(GlyphDefResponse { glyphs: vec![] }))
+    }
+
     /// Execute an async job
     /// Routes to appropriate handler based on handler_name
     async fn execute_job(
@@ -562,6 +571,8 @@ impl PythonPluginService {
                 progress_current: 0,
                 progress_total: 0,
                 cost_actual: 0.0,
+                log_entries: vec![],
+                plugin_version: env!("CARGO_PKG_VERSION").to_string(),
             }))
         } else {
             // Execution failed
@@ -574,6 +585,8 @@ impl PythonPluginService {
                 progress_current: 0,
                 progress_total: 0,
                 cost_actual: 0.0,
+                log_entries: vec![],
+                plugin_version: env!("CARGO_PKG_VERSION").to_string(),
             }))
         }
     }
@@ -641,6 +654,8 @@ impl PythonPluginService {
                 progress_current: 0,
                 progress_total: 0,
                 cost_actual: 0.0,
+                log_entries: vec![],
+                plugin_version: env!("CARGO_PKG_VERSION").to_string(),
             }))
         } else {
             // Execution failed
@@ -653,6 +668,8 @@ impl PythonPluginService {
                 progress_current: 0,
                 progress_total: 0,
                 cost_actual: 0.0,
+                log_entries: vec![],
+                plugin_version: env!("CARGO_PKG_VERSION").to_string(),
             }))
         }
     }

--- a/server/plugin_log_handlers.go
+++ b/server/plugin_log_handlers.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	grpcplugin "github.com/teranos/QNTX/plugin/grpc"
+)
+
+// HandlePluginLogs streams plugin log entries via Server-Sent Events.
+// GET /api/plugins/{name}/logs
+func (s *QNTXServer) HandlePluginLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Parse plugin name from path: /api/plugins/{name}/logs
+	path := strings.TrimPrefix(r.URL.Path, "/api/plugins/")
+	pluginName := strings.TrimSuffix(path, "/logs")
+
+	if pluginName == "" {
+		writeError(w, http.StatusBadRequest, "plugin name required in URL path")
+		return
+	}
+
+	pm := s.getPluginManager()
+	if pm == nil {
+		writeError(w, http.StatusServiceUnavailable, "plugin manager not available")
+		return
+	}
+
+	buf := pm.GetLogBuffer(pluginName)
+	if buf == nil {
+		writeError(w, http.StatusNotFound,
+			fmt.Sprintf("no log buffer for plugin '%s' (remote plugins don't have local logs)", pluginName))
+		return
+	}
+
+	// SSE headers
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Send recent history as initial batch
+	history := buf.Recent(200)
+	for _, entry := range history {
+		writeSSEEntry(w, entry)
+	}
+	flusher.Flush()
+
+	// Subscribe for new entries
+	ch := buf.Subscribe()
+	defer buf.Unsubscribe(ch)
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry, ok := <-ch:
+			if !ok {
+				return
+			}
+			writeSSEEntry(w, entry)
+			flusher.Flush()
+		}
+	}
+}
+
+func writeSSEEntry(w http.ResponseWriter, entry grpcplugin.LogEntry) {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "data: %s\n\n", data)
+}

--- a/server/routing.go
+++ b/server/routing.go
@@ -87,6 +87,7 @@ func (s *QNTXServer) setupHTTPRoutes() {
 	http.HandleFunc("/api/pulse/jobs/", wrap(s.HandlePulseJob))                                     // Individual async job and sub-resources (GET)
 	http.HandleFunc("/api/pulse/jobs", wrap(s.HandlePulseJobs))                                     // List async jobs (GET)
 	http.HandleFunc("/api/prompt/", wrap(s.HandlePrompt))                                           // Prompt operations (preview/execute/list/save/get/versions)
+	http.HandleFunc("/api/plugins/{name}/logs", wrap(s.HandlePluginLogs))                           // Plugin log stream (SSE)
 	http.HandleFunc("/api/plugins/{name}/config", wrap(s.HandlePluginConfig))                       // Plugin configuration (GET/PUT)
 	http.HandleFunc("/api/plugins/glyphs", wrap(s.HandlePluginGlyphs))                              // List custom plugin glyphs (GET)
 	http.HandleFunc("/api/plugins/", wrap(s.HandlePluginAction))                                    // Plugin actions: pause/resume (POST)

--- a/web/css/plugin-panel.css
+++ b/web/css/plugin-panel.css
@@ -593,6 +593,71 @@
     white-space: pre-wrap;
 }
 
+/* Log Viewer */
+.plugin-log-viewer {
+    margin-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 10px;
+}
+
+.plugin-log-header {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #6b7280;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+}
+
+.plugin-log-container {
+    max-height: 240px;
+    overflow-y: auto;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+    padding: 6px 0;
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.plugin-log-entry {
+    display: flex;
+    gap: 8px;
+    padding: 1px 8px;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.plugin-log-entry:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.plugin-log-time {
+    flex-shrink: 0;
+    color: #6b7280;
+}
+
+.plugin-log-level {
+    flex-shrink: 0;
+    width: 42px;
+    text-align: right;
+}
+
+.plugin-log-line {
+    flex: 1;
+    color: #d1d5db;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+/* Log level colors */
+.plugin-log-level-debug .plugin-log-level { color: #6b7280; }
+.plugin-log-level-info .plugin-log-level { color: #60a5fa; }
+.plugin-log-level-warn .plugin-log-level { color: #fbbf24; }
+.plugin-log-level-error .plugin-log-level { color: #f87171; }
+.plugin-log-level-error .plugin-log-line { color: #fca5a5; }
+
 /* Responsive */
 @media (max-width: 768px) {
     .plugin-card-header {

--- a/web/ts/plugin-panel.ts
+++ b/web/ts/plugin-panel.ts
@@ -94,6 +94,9 @@ let contentElement: HTMLElement | null = null;
 // Tooltip cleanup function
 let tooltipCleanup: (() => void) | null = null;
 
+// Log stream state
+let activeLogStream: EventSource | null = null;
+
 async function fetchServerHealth(): Promise<void> {
     try {
         const response = await apiFetch('/health');
@@ -231,6 +234,7 @@ function attachEventDelegation(): void {
             e.stopPropagation();
             expandedPlugin = null;
             configState = null;
+            disconnectLogStream();
             render();
             return;
         }
@@ -451,7 +455,7 @@ function renderPlugin(plugin: PluginInfo): string {
             </div>
             ${controls ? `<div class="plugin-controls">${controls}</div>` : ''}
             ${!plugin.healthy && plugin.message ? `<div class="plugin-message plugin-message-error">${escapeHtml(plugin.message)}</div>` : ''}
-            ${isExpanded ? renderConfigForm() : ''}
+            ${isExpanded ? renderExpandedContent(plugin) : ''}
         </div>
     `;
 }
@@ -518,11 +522,17 @@ async function togglePluginConfig(pluginName: string): Promise<void> {
     if (expandedPlugin === pluginName) {
         expandedPlugin = null;
         configState = null;
+        disconnectLogStream();
     } else {
         expandedPlugin = pluginName;
         await fetchPluginConfig(pluginName);
     }
     render();
+
+    // Connect log stream after render so the container DOM exists
+    if (expandedPlugin) {
+        connectLogStream(expandedPlugin);
+    }
 }
 
 async function fetchPluginConfig(pluginName: string): Promise<void> {
@@ -583,6 +593,16 @@ async function fetchPluginConfig(pluginName: string): Promise<void> {
         };
         render();
     }
+}
+
+function renderExpandedContent(plugin: PluginInfo): string {
+    return `
+        <div class="plugin-log-viewer">
+            <div class="plugin-log-header">Activity Log</div>
+            <div class="plugin-log-container" data-plugin="${escapeHtml(plugin.name)}"></div>
+        </div>
+        ${renderConfigForm()}
+    `;
 }
 
 function renderConfigForm(): string {
@@ -806,6 +826,81 @@ async function savePluginConfig(): Promise<void> {
             configState.needsConfirmation = false;
             render();
         }
+    }
+}
+
+interface LogEntryData {
+    timestamp: string;
+    level: string;
+    line: string;
+    source: string;
+}
+
+function connectLogStream(pluginName: string): void {
+    disconnectLogStream();
+
+    const backendUrl = (window as any).__BACKEND_URL__ || window.location.origin;
+    const url = `${backendUrl}/api/plugins/${pluginName}/logs`;
+    const es = new EventSource(url, { withCredentials: true });
+
+    es.onmessage = (event: MessageEvent) => {
+        try {
+            const entry: LogEntryData = JSON.parse(event.data);
+            appendLogEntry(pluginName, entry);
+        } catch {
+            // Ignore malformed entries
+        }
+    };
+
+    es.onerror = () => {
+        // EventSource auto-reconnects; nothing to do
+    };
+
+    activeLogStream = es;
+}
+
+function disconnectLogStream(): void {
+    if (activeLogStream) {
+        activeLogStream.close();
+        activeLogStream = null;
+    }
+}
+
+function appendLogEntry(pluginName: string, entry: LogEntryData): void {
+    if (!contentElement) return;
+
+    const container = contentElement.querySelector(`.plugin-log-container[data-plugin="${pluginName}"]`);
+    if (!container) return;
+
+    const row = document.createElement('div');
+    row.className = `plugin-log-entry plugin-log-level-${entry.level}`;
+
+    const time = document.createElement('span');
+    time.className = 'plugin-log-time';
+    const date = new Date(entry.timestamp);
+    const hh = String(date.getHours()).padStart(2, '0');
+    const mm = String(date.getMinutes()).padStart(2, '0');
+    const ss = String(date.getSeconds()).padStart(2, '0');
+    time.textContent = `${hh}:${mm}:${ss}`;
+
+    const level = document.createElement('span');
+    level.className = 'plugin-log-level';
+    level.textContent = entry.level.toUpperCase();
+
+    const line = document.createElement('span');
+    line.className = 'plugin-log-line';
+    line.textContent = entry.line;
+
+    row.appendChild(time);
+    row.appendChild(level);
+    row.appendChild(line);
+    container.appendChild(row);
+
+    // Auto-scroll if near bottom
+    const scrollThreshold = 40;
+    const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < scrollThreshold;
+    if (isNearBottom) {
+        container.scrollTop = container.scrollHeight;
     }
 }
 


### PR DESCRIPTION
## Summary

- Ring buffer (200 entries) per managed plugin captures stdout/stderr with level detection
- SSE endpoint (`/api/plugins/{name}/logs`) streams history + live entries
- Plugin panel shows log viewer on card expand, disconnects on collapse

## Test plan

- [x] `make test` passes (666 frontend + all Go tests)
- [x] 12 new tests in `plugin/grpc/logbuffer_test.go`: ring wraparound, pub/sub, concurrent writes, pluginLogger integration
- [x] Manual: expand plugin card → log history appears → generate activity → new lines stream in
- [ ] Manual: collapse card → verify EventSource disconnects in devtools