### PR TITLE
Centralize job logging and error handling in protocol package

### DIFF
--- a/plugin/grpc/protocol/convert.go
+++ b/plugin/grpc/protocol/convert.go
@@ -8,6 +8,22 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// NewJobLogEntry creates a JobLogEntry with the current timestamp.
+// This is the standard way to build log entries in ExecuteJob implementations.
+func NewJobLogEntry(level, stage, message string) *JobLogEntry {
+	return &JobLogEntry{
+		Timestamp: time.Now().Format(time.RFC3339),
+		Level:     level,
+		Stage:     stage,
+		Message:   message,
+	}
+}
+
+// ErrUnknownHandler returns a formatted error for unrecognized handler names in ExecuteJob.
+func ErrUnknownHandler(handlerName string) error {
+	return fmt.Errorf("unknown handler: %s", handlerName)
+}
+
 // ToTypes converts a proto Attestation to types.As.
 func (p *Attestation) ToTypes() *types.As {
 	attributes := make(map[string]interface{})

--- a/qntx-atproto/plugin.go
+++ b/qntx-atproto/plugin.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/bluesky-social/indigo/xrpc"
 	"github.com/teranos/QNTX/errors"
@@ -48,7 +47,7 @@ func NewPlugin() *Plugin {
 	return &Plugin{
 		Base: plugin.NewBase(plugin.Metadata{
 			Name:        "atproto",
-			Version:     "0.3.2",
+			Version:     "0.3.3",
 			QNTXVersion: ">= 0.1.0",
 			Description: "AT Protocol integration (Bluesky) with auto-scheduled timeline sync",
 			Author:      "QNTX Team",
@@ -282,14 +281,14 @@ func (p *Plugin) GetHandlerNames() []string {
 func (p *Plugin) ExecuteJob(ctx context.Context, handlerName string, jobID string, payload []byte) (result []byte, logs []*protocol.JobLogEntry, err error) {
 	switch handlerName {
 	case "atproto.timeline-sync":
-		logs = append(logs, jobLog("info", "timeline-sync", "Starting timeline sync"))
+		logs = append(logs, protocol.NewJobLogEntry("info", "timeline-sync", "Starting timeline sync"))
 
 		if err := p.syncTimeline(ctx, jobID); err != nil {
-			logs = append(logs, jobLog("error", "timeline-sync", fmt.Sprintf("Sync failed: %v", err)))
+			logs = append(logs, protocol.NewJobLogEntry("error", "timeline-sync", fmt.Sprintf("Sync failed: %v", err)))
 			return nil, logs, err
 		}
 
-		logs = append(logs, jobLog("info", "timeline-sync", "Timeline sync completed"))
+		logs = append(logs, protocol.NewJobLogEntry("info", "timeline-sync", "Timeline sync completed"))
 
 		resultData := map[string]string{
 			"status": "Timeline sync completed",
@@ -298,16 +297,7 @@ func (p *Plugin) ExecuteJob(ctx context.Context, handlerName string, jobID strin
 		return result, logs, err
 
 	default:
-		return nil, nil, fmt.Errorf("unknown handler: %s", handlerName)
-	}
-}
-
-func jobLog(level, stage, message string) *protocol.JobLogEntry {
-	return &protocol.JobLogEntry{
-		Timestamp: time.Now().Format(time.RFC3339),
-		Level:     level,
-		Stage:     stage,
-		Message:   message,
+		return nil, nil, protocol.ErrUnknownHandler(handlerName)
 	}
 }
 

--- a/qntx-github/plugin.go
+++ b/qntx-github/plugin.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
@@ -22,7 +21,7 @@ func NewPlugin() *Plugin {
 	return &Plugin{
 		Base: plugin.NewBase(plugin.Metadata{
 			Name:        "github",
-			Version:     "0.1.6",
+			Version:     "0.1.7",
 			QNTXVersion: ">= 0.1.0",
 			Description: "GitHub integration for repository events and automation",
 			Author:      "QNTX Team",
@@ -126,15 +125,15 @@ func (p *Plugin) GetHandlerNames() []string {
 func (p *Plugin) ExecuteJob(ctx context.Context, handlerName string, jobID string, payload []byte) (result []byte, logs []*protocol.JobLogEntry, err error) {
 	switch handlerName {
 	case "github.poll-events":
-		logs = append(logs, jobLog("info", "poll-events", "Polling GitHub events"))
+		logs = append(logs, protocol.NewJobLogEntry("info", "poll-events", "Polling GitHub events"))
 
 		count, err := p.HandlePulseJob(ctx, jobID)
 		if err != nil {
-			logs = append(logs, jobLog("error", "poll-events", fmt.Sprintf("Poll failed: %v", err)))
+			logs = append(logs, protocol.NewJobLogEntry("error", "poll-events", fmt.Sprintf("Poll failed: %v", err)))
 			return nil, logs, err
 		}
 
-		logs = append(logs, jobLog("info", "poll-events", fmt.Sprintf("Poll complete, %d attestations created", count)))
+		logs = append(logs, protocol.NewJobLogEntry("info", "poll-events", fmt.Sprintf("Poll complete, %d attestations created", count)))
 
 		resultData := map[string]interface{}{
 			"attestations_created": count,
@@ -143,16 +142,7 @@ func (p *Plugin) ExecuteJob(ctx context.Context, handlerName string, jobID strin
 		return result, logs, err
 
 	default:
-		return nil, nil, fmt.Errorf("unknown handler: %s", handlerName)
-	}
-}
-
-func jobLog(level, stage, message string) *protocol.JobLogEntry {
-	return &protocol.JobLogEntry{
-		Timestamp: time.Now().Format(time.RFC3339),
-		Level:     level,
-		Stage:     stage,
-		Message:   message,
+		return nil, nil, protocol.ErrUnknownHandler(handlerName)
 	}
 }
 

--- a/qntx-ix-json/plugin.go
+++ b/qntx-ix-json/plugin.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/teranos/QNTX/ats"
 	atstypes "github.com/teranos/QNTX/ats/types"
@@ -29,15 +28,6 @@ import (
 
 //go:embed web/ix-glyph-module.js
 var ixGlyphModuleJS []byte
-
-func logEntry(level, stage, message string) *protocol.JobLogEntry {
-	return &protocol.JobLogEntry{
-		Timestamp: time.Now().Format(time.RFC3339),
-		Level:     level,
-		Stage:     stage,
-		Message:   message,
-	}
-}
 
 // OperationMode represents the current operational mode of a glyph.
 type OperationMode string
@@ -72,7 +62,7 @@ func NewPlugin() *Plugin {
 	return &Plugin{
 		Base: plugin.NewBase(plugin.Metadata{
 			Name:        "ix-json",
-			Version:     "0.4.0",
+			Version:     "0.4.1",
 			QNTXVersion: ">= 0.1.0",
 			Description: "Generic JSON API ingestion with configurable mapping to attestations",
 			Author:      "QNTX Team",
@@ -347,12 +337,12 @@ func (p *Plugin) ExecuteJob(ctx context.Context, handlerName string, jobID strin
 			"glyph_id": req.GlyphID,
 		})
 		logs := []*protocol.JobLogEntry{
-			logEntry("info", "poll", fmt.Sprintf("Fetched %s, created %d attestations", pollRes.APIURL, pollRes.AttestationsCreated)),
+			protocol.NewJobLogEntry("info", "poll", fmt.Sprintf("Fetched %s, created %d attestations", pollRes.APIURL, pollRes.AttestationsCreated)),
 		}
 		return result, logs, nil
 
 	default:
-		return nil, nil, fmt.Errorf("unknown handler: %s", handlerName)
+		return nil, nil, protocol.ErrUnknownHandler(handlerName)
 	}
 }
 

--- a/qntx-openrouter/plugin.go
+++ b/qntx-openrouter/plugin.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
@@ -23,7 +22,7 @@ func NewPlugin() *Plugin {
 	return &Plugin{
 		Base: plugin.NewBase(plugin.Metadata{
 			Name:        "openrouter",
-			Version:     "0.3.0",
+			Version:     "0.3.1",
 			QNTXVersion: ">= 0.1.0",
 			Description: "OpenRouter LLM gateway for prompt execution, usage tracking, and model pricing",
 			Author:      "QNTX Team",
@@ -104,30 +103,21 @@ func (p *Plugin) GetHandlerNames() []string {
 func (p *Plugin) ExecuteJob(ctx context.Context, handlerName string, jobID string, payload []byte) (result []byte, logs []*protocol.JobLogEntry, err error) {
 	switch handlerName {
 	case PromptExecuteHandlerName:
-		logs = append(logs, jobLog("info", "prompt", "Executing prompt via OpenRouter"))
+		logs = append(logs, protocol.NewJobLogEntry("info", "prompt", "Executing prompt via OpenRouter"))
 
 		results, execErr := p.executePromptJob(ctx, jobID, payload)
 		if execErr != nil {
-			logs = append(logs, jobLog("error", "prompt", fmt.Sprintf("Prompt execution failed: %v", execErr)))
+			logs = append(logs, protocol.NewJobLogEntry("error", "prompt", fmt.Sprintf("Prompt execution failed: %v", execErr)))
 			return nil, logs, execErr
 		}
 
-		logs = append(logs, jobLog("info", "prompt", fmt.Sprintf("Prompt execution complete, %d results", len(results))))
+		logs = append(logs, protocol.NewJobLogEntry("info", "prompt", fmt.Sprintf("Prompt execution complete, %d results", len(results))))
 
 		resultData, _ := json.Marshal(results)
 		return resultData, logs, nil
 
 	default:
-		return nil, nil, fmt.Errorf("unknown handler: %s", handlerName)
-	}
-}
-
-func jobLog(level, stage, message string) *protocol.JobLogEntry {
-	return &protocol.JobLogEntry{
-		Timestamp: time.Now().Format(time.RFC3339),
-		Level:     level,
-		Stage:     stage,
-		Message:   message,
+		return nil, nil, protocol.ErrUnknownHandler(handlerName)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR refactors job logging and error handling across multiple plugins by centralizing common functionality into the protocol package. This eliminates code duplication and provides a consistent interface for all plugins.

## Key Changes
- **Added protocol helpers**: Introduced `NewJobLogEntry()` and `ErrUnknownHandler()` functions in `plugin/grpc/protocol/convert.go` to standardize job logging and error handling across all plugins
- **Removed duplicate code**: Eliminated local `jobLog()` and `logEntry()` helper functions from:
  - qntx-atproto
  - qntx-github
  - qntx-openrouter
  - qntx-ix-json
- **Removed unused imports**: Cleaned up `time` imports from all affected plugin files since timestamp generation is now handled centrally
- **Updated all ExecuteJob implementations**: Replaced local helper calls with `protocol.NewJobLogEntry()` and `protocol.ErrUnknownHandler()` calls
- **Version bumps**: Incremented patch versions for all modified plugins:
  - atproto: 0.3.2 → 0.3.3
  - github: 0.1.6 → 0.1.7
  - openrouter: 0.3.0 → 0.3.1
  - ix-json: 0.4.0 → 0.4.1

## Implementation Details
- The centralized `NewJobLogEntry()` function automatically captures the current timestamp in RFC3339 format, ensuring consistent timestamp handling across all plugins
- The `ErrUnknownHandler()` function provides a standardized error message format for unrecognized handler names
- All plugins now follow the same pattern for job execution logging and error handling, improving maintainability and consistency

https://claude.ai/code/session_01JAj7P5EE5om7smPfwTVNFv