### PR TITLE
Auto-refresh AT Protocol session on token expiry

### DIFF
--- a/qntx-atproto/handlers.go
+++ b/qntx-atproto/handlers.go
@@ -75,10 +75,13 @@ func (p *Plugin) handleProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := p.getClient()
-	profile, err := appbsky.ActorGetProfile(r.Context(), client, client.Auth.Did)
-	if err != nil {
-		p.Services().Logger("atproto").Errorw("Failed to get profile", "did", client.Auth.Did, "error", err)
+	var profile *appbsky.ActorDefs_ProfileViewDetailed
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		profile, err = appbsky.ActorGetProfile(r.Context(), c, c.Auth.Did)
+		return err
+	}); err != nil {
+		p.Services().Logger("atproto").Errorw("Failed to get profile", "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to get profile: %v", err))
 		return
 	}
@@ -102,8 +105,12 @@ func (p *Plugin) handleActorProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	profile, err := appbsky.ActorGetProfile(r.Context(), p.getClient(), actor)
-	if err != nil {
+	var profile *appbsky.ActorDefs_ProfileViewDetailed
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		profile, err = appbsky.ActorGetProfile(r.Context(), c, actor)
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to get actor profile", "actor", actor, "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to get profile for %s: %v", actor, err))
 		return
@@ -129,8 +136,12 @@ func (p *Plugin) handleTimeline(w http.ResponseWriter, r *http.Request) {
 	}
 	cursor := r.URL.Query().Get("cursor")
 
-	resp, err := appbsky.FeedGetTimeline(r.Context(), p.getClient(), "", cursor, limit)
-	if err != nil {
+	var resp *appbsky.FeedGetTimeline_Output
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		resp, err = appbsky.FeedGetTimeline(r.Context(), c, "", cursor, limit)
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to get timeline", "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to get timeline: %v", err))
 		return
@@ -163,8 +174,12 @@ func (p *Plugin) handleAuthorFeed(w http.ResponseWriter, r *http.Request) {
 	}
 	cursor := r.URL.Query().Get("cursor")
 
-	resp, err := appbsky.FeedGetAuthorFeed(r.Context(), p.getClient(), actor, cursor, "", false, limit)
-	if err != nil {
+	var resp *appbsky.FeedGetAuthorFeed_Output
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		resp, err = appbsky.FeedGetAuthorFeed(r.Context(), c, actor, cursor, "", false, limit)
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to get author feed", "actor", actor, "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to get feed for %s: %v", actor, err))
 		return
@@ -190,8 +205,12 @@ func (p *Plugin) handleNotifications(w http.ResponseWriter, r *http.Request) {
 	}
 	cursor := r.URL.Query().Get("cursor")
 
-	resp, err := appbsky.NotificationListNotifications(r.Context(), p.getClient(), cursor, limit, false, nil, "")
-	if err != nil {
+	var resp *appbsky.NotificationListNotifications_Output
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		resp, err = appbsky.NotificationListNotifications(r.Context(), c, cursor, limit, false, nil, "")
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to get notifications", "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to get notifications: %v", err))
 		return
@@ -270,8 +289,6 @@ func (p *Plugin) handleCreatePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := p.getClient()
-
 	post := &appbsky.FeedPost{
 		Text:      req.Text,
 		CreatedAt: time.Now().Format(time.RFC3339),
@@ -300,18 +317,22 @@ func (p *Plugin) handleCreatePost(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp, err := comatproto.RepoCreateRecord(r.Context(), client, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.feed.post",
-		Repo:       client.Auth.Did,
-		Record:     &util.LexiconTypeDecoder{Val: post},
-	})
-	if err != nil {
+	var resp *comatproto.RepoCreateRecord_Output
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		resp, err = comatproto.RepoCreateRecord(r.Context(), c, &comatproto.RepoCreateRecord_Input{
+			Collection: "app.bsky.feed.post",
+			Repo:       c.Auth.Did,
+			Record:     &util.LexiconTypeDecoder{Val: post},
+		})
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to create post", "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to create post: %v", err))
 		return
 	}
 
-	p.attestPost(client.Auth.Did, resp.Uri, resp.Cid, req.Text)
+	p.attestPost(p.getDID(), resp.Uri, resp.Cid, req.Text)
 
 	writeJSON(w, http.StatusCreated, map[string]string{
 		"uri": resp.Uri,
@@ -343,25 +364,27 @@ func (p *Plugin) handleFollow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := p.getClient()
-
 	follow := &appbsky.GraphFollow{
 		Subject:   req.Subject,
 		CreatedAt: time.Now().Format(time.RFC3339),
 	}
 
-	resp, err := comatproto.RepoCreateRecord(r.Context(), client, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.graph.follow",
-		Repo:       client.Auth.Did,
-		Record:     &util.LexiconTypeDecoder{Val: follow},
-	})
-	if err != nil {
+	var resp *comatproto.RepoCreateRecord_Output
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		resp, err = comatproto.RepoCreateRecord(r.Context(), c, &comatproto.RepoCreateRecord_Input{
+			Collection: "app.bsky.graph.follow",
+			Repo:       c.Auth.Did,
+			Record:     &util.LexiconTypeDecoder{Val: follow},
+		})
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to follow actor", "subject", req.Subject, "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to follow %s: %v", req.Subject, err))
 		return
 	}
 
-	p.attestFollow(client.Auth.Did, req.Subject, resp.Uri)
+	p.attestFollow(p.getDID(), req.Subject, resp.Uri)
 
 	writeJSON(w, http.StatusCreated, map[string]string{
 		"uri": resp.Uri,
@@ -394,8 +417,6 @@ func (p *Plugin) handleLike(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := p.getClient()
-
 	like := &appbsky.FeedLike{
 		Subject: &comatproto.RepoStrongRef{
 			Uri: req.URI,
@@ -404,18 +425,22 @@ func (p *Plugin) handleLike(w http.ResponseWriter, r *http.Request) {
 		CreatedAt: time.Now().Format(time.RFC3339),
 	}
 
-	resp, err := comatproto.RepoCreateRecord(r.Context(), client, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.feed.like",
-		Repo:       client.Auth.Did,
-		Record:     &util.LexiconTypeDecoder{Val: like},
-	})
-	if err != nil {
+	var resp *comatproto.RepoCreateRecord_Output
+	if err := p.doWithRefresh(r.Context(), func(c *xrpc.Client) error {
+		var err error
+		resp, err = comatproto.RepoCreateRecord(r.Context(), c, &comatproto.RepoCreateRecord_Input{
+			Collection: "app.bsky.feed.like",
+			Repo:       c.Auth.Did,
+			Record:     &util.LexiconTypeDecoder{Val: like},
+		})
+		return err
+	}); err != nil {
 		p.Services().Logger("atproto").Errorw("Failed to like post", "uri", req.URI, "error", err)
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("Failed to like post: %v", err))
 		return
 	}
 
-	p.attestLike(client.Auth.Did, req.URI, resp.Uri)
+	p.attestLike(p.getDID(), req.URI, resp.Uri)
 
 	writeJSON(w, http.StatusCreated, map[string]string{
 		"uri": resp.Uri,
@@ -467,8 +492,12 @@ func (p *Plugin) handleFeedGlyph(w http.ResponseWriter, r *http.Request) {
 	limit := int64(20) // posts per page
 	ctx := r.Context()
 
-	feedResp, err := appbsky.FeedGetAuthorFeed(ctx, p.getClient(), actor, cursor, "", false, limit)
-	if err != nil {
+	var feedResp *appbsky.FeedGetAuthorFeed_Output
+	if err := p.doWithRefresh(ctx, func(c *xrpc.Client) error {
+		var err error
+		feedResp, err = appbsky.FeedGetAuthorFeed(ctx, c, actor, cursor, "", false, limit)
+		return err
+	}); err != nil {
 		err = errors.WithDetail(err, fmt.Sprintf("Actor: %s, cursor: %s", actor, cursor))
 		p.Services().Logger("atproto").Errorw("Failed to fetch feed", "actor", actor, "error", err)
 		http.Error(w, fmt.Sprintf("Failed to fetch feed: %v", err), http.StatusInternalServerError)

--- a/qntx-atproto/plugin.go
+++ b/qntx-atproto/plugin.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 )
@@ -35,6 +36,11 @@ type Plugin struct {
 	mu     sync.RWMutex
 	client *xrpc.Client // Protected by mu
 	did    string       // Protected by mu
+
+	// Stored for re-authentication when refresh token also expires
+	pdsHost     string
+	identifier  string
+	appPassword string
 }
 
 // NewPlugin creates a new AT Protocol domain plugin.
@@ -42,7 +48,7 @@ func NewPlugin() *Plugin {
 	return &Plugin{
 		Base: plugin.NewBase(plugin.Metadata{
 			Name:        "atproto",
-			Version:     "0.2.15",
+			Version:     "0.3.0",
 			QNTXVersion: ">= 0.1.0",
 			Description: "AT Protocol integration (Bluesky) with auto-scheduled timeline sync",
 			Author:      "QNTX Team",
@@ -64,6 +70,10 @@ func (p *Plugin) Initialize(ctx context.Context, services plugin.ServiceRegistry
 	if pdsHost == "" {
 		pdsHost = "https://bsky.social"
 	}
+
+	p.pdsHost = pdsHost
+	p.identifier = identifier
+	p.appPassword = appPassword
 
 	if identifier != "" && appPassword != "" {
 		client, did, err := createSession(ctx, pdsHost, identifier, appPassword)
@@ -171,6 +181,54 @@ func (p *Plugin) ConfigSchema() map[string]plugin.ConfigField {
 			Required:     false,
 		},
 	}
+}
+
+// doWithRefresh executes an operation with the authenticated client. If the access token
+// has expired, it refreshes the session and retries once. If the refresh token is also
+// expired, it falls back to full re-authentication with stored credentials.
+func (p *Plugin) doWithRefresh(ctx context.Context, op func(*xrpc.Client) error) error {
+	p.mu.RLock()
+	client := p.client
+	p.mu.RUnlock()
+
+	if client == nil {
+		return errors.New("not authenticated")
+	}
+
+	err := op(client)
+	if err == nil || !isExpiredToken(err) {
+		return err
+	}
+
+	logger := p.Services().Logger("atproto")
+	logger.Info("Access token expired, refreshing session")
+
+	// Try refresh token first
+	p.mu.Lock()
+	refreshErr := refreshSession(ctx, p.client)
+	if refreshErr == nil {
+		logger.Info("Session refreshed successfully")
+		client = p.client
+		p.mu.Unlock()
+		return op(client)
+	}
+	p.mu.Unlock()
+
+	logger.Warnw("Refresh token failed, re-authenticating", "error", refreshErr)
+
+	// Fall back to full re-authentication
+	newClient, did, authErr := createSession(ctx, p.pdsHost, p.identifier, p.appPassword)
+	if authErr != nil {
+		return errors.Wrap(authErr, "re-authentication failed after token expiry")
+	}
+
+	p.mu.Lock()
+	p.client = newClient
+	p.did = did
+	p.mu.Unlock()
+
+	logger.Infow("Re-authenticated with PDS", "did", did)
+	return op(newClient)
 }
 
 // getClient returns the authenticated XRPC client, or nil if not authenticated.

--- a/qntx-atproto/session.go
+++ b/qntx-atproto/session.go
@@ -34,6 +34,41 @@ func createSession(ctx context.Context, pdsHost, identifier, appPassword string)
 	return client, session.Did, nil
 }
 
-// TODO: Implement session refresh to handle token expiry (~2 hours).
-// Options: (a) retry on 401 with refresh token, or (b) background goroutine.
-// Without this, plugin breaks on token expiry until restart.
+// refreshSession uses the refresh JWT to obtain new access and refresh tokens.
+// The AT Protocol refresh endpoint requires the refresh token as the Bearer token.
+func refreshSession(ctx context.Context, client *xrpc.Client) error {
+	if client.Auth == nil || client.Auth.RefreshJwt == "" {
+		return errors.New("no refresh token available")
+	}
+
+	// ServerRefreshSession sends Bearer <AccessJwt>, so temporarily swap in the refresh token
+	savedAccess := client.Auth.AccessJwt
+	client.Auth.AccessJwt = client.Auth.RefreshJwt
+
+	session, err := comatproto.ServerRefreshSession(ctx, client)
+	if err != nil {
+		// Restore original token on failure so the client state isn't corrupted
+		client.Auth.AccessJwt = savedAccess
+		return errors.Wrap(err, "failed to refresh session")
+	}
+
+	client.Auth.AccessJwt = session.AccessJwt
+	client.Auth.RefreshJwt = session.RefreshJwt
+	client.Auth.Handle = session.Handle
+	client.Auth.Did = session.Did
+	return nil
+}
+
+// isExpiredToken checks if an error is an AT Protocol ExpiredToken error.
+// The PDS returns HTTP 400 with {"error": "ExpiredToken"} when the access token has expired.
+func isExpiredToken(err error) bool {
+	var xrpcErr *xrpc.Error
+	if !errors.As(err, &xrpcErr) {
+		return false
+	}
+	var inner *xrpc.XRPCError
+	if errors.As(xrpcErr.Wrapped, &inner) {
+		return inner.ErrStr == "ExpiredToken"
+	}
+	return false
+}

--- a/qntx-atproto/timeline_sync.go
+++ b/qntx-atproto/timeline_sync.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/xrpc"
 	"github.com/teranos/QNTX/errors"
 )
 
@@ -19,8 +20,7 @@ func (p *Plugin) syncTimeline(ctx context.Context, jobID string) error {
 	}
 
 	// Skip if not authenticated
-	client := p.getClient()
-	if client == nil {
+	if p.getClient() == nil {
 		logger.Debug("Timeline sync skipped (not authenticated)")
 		return nil
 	}
@@ -36,9 +36,13 @@ func (p *Plugin) syncTimeline(ctx context.Context, jobID string) error {
 
 	logger.Infow("Starting timeline sync", "limit", limit)
 
-	// Fetch timeline (use request context for this)
-	resp, err := appbsky.FeedGetTimeline(ctx, client, "", "", limit)
-	if err != nil {
+	// Fetch timeline with automatic token refresh on expiry
+	var resp *appbsky.FeedGetTimeline_Output
+	if err := p.doWithRefresh(ctx, func(c *xrpc.Client) error {
+		var err error
+		resp, err = appbsky.FeedGetTimeline(ctx, c, "", "", limit)
+		return err
+	}); err != nil {
 		return errors.Wrap(err, "failed to fetch timeline")
 	}
 


### PR DESCRIPTION
## Summary

- Access tokens expire after ~2 hours, breaking all API calls until restart
- `doWithRefresh` wrapper catches `ExpiredToken` errors, refreshes via refresh JWT, retries once
- Falls back to full re-authentication if refresh token is also expired
- All authenticated API calls (handlers + timeline sync) wrapped

## Test plan

- [x] `make test` passes (666/666)
- [x] Let plugin run >2 hours, confirm auto-refresh in logs instead of `ExpiredToken` failures