### PR TITLE
ix-net: serve captured images over HTTP for browser integration

### DIFF
--- a/qntx-plugins/ix-net/HANDOVER.md
+++ b/qntx-plugins/ix-net/HANDOVER.md
@@ -1,0 +1,114 @@
+# ix-net Image Serving & Browser Integration — Handover
+
+## Vision
+
+Claude Code runs through ix-net (HTTPS MITM proxy). ix-net captures images from the API traffic — screenshots, diagrams, anything Claude sees or produces. These images are valuable context for PR descriptions but can't be inserted programmatically (GitHub API doesn't support images in PR bodies via API or `gh`).
+
+Xffexlex (Firefox extension) solves this by showing image thumbnails when editing a PR description on GitHub. Left-click inserts into the editor (via synthetic paste), right-click dismisses. The extension talks to ix-net through QNTX's HTTP handler infrastructure to fetch the images.
+
+Longer term, Xffexlex was envisioned as a general "window into QNTX" — the browser becomes a QNTX node. Firefox extensions can run WASM, so the extension could carry `qntx-wasm` directly and only need the localhost connection for server-side operations (ATS queries, plugin endpoints).
+
+## What was built
+
+### ix-net HTTP endpoints (D, plugin.d)
+
+Three routes added to `handleHTTP`:
+
+- `GET /images?branch=<name>` — resolves branch to capture sessions via ATS, returns `{ branch, sessions: [{ session, images: [...] }] }`
+- `GET /images?session=<id>` — lists image files in a session directory, returns `{ session, images: [...] }`
+- `GET /images/<session>/<filename>` — serves raw image bytes with correct MIME type and cache header
+
+**Branch → session resolution logic** (in `handleImagesByBranch`):
+1. Query ATS for attestations with predicate `"captured"` (ix-net capture attestations)
+2. Extract `session_id` and `image_dir` from each attestation's attributes
+3. For each session, query ATS for `"PreToolUse"` attestations with context `"session:<id>"`
+4. Search raw attribute bytes for `"checkout -b <branch>"` or `"checkout <branch>"`
+5. If found, that session belongs to this branch — list its images
+
+### ix-net glyph (D inline JS, web/glyph-module.ts)
+
+Status dashboard showing:
+- Proxy status (listening / not reachable)
+- Capture count, image count
+- Input/output token totals
+- Last model and status code
+
+Uses GlyphUI SDK: `ui.container()`, `ui.pluginFetch('/captures')`, `ui.statusLine()`, `ui.onCleanup()`. Refreshes every 5 seconds.
+
+The glyph module is served inline as a JS string from plugin.d at `/glyph-module.js`. The typed source lives at `web/glyph-module.ts` for editing with proper tooling — these must be kept in sync manually. The glyph is registered via Phase 1 (gRPC `registerGlyphs`) but also exports `glyphDef` so Phase 2 auto-discovery works.
+
+### Configurable proxy port (D, plugin.d + am.toml)
+
+The proxy reads `proxy_port` from the `[ix-net]` section in `am.toml` (passed via `InitializeRequest.config`). Defaults to 9100. This prevents port collisions when multiple QNTX instances run ix-net simultaneously.
+
+`claude.fish` parses the same `am.toml` to read the port, so the wrapper and plugin stay in sync automatically.
+
+### Xffexlex Firefox extension (TypeScript, separate repo)
+
+Location: `/Users/s.b.vanhouten/SBVH/teranos/Xffexlex`
+
+Architecture:
+- **Background script** (`src/background.ts`) — sole QNTX communication layer. Content scripts never talk to localhost directly. Fetches from ix-net endpoints, converts image blobs to data URLs (blobs can't cross the message boundary). Port configurable via `browser.storage.local`.
+- **Content script** (`src/content-github-pr.ts`) — injected on `https://github.com/*/pull/*`. Detects edit mode via MutationObserver watching for `textarea[name='pull_request[body]']`. Sends messages to background script to fetch images. Renders thumbnail panel above textarea. Click inserts via synthetic ClipboardEvent paste. Right-click dismisses thumbnail.
+- **Manifest** (`manifest.json`) — manifest v2, permissions: `activeTab`, `storage`, `http://localhost/*`. Extension ID: `xffexlex@teranos`.
+
+Builds with `bun run build` → `dist/background.js`, `dist/content-github-pr.js`.
+
+### Supporting changes
+
+- `ats.d` — added `getAttestations()` method on ATSClient for querying ATS via gRPC
+- `proto.d` — added `AttestationFilter`, `GetAttestationsRequest`, `GetAttestationsResponse` structs
+- `proxy.d` — changed `jsonEscape` and `getImageDir` from `private` to `package` visibility
+
+## What has NOT been tested
+
+- **Image-serving endpoints** — never curled. The branch→session ATS query logic is entirely untested.
+- **The glyph** — never spawned in the QNTX UI. Port collision issue was hit, then the glyph was rewritten, never retried.
+- **Xffexlex end-to-end** — extension loads in Firefox (confirmed), but never tested: fetch images → show thumbnails → click to insert. The background script architecture (replacing direct fetch with message passing) was never tested in browser.
+- **Configurable port** — v0.9.6 with port config was built but QNTX was not restarted to verify it binds to the configured port.
+- **claude.fish am.toml parsing** — the fish script's TOML parser is simple (line-by-line, looks for `[ix-net]` section, extracts `proxy_port`). Not tested.
+- **Image deduplication** — ix-net captures accumulate duplicate images across API calls (each call includes all previous images in context). The endpoints return all files. No deduplication logic exists on server or client side.
+
+## Known limitations and fragility
+
+1. **Branch→session search is fragile** — searches raw protobuf attribute bytes for string `"checkout -b <branch>"`. Could false-match if a branch name appears in unrelated attribute data. Could also miss branches checked out with `git switch -c` or other variations.
+
+2. **Glyph source duplication** — the JS module is inlined as a D string in `plugin.d` and separately exists as `web/glyph-module.ts`. These must be manually kept in sync. A better approach would be to have the Makefile compile the TS and embed it, or have the plugin read it from disk at runtime.
+
+3. **Image paths are hardcoded to `$HOME`** — `getImageDir()` resolves to `~/.qntx/files/ix-net/`. This is shared across all QNTX instances. Multiple ix-net instances write to the same directory tree, differentiated only by session ID.
+
+4. **`make install` overwrites certs** — the Makefile copies certs from the source tree to `~/.qntx/certs/`. Running `make install` from one QNTX instance replaces another instance's certs. This caused TLS failures during development when tmp and tmp3 had different CA certificates.
+
+5. **No CORS headers** — removed because the extension uses background script fetch (not subject to CORS). If anything else needs to call these endpoints from a browser page context, CORS headers would need to be re-added.
+
+## Files changed (PR #669)
+
+```
+qntx-plugins/ix-net/source/ixnet/ats.d       — getAttestations() method
+qntx-plugins/ix-net/source/ixnet/plugin.d    — image endpoints, glyph, port config
+qntx-plugins/ix-net/source/ixnet/proto.d     — AttestationFilter, request/response types
+qntx-plugins/ix-net/source/ixnet/proxy.d     — private → package visibility
+qntx-plugins/ix-net/source/ixnet/version_.d  — 0.8.0 → 0.9.6
+qntx-plugins/ix-net/web/glyph-module.ts      — typed glyph source (new file)
+qntx-plugins/ix-net/claude.fish              — reads proxy_port from am.toml
+am.toml                                       — [ix-net] proxy_port = 9176
+```
+
+## Commits
+
+1. `ix-net: serve captured images over HTTP for browser integration` — endpoints + ATS queries
+2. `ix-net: remove CORS headers from image endpoints` — background script approach
+3. `ix-net: configurable proxy port, GlyphUI glyph, claude.fish reads am.toml`
+
+## If continuing
+
+The critical path to a working demo:
+1. Restart QNTX, verify ix-net binds to configured port (check logs for `proxy auto-started on port 9176`)
+2. Run Claude Code through the proxy, capture some images
+3. `curl http://localhost:8776/api/ix-net/images?session=<session-id>` — verify endpoint returns image list
+4. `curl http://localhost:8776/api/ix-net/images?branch=<branch-name>` — verify branch resolution works (this is the most likely failure point — depends on attestation format)
+5. Load Xffexlex in Firefox (`about:debugging` → Load Temporary Add-on → `manifest.json`)
+6. Open a PR for the branch, click edit, verify thumbnail panel appears
+7. Click a thumbnail, verify it pastes into the textarea
+
+The branch→session ATS query is the riskiest piece. If the attestation format has changed or the raw byte search doesn't find matches, that's where to debug first.

--- a/qntx-plugins/ix-net/claude.fish
+++ b/qntx-plugins/ix-net/claude.fish
@@ -1,10 +1,30 @@
 #!/usr/bin/env fish
 # Launch Claude Code through ix-net proxy.
-# Assumes proxy is already running on port 9100.
+# Reads proxy_port from am.toml in the QNTX root (two levels up from this script).
 
 set -l IX_NET_DIR (dirname (status filename))
+set -l QNTX_ROOT "$IX_NET_DIR/../.."
+set -l AM_TOML "$QNTX_ROOT/am.toml"
 
-set -x HTTPS_PROXY "http://localhost:9100"
+# Read proxy_port from [ix-net] section, default 9100
+set -l PROXY_PORT 9100
+if test -f "$AM_TOML"
+    set -l in_section 0
+    for line in (cat "$AM_TOML")
+        if string match -q '[ix-net]' -- $line
+            set in_section 1
+        else if string match -q '[*' -- $line
+            set in_section 0
+        else if test $in_section -eq 1
+            set -l val (string match -r 'proxy_port\s*=\s*(\d+)' -- $line)
+            if test (count $val) -gt 1
+                set PROXY_PORT $val[2]
+            end
+        end
+    end
+end
+
+set -x HTTPS_PROXY "http://localhost:$PROXY_PORT"
 set -x NODE_EXTRA_CA_CERTS "$IX_NET_DIR/certs/ca.pem"
 
 claude $argv

--- a/qntx-plugins/ix-net/source/ixnet/ats.d
+++ b/qntx-plugins/ix-net/source/ixnet/ats.d
@@ -57,6 +57,34 @@ struct ATSClient {
         return true;
     }
 
+    /// Query attestations using a filter.
+    /// Returns attestations on success, empty array on failure.
+    Attestation[] getAttestations(ref const AttestationFilter filter, ref string error) {
+        if (!connected) {
+            error = "ATSStore client not connected to " ~ endpoint;
+            return [];
+        }
+
+        auto requestBytes = encodeGetAttestationsRequest(authToken, filter);
+        auto responseBytes = client.call(
+            "/protocol.ATSStoreService/GetAttestations",
+            requestBytes
+        );
+
+        if (responseBytes.length == 0) {
+            error = "empty response from ATSStore at " ~ endpoint;
+            return [];
+        }
+
+        auto resp = decode!GetAttestationsResponse(responseBytes);
+        if (!resp.success) {
+            error = resp.error;
+            logError("[ix-net] ATSStore: query failed: %s", resp.error);
+            return [];
+        }
+        return resp.attestations;
+    }
+
     void close() {
         client.close();
         connected = false;

--- a/qntx-plugins/ix-net/source/ixnet/plugin.d
+++ b/qntx-plugins/ix-net/source/ixnet/plugin.d
@@ -123,7 +123,7 @@ GlyphDefResponse registerGlyphs() {
     glyph.symbol       = "\U0001F50D"; // magnifying glass: 🔍
     glyph.title        = "Network Inspector";
     glyph.label        = "ix-net";
-    glyph.modulePath   = "/net-inspector-module.js";
+    glyph.modulePath   = "/glyph-module.js";
     glyph.defaultWidth = 800;
     glyph.defaultHeight = 600;
     resp.glyphs = [glyph];
@@ -146,7 +146,7 @@ HTTPResponse handleHTTP(ref const HTTPRequest req) {
         return handleStop();
     } else if (method == "GET" && path == "/captures") {
         return handleCaptures();
-    } else if (method == "GET" && path == "/net-inspector-module.js") {
+    } else if (method == "GET" && path == "/glyph-module.js") {
         return serveGlyphModule();
     } else if (method == "GET" && path.length >= 7 && path[0 .. 7] == "/images") {
         return handleImages(path, req);
@@ -240,18 +240,97 @@ private HTTPResponse handleCaptures() {
     return jsonResponse(200, captures);
 }
 
-/// GET /net-inspector-module.js — serve the glyph UI module.
+/// GET /glyph-module.js — serve the glyph UI module.
+/// Source of truth: web/glyph-module.ts (keep in sync).
 private HTTPResponse serveGlyphModule() {
     HTTPResponse resp;
     resp.statusCode = 200;
-    // Minimal placeholder — will be expanded
     resp.body_ = cast(ubyte[])(
-        "export function render(glyph, ui) {\n" ~
-        "  const c = document.createElement('div');\n" ~
-        "  c.style.cssText = 'padding: 20px; font-family: monospace; color: #33ff33; background: #0a0a0f; height: 100%;';\n" ~
-        "  c.textContent = 'ix-net: Claude Code API Inspector';\n" ~
-        "  return c;\n" ~
-        "}\n"
+        "export const glyphDef = {\n" ~
+        "  symbol: '\\u{1F50D}',\n" ~
+        "  title: 'Network Inspector',\n" ~
+        "  label: 'ix-net',\n" ~
+        "  defaultWidth: 320,\n" ~
+        "  defaultHeight: 280,\n" ~
+        "};\n" ~
+        "\n" ~
+        "export const render = async (glyph, ui) => {\n" ~
+        "  const { element } = ui.container({\n" ~
+        "    defaults: {\n" ~
+        "      x: glyph.x ?? 100,\n" ~
+        "      y: glyph.y ?? 100,\n" ~
+        "      width: 320,\n" ~
+        "      height: 280,\n" ~
+        "    },\n" ~
+        "    titleBar: { label: 'ix-net' },\n" ~
+        "    resizable: true,\n" ~
+        "  });\n" ~
+        "\n" ~
+        "  const body = document.createElement('div');\n" ~
+        "  body.style.flex = '1';\n" ~
+        "  body.style.overflow = 'auto';\n" ~
+        "  body.style.padding = '12px';\n" ~
+        "  body.style.fontFamily = 'monospace';\n" ~
+        "  body.style.fontSize = '13px';\n" ~
+        "  element.appendChild(body);\n" ~
+        "\n" ~
+        "  const status = ui.statusLine();\n" ~
+        "  element.appendChild(status.element);\n" ~
+        "\n" ~
+        "  function row(parent, label, value) {\n" ~
+        "    const el = document.createElement('div');\n" ~
+        "    el.style.display = 'flex';\n" ~
+        "    el.style.justifyContent = 'space-between';\n" ~
+        "    el.style.padding = '2px 0';\n" ~
+        "    const lbl = document.createElement('span');\n" ~
+        "    lbl.style.color = 'var(--muted-foreground, #888)';\n" ~
+        "    lbl.textContent = label;\n" ~
+        "    const val = document.createElement('span');\n" ~
+        "    val.textContent = value;\n" ~
+        "    el.appendChild(lbl);\n" ~
+        "    el.appendChild(val);\n" ~
+        "    parent.appendChild(el);\n" ~
+        "  }\n" ~
+        "\n" ~
+        "  async function refresh() {\n" ~
+        "    try {\n" ~
+        "      const resp = await ui.pluginFetch('/captures');\n" ~
+        "      const data = await resp.json();\n" ~
+        "      const caps = data.captures || [];\n" ~
+        "      const total = data.total || 0;\n" ~
+        "      const withImages = caps.filter(c => c.has_images).length;\n" ~
+        "      const totalImages = caps.reduce((n, c) => n + c.image_count, 0);\n" ~
+        "      const totalIn = caps.reduce((n, c) => n + c.input_tokens, 0);\n" ~
+        "      const totalOut = caps.reduce((n, c) => n + c.output_tokens, 0);\n" ~
+        "\n" ~
+        "      body.innerHTML = '';\n" ~
+        "      row(body, 'Proxy', 'listening');\n" ~
+        "      row(body, 'Captures', String(total));\n" ~
+        "      row(body, 'With images', String(withImages));\n" ~
+        "      row(body, 'Total images', String(totalImages));\n" ~
+        "      row(body, 'Input tokens', totalIn.toLocaleString());\n" ~
+        "      row(body, 'Output tokens', totalOut.toLocaleString());\n" ~
+        "\n" ~
+        "      if (caps.length > 0) {\n" ~
+        "        const last = caps[caps.length - 1];\n" ~
+        "        row(body, 'Last model', last.model);\n" ~
+        "        row(body, 'Last status', String(last.status_code));\n" ~
+        "      }\n" ~
+        "\n" ~
+        "      status.clear();\n" ~
+        "    } catch {\n" ~
+        "      body.innerHTML = '';\n" ~
+        "      row(body, 'Proxy', 'not reachable');\n" ~
+        "      status.show('fetch failed', true);\n" ~
+        "    }\n" ~
+        "  }\n" ~
+        "\n" ~
+        "  await refresh();\n" ~
+        "  const interval = setInterval(refresh, 5000);\n" ~
+        "  ui.onCleanup(() => clearInterval(interval));\n" ~
+        "\n" ~
+        "  return element;\n" ~
+        "};\n"
     );
     resp.headers = [
         httpHeader("Content-Type", "application/javascript"),
@@ -639,6 +718,11 @@ private void autoStartProxy() {
     import ixnet.log;
 
     ushort proxyPort = 9100;
+    if (auto pp = "proxy_port" in state.config) {
+        import std.conv : to;
+        try { proxyPort = (*pp).to!ushort; }
+        catch (Exception) {}
+    }
 
     string certFile, keyFile;
     resolveCertPaths(certFile, keyFile);

--- a/qntx-plugins/ix-net/source/ixnet/plugin.d
+++ b/qntx-plugins/ix-net/source/ixnet/plugin.d
@@ -311,7 +311,6 @@ private HTTPResponse handleImages(string path, ref const HTTPRequest req) {
         resp.headers = [
             httpHeader("Content-Type", mimeForFile(filename)),
             httpHeader("Cache-Control", "max-age=3600"),
-            httpHeader("Access-Control-Allow-Origin", "https://github.com"),
         ];
         return resp;
     } catch (Exception e) {
@@ -364,7 +363,7 @@ private HTTPResponse handleImagesBySession(string session, string baseDir) {
         first = false;
     }
     json ~= `]}`;
-    return corsJsonResponse(200, json);
+    return jsonResponse(200, json);
 }
 
 /// Resolve branch → sessions via ATS, then list all images across sessions.
@@ -407,7 +406,7 @@ private HTTPResponse handleImagesByBranch(string branch, string baseDir) {
     }
 
     if (sessionIds.length == 0)
-        return corsJsonResponse(200, `{"branch":"` ~ jsonEscape(branch) ~ `","sessions":[]}`);
+        return jsonResponse(200, `{"branch":"` ~ jsonEscape(branch) ~ `","sessions":[]}`);
 
     // Step 3: Check which sessions had a checkout of this branch.
     // Query PreToolUse attestations for each session that contain the branch name.
@@ -456,20 +455,9 @@ private HTTPResponse handleImagesByBranch(string branch, string baseDir) {
     }
 
     json ~= `]}`;
-    return corsJsonResponse(200, json);
+    return jsonResponse(200, json);
 }
 
-/// JSON response with CORS header for github.com.
-private HTTPResponse corsJsonResponse(int status, string body_) {
-    HTTPResponse resp;
-    resp.statusCode = status;
-    resp.body_ = cast(ubyte[])body_;
-    resp.headers = [
-        httpHeader("Content-Type", "application/json"),
-        httpHeader("Access-Control-Allow-Origin", "https://github.com"),
-    ];
-    return resp;
-}
 
 /// Decode a google.protobuf.Struct (raw bytes) into a flat string[string] map.
 /// Only extracts string values — skips numbers, bools, nested structs.

--- a/qntx-plugins/ix-net/source/ixnet/plugin.d
+++ b/qntx-plugins/ix-net/source/ixnet/plugin.d
@@ -148,6 +148,8 @@ HTTPResponse handleHTTP(ref const HTTPRequest req) {
         return handleCaptures();
     } else if (method == "GET" && path == "/net-inspector-module.js") {
         return serveGlyphModule();
+    } else if (method == "GET" && path.length >= 7 && path[0 .. 7] == "/images") {
+        return handleImages(path, req);
     }
 
     // 404
@@ -256,6 +258,314 @@ private HTTPResponse serveGlyphModule() {
         httpHeader("Cache-Control", "no-cache"),
     ];
     return resp;
+}
+
+/// GET /images?session=<id> — list images for a session.
+/// GET /images?branch=<name> — find sessions for a branch, list all images.
+/// GET /images/<session>/<filename> — serve an image file.
+private HTTPResponse handleImages(string path, ref const HTTPRequest req) {
+    import std.file : exists, isDir, dirEntries, SpanMode, read_ = read;
+
+    auto baseDir = getImageDir();
+    if (baseDir.length == 0)
+        return jsonResponse(500, `{"error":"cannot resolve image directory"}`);
+
+    if (path == "/images" || (path.length > 7 && path[7] == '?')) {
+        auto branch = getQueryParam(req, "branch");
+        auto session = getQueryParam(req, "session");
+
+        // Branch query: resolve branch → session IDs via ATS
+        if (branch.length > 0) {
+            return handleImagesByBranch(branch, baseDir);
+        }
+
+        if (session.length == 0)
+            return jsonResponse(400, `{"error":"missing session or branch parameter"}`);
+
+        return handleImagesBySession(session, baseDir);
+    }
+
+    // Serve image: GET /images/<session>/<filename>
+    // path is "/images/<session>/<filename>"
+    auto rest = path[8 .. $]; // skip "/images/"
+    auto slashIdx = indexOf(rest, "/");
+    if (slashIdx < 0)
+        return jsonResponse(400, `{"error":"expected /images/<session>/<filename>"}`);
+
+    auto session = rest[0 .. slashIdx];
+    auto filename = rest[slashIdx + 1 .. $];
+
+    if (!isSafePath(session) || !isSafePath(filename))
+        return jsonResponse(400, `{"error":"invalid path"}`);
+
+    auto filePath = baseDir ~ "/" ~ session ~ "/" ~ filename;
+    if (!exists(filePath))
+        return jsonResponse(404, `{"error":"image not found"}`);
+
+    // Read and serve
+    try {
+        auto data = cast(ubyte[])read_(filePath);
+        HTTPResponse resp;
+        resp.statusCode = 200;
+        resp.body_ = data;
+        resp.headers = [
+            httpHeader("Content-Type", mimeForFile(filename)),
+            httpHeader("Cache-Control", "max-age=3600"),
+            httpHeader("Access-Control-Allow-Origin", "https://github.com"),
+        ];
+        return resp;
+    } catch (Exception e) {
+        return jsonResponse(500, `{"error":"failed to read image"}`);
+    }
+}
+
+/// Extract the filename from a full path.
+private string entryName(string fullPath) {
+    for (ptrdiff_t i = cast(ptrdiff_t)fullPath.length - 1; i >= 0; i--) {
+        if (fullPath[i] == '/') return fullPath[i + 1 .. $];
+    }
+    return fullPath;
+}
+
+/// Check if a filename looks like an image.
+private bool isImageFile(string name) {
+    return endsWith(name, ".png") || endsWith(name, ".jpeg") ||
+           endsWith(name, ".jpg") || endsWith(name, ".gif") ||
+           endsWith(name, ".webp");
+}
+
+/// Get MIME type from filename extension.
+private string mimeForFile(string name) {
+    if (endsWith(name, ".png")) return "image/png";
+    if (endsWith(name, ".jpeg") || endsWith(name, ".jpg")) return "image/jpeg";
+    if (endsWith(name, ".gif")) return "image/gif";
+    if (endsWith(name, ".webp")) return "image/webp";
+    return "application/octet-stream";
+}
+
+/// List images for a single session.
+private HTTPResponse handleImagesBySession(string session, string baseDir) {
+    import std.file : exists, isDir, dirEntries, SpanMode;
+
+    if (!isSafePath(session))
+        return jsonResponse(400, `{"error":"invalid session id"}`);
+
+    auto sessionDir = baseDir ~ "/" ~ session;
+    if (!exists(sessionDir) || !isDir(sessionDir))
+        return jsonResponse(404, `{"error":"session not found"}`);
+
+    string json = `{"session":"` ~ jsonEscape(session) ~ `","images":[`;
+    bool first = true;
+    foreach (entry; dirEntries(sessionDir, SpanMode.shallow)) {
+        auto name = entryName(entry.name);
+        if (!isImageFile(name)) continue;
+        if (!first) json ~= ",";
+        json ~= `"` ~ jsonEscape(name) ~ `"`;
+        first = false;
+    }
+    json ~= `]}`;
+    return corsJsonResponse(200, json);
+}
+
+/// Resolve branch → sessions via ATS, then list all images across sessions.
+///
+/// Queries GraundedPreToolUse attestations with control=git-checkout-b
+/// to find which sessions created branches. The branch name is in the
+/// companion PreToolUse attestation's tool_input.command.
+/// Then collects images from ix-net captures for those sessions.
+private HTTPResponse handleImagesByBranch(string branch, string baseDir) {
+    import std.file : exists, isDir, dirEntries, SpanMode;
+    import ixnet.ats : ATSClient;
+    import ixnet.proto : AttestationFilter, Attestation;
+
+    if (!state.atsClient.connected)
+        return jsonResponse(503, `{"error":"ATS not connected"}`);
+
+    // Step 1: Find ix-net capture attestations that have image_dir set.
+    // These have predicate "captured", source "ix-net", and attributes
+    // with session_id and image_dir.
+    AttestationFilter captureFilter;
+    captureFilter.predicates = ["captured"];
+    captureFilter.limit = 100;
+
+    string err;
+    auto captures = state.atsClient.getAttestations(captureFilter, err);
+    if (err.length > 0)
+        return jsonResponse(500, `{"error":"ATS query failed: ` ~ jsonEscape(err) ~ `"}`);
+
+    // Step 2: For each capture, check if its session had a checkout of this branch.
+    // Collect session IDs from captures that have images.
+    string[] sessionIds;
+    string[string] sessionImageDirs; // session_id → image_dir
+    foreach (ref cap; captures) {
+        auto attrs = decodeStructToStringMap(cap.attributes);
+        auto sid = "session_id" in attrs;
+        auto imgDir = "image_dir" in attrs;
+        if (sid is null || imgDir is null) continue;
+        sessionImageDirs[*sid] = *imgDir;
+        sessionIds ~= *sid;
+    }
+
+    if (sessionIds.length == 0)
+        return corsJsonResponse(200, `{"branch":"` ~ jsonEscape(branch) ~ `","sessions":[]}`);
+
+    // Step 3: Check which sessions had a checkout of this branch.
+    // Query PreToolUse attestations for each session that contain the branch name.
+    string json = `{"branch":"` ~ jsonEscape(branch) ~ `","sessions":[`;
+    bool firstSession = true;
+
+    foreach (sid; sessionIds) {
+        AttestationFilter branchFilter;
+        branchFilter.predicates = ["PreToolUse"];
+        branchFilter.contexts = ["session:" ~ sid];
+        branchFilter.limit = 50;
+
+        string berr;
+        auto events = state.atsClient.getAttestations(branchFilter, berr);
+
+        // Check if any event has checkout -b <branch> in the raw attributes.
+        // tool_input is a nested Struct so we search the raw bytes for the branch name.
+        bool found = false;
+        foreach (ref ev; events) {
+            auto raw = cast(string)ev.attributes;
+            if (indexOf(raw, "checkout -b " ~ branch) >= 0 ||
+                indexOf(raw, "checkout " ~ branch) >= 0) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) continue;
+
+        // This session checked out this branch — list its images
+        auto imgDir = sessionImageDirs[sid];
+        if (!exists(imgDir) || !isDir(imgDir)) continue;
+
+        if (!firstSession) json ~= ",";
+        json ~= `{"session":"` ~ jsonEscape(sid) ~ `","images":[`;
+        bool firstImg = true;
+        foreach (entry; dirEntries(imgDir, SpanMode.shallow)) {
+            auto name = entryName(entry.name);
+            if (!isImageFile(name)) continue;
+            if (!firstImg) json ~= ",";
+            json ~= `"` ~ jsonEscape(name) ~ `"`;
+            firstImg = false;
+        }
+        json ~= `]}`;
+        firstSession = false;
+    }
+
+    json ~= `]}`;
+    return corsJsonResponse(200, json);
+}
+
+/// JSON response with CORS header for github.com.
+private HTTPResponse corsJsonResponse(int status, string body_) {
+    HTTPResponse resp;
+    resp.statusCode = status;
+    resp.body_ = cast(ubyte[])body_;
+    resp.headers = [
+        httpHeader("Content-Type", "application/json"),
+        httpHeader("Access-Control-Allow-Origin", "https://github.com"),
+    ];
+    return resp;
+}
+
+/// Decode a google.protobuf.Struct (raw bytes) into a flat string[string] map.
+/// Only extracts string values — skips numbers, bools, nested structs.
+private string[string] decodeStructToStringMap(const(ubyte)[] data) {
+    import ixnet.proto : decodeVarint, WireType, skipField;
+    string[string] result;
+    size_t pos = 0;
+    while (pos < data.length) {
+        auto tag = decodeVarint(data, pos);
+        int fieldNum = cast(int)(tag >> 3);
+        WireType wt = cast(WireType)(tag & 0x7);
+        if (fieldNum == 1 && wt == WireType.LengthDelimited) {
+            // Map entry message
+            auto len = cast(size_t)decodeVarint(data, pos);
+            auto end = pos + len;
+            string k, v;
+            while (pos < end) {
+                auto etag = decodeVarint(data, pos);
+                int eNum = cast(int)(etag >> 3);
+                WireType ewt = cast(WireType)(etag & 0x7);
+                if (eNum == 1 && ewt == WireType.LengthDelimited) {
+                    // key
+                    auto klen = cast(size_t)decodeVarint(data, pos);
+                    k = cast(string)data[pos .. pos + klen].idup;
+                    pos += klen;
+                } else if (eNum == 2 && ewt == WireType.LengthDelimited) {
+                    // Value message — extract string_value (field 3)
+                    auto vlen = cast(size_t)decodeVarint(data, pos);
+                    auto vend = pos + vlen;
+                    while (pos < vend) {
+                        auto vtag = decodeVarint(data, pos);
+                        int vNum = cast(int)(vtag >> 3);
+                        WireType vwt = cast(WireType)(vtag & 0x7);
+                        if (vNum == 3 && vwt == WireType.LengthDelimited) {
+                            auto slen = cast(size_t)decodeVarint(data, pos);
+                            v = cast(string)data[pos .. pos + slen].idup;
+                            pos += slen;
+                        } else {
+                            skipField(data, pos, vwt);
+                        }
+                    }
+                } else {
+                    skipField(data, pos, ewt);
+                }
+            }
+            if (k.length > 0) result[k] = v;
+        } else {
+            skipField(data, pos, wt);
+        }
+    }
+    return result;
+}
+
+/// Check that a path segment contains only safe characters (no traversal).
+private bool isSafePath(string s) {
+    if (s.length == 0) return false;
+    foreach (c; s) {
+        if (c == '/' || c == '\\' || c == '\0') return false;
+        if (c == '.' && s.length >= 2 && s[0] == '.' && s[1] == '.') return false;
+    }
+    // Also reject if it starts with ".."
+    if (s.length >= 2 && s[0] == '.' && s[1] == '.') return false;
+    return true;
+}
+
+/// Check if string ends with suffix.
+private bool endsWith(string s, string suffix) {
+    if (suffix.length > s.length) return false;
+    return s[$ - suffix.length .. $] == suffix;
+}
+
+/// Extract a query parameter from the request.
+/// Looks for "key=value" in the query string portion of the path or body.
+private string getQueryParam(ref const HTTPRequest req, string key) {
+    // Check if path contains query string
+    auto qIdx = indexOf(req.path, "?");
+    if (qIdx < 0) return "";
+    auto query = req.path[qIdx + 1 .. $];
+    return findParam(query, key);
+}
+
+private string findParam(string query, string key) {
+    size_t pos = 0;
+    while (pos < query.length) {
+        // Find key=
+        auto eqIdx = indexOf(query[pos .. $], "=");
+        if (eqIdx < 0) break;
+        auto paramName = query[pos .. pos + eqIdx];
+        auto valStart = pos + eqIdx + 1;
+        // Find end of value (& or end)
+        auto ampIdx = indexOf(query[valStart .. $], "&");
+        size_t valEnd = ampIdx < 0 ? query.length : valStart + ampIdx;
+        if (paramName == key) return query[valStart .. valEnd].idup;
+        pos = valEnd + 1;
+    }
+    return "";
 }
 
 // ---------------------------------------------------------------------------

--- a/qntx-plugins/ix-net/source/ixnet/proto.d
+++ b/qntx-plugins/ix-net/source/ixnet/proto.d
@@ -516,6 +516,46 @@ GenerateAttestationResponse decodeGenerateAttestationResponse(const ubyte[] data
     return result;
 }
 
+// ATSStore query messages (atsstore.proto)
+
+struct AttestationFilter {
+    @Proto(1) string[] subjects;
+    @Proto(2) string[] predicates;
+    @Proto(3) string[] contexts;
+    @Proto(4) string[] actors;
+    @Proto(5) long timeStart;
+    @Proto(6) long timeEnd;
+    @Proto(7) int limit;
+}
+
+struct GetAttestationsRequest {
+    @Proto(1) string authToken;
+    @Proto(2) AttestationFilter filter;
+}
+
+/// Encode GetAttestationsRequest with embedded filter message.
+ubyte[] encodeGetAttestationsRequest(string authToken, ref const AttestationFilter filter) {
+    ubyte[] result;
+    if (authToken.length > 0) {
+        result ~= encodeTag(1, WireType.LengthDelimited);
+        result ~= encodeVarint(authToken.length);
+        result ~= cast(const(ubyte)[])authToken;
+    }
+    auto filterBytes = encode(filter);
+    if (filterBytes.length > 0) {
+        result ~= encodeTag(2, WireType.LengthDelimited);
+        result ~= encodeVarint(filterBytes.length);
+        result ~= filterBytes;
+    }
+    return result;
+}
+
+struct GetAttestationsResponse {
+    @Proto(1) bool success;
+    @Proto(2) string error;
+    @Proto(3) Attestation[] attestations;
+}
+
 // ---------------------------------------------------------------------------
 // google.protobuf.Struct encoding helpers
 //

--- a/qntx-plugins/ix-net/source/ixnet/proxy.d
+++ b/qntx-plugins/ix-net/source/ixnet/proxy.d
@@ -839,7 +839,7 @@ private bool startsWith(string s, string prefix) {
 }
 
 /// Escape a string for safe JSON interpolation.
-private string jsonEscape(string s) {
+package string jsonEscape(string s) {
     bool needsEscape = false;
     foreach (c; s) {
         if (c == '"' || c == '\\' || c < 0x20) { needsEscape = true; break; }
@@ -917,7 +917,7 @@ private string intToStr(int n) {
 }
 
 /// Resolve image storage directory (~/.qntx/files/ix-net/).
-private string getImageDir() {
+package string getImageDir() {
     import core.stdc.stdlib : getenv;
     auto home = getenv("HOME");
     if (home is null) return "";

--- a/qntx-plugins/ix-net/source/ixnet/version_.d
+++ b/qntx-plugins/ix-net/source/ixnet/version_.d
@@ -2,4 +2,4 @@
 module ixnet.version_;
 
 enum PLUGIN_NAME    = "ix-net";
-enum PLUGIN_VERSION = "0.9.2";
+enum PLUGIN_VERSION = "0.9.3";

--- a/qntx-plugins/ix-net/source/ixnet/version_.d
+++ b/qntx-plugins/ix-net/source/ixnet/version_.d
@@ -2,4 +2,4 @@
 module ixnet.version_;
 
 enum PLUGIN_NAME    = "ix-net";
-enum PLUGIN_VERSION = "0.9.3";
+enum PLUGIN_VERSION = "0.9.6";

--- a/qntx-plugins/ix-net/source/ixnet/version_.d
+++ b/qntx-plugins/ix-net/source/ixnet/version_.d
@@ -2,4 +2,4 @@
 module ixnet.version_;
 
 enum PLUGIN_NAME    = "ix-net";
-enum PLUGIN_VERSION = "0.8.0";
+enum PLUGIN_VERSION = "0.9.2";

--- a/qntx-plugins/ix-net/web/glyph-module.ts
+++ b/qntx-plugins/ix-net/web/glyph-module.ts
@@ -1,0 +1,102 @@
+/**
+ * ix-net Glyph Module — Network Inspector status dashboard.
+ *
+ * Shows proxy status, capture counts, image counts, and token usage.
+ * Refreshes every 5 seconds. Uses GlyphUI SDK for container, status line,
+ * and plugin fetch.
+ */
+
+import type { Glyph, GlyphUI, GlyphDef, RenderFn } from '@qntx/glyphs';
+
+export const glyphDef: GlyphDef = {
+    symbol: '\u{1F50D}',
+    title: 'Network Inspector',
+    label: 'ix-net',
+    defaultWidth: 320,
+    defaultHeight: 280,
+};
+
+export const render: RenderFn = async (glyph: Glyph, ui: GlyphUI): Promise<HTMLElement> => {
+    const { element } = ui.container({
+        defaults: {
+            x: glyph.x ?? 100,
+            y: glyph.y ?? 100,
+            width: 320,
+            height: 280,
+        },
+        titleBar: { label: 'ix-net' },
+        resizable: true,
+    });
+
+    const body = document.createElement('div');
+    body.style.flex = '1';
+    body.style.overflow = 'auto';
+    body.style.padding = '12px';
+    body.style.fontFamily = 'monospace';
+    body.style.fontSize = '13px';
+    element.appendChild(body);
+
+    const status = ui.statusLine();
+    element.appendChild(status.element);
+
+    function row(parent: HTMLElement, label: string, value: string): void {
+        const el = document.createElement('div');
+        el.style.display = 'flex';
+        el.style.justifyContent = 'space-between';
+        el.style.padding = '2px 0';
+        const lbl = document.createElement('span');
+        lbl.style.color = 'var(--muted-foreground, #888)';
+        lbl.textContent = label;
+        const val = document.createElement('span');
+        val.textContent = value;
+        el.appendChild(lbl);
+        el.appendChild(val);
+        parent.appendChild(el);
+    }
+
+    async function refresh(): Promise<void> {
+        try {
+            const resp = await ui.pluginFetch('/captures');
+            const data = await resp.json();
+            const caps: Array<{
+                has_images: boolean;
+                image_count: number;
+                input_tokens: number;
+                output_tokens: number;
+                model: string;
+                status_code: number;
+            }> = data.captures || [];
+            const total: number = data.total || 0;
+            const withImages = caps.filter(c => c.has_images).length;
+            const totalImages = caps.reduce((n, c) => n + c.image_count, 0);
+            const totalIn = caps.reduce((n, c) => n + c.input_tokens, 0);
+            const totalOut = caps.reduce((n, c) => n + c.output_tokens, 0);
+
+            body.innerHTML = '';
+            row(body, 'Proxy', 'listening');
+            row(body, 'Captures', String(total));
+            row(body, 'With images', String(withImages));
+            row(body, 'Total images', String(totalImages));
+            row(body, 'Input tokens', totalIn.toLocaleString());
+            row(body, 'Output tokens', totalOut.toLocaleString());
+
+            if (caps.length > 0) {
+                const last = caps[caps.length - 1];
+                row(body, 'Last model', last.model);
+                row(body, 'Last status', String(last.status_code));
+            }
+
+            status.clear();
+        } catch {
+            body.innerHTML = '';
+            row(body, 'Proxy', 'not reachable');
+            status.show('fetch failed', true);
+        }
+    }
+
+    await refresh();
+    const interval = setInterval(refresh, 5000);
+    ui.onCleanup(() => clearInterval(interval));
+
+    return element;
+};


### PR DESCRIPTION
## Summary

ix-net serves captured development screenshots over HTTP so browser extensions can access them. The browser can't read `~/.qntx/files` directly.

- **Image endpoints**: `/images?branch=<name>`, `/images?session=<id>`, `/images/<session>/<filename>` — branch→session resolution via ATS queries
- **GlyphUI glyph**: live status dashboard (proxy status, captures, tokens) using the SDK properly
- **Configurable proxy port**: reads `proxy_port` from `[ix-net]` in `am.toml` — no more port collisions between instances
- **`claude.fish` reads am.toml**: wrapper script and plugin stay in sync automatically

## Status: paused

See `qntx-plugins/ix-net/HANDOVER.md` for full context, known limitations, untested areas, and the path to a working demo if this work is resumed.

**Nothing in this PR has been end-to-end tested.** The image endpoints, glyph, port config, and branch→session ATS resolution are all unverified.

## Consumer: Xffexlex

Firefox extension at `/SBVH/teranos/Xffexlex`. Background script architecture — content scripts message the background script, which fetches from ix-net. No CORS needed.