### PR TITLE
Unify logger: file output from init

### DIFF
--- a/cmd/qntx/main.go
+++ b/cmd/qntx/main.go
@@ -59,6 +59,15 @@ func init() {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to initialize logger: %v\n", err)
 	}
 
+	// Add file output to the global logger before plugin loading starts.
+	// This makes plugin-loader logs visible in the structured log file.
+	if cfg, err := am.Load(); err == nil {
+		logPath := cfg.GetLogPath(am.GetServerPort())
+		if err := logger.AddFileOutput(logPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to add file output to logger: %v\n", err)
+		}
+	}
+
 	// Initialize domain plugin registry
 	initializePluginRegistry()
 
@@ -175,24 +184,6 @@ func loadPluginsAsync(cfg *am.Config, pluginLogger *zap.SugaredLogger, registry 
 	// Get the server's service registry (this is a bit hacky but necessary for async loading)
 	defaultServer := server.GetDefaultServer()
 
-	// Log plugin loading results through the server logger (writes to structured log file).
-	// The pluginLogger only writes to terminal, so failures are invisible in tmp/qntx-*.log.
-	if defaultServer != nil {
-		serverLogger := defaultServer.GetLogger()
-		if serverLogger != nil {
-			serverLogger.Infow("Plugin loading completed (async)",
-				"loaded", len(loadedPlugins), "enabled", len(cfg.Plugin.Enabled))
-			for name, reason := range manager.GetFailedPlugins() {
-				serverLogger.Errorw("Plugin failed to load",
-					"plugin", name, "error", reason)
-			}
-			for _, p := range loadedPlugins {
-				meta := p.Metadata()
-				serverLogger.Infow("Plugin loaded successfully",
-					"plugin", meta.Name, "version", meta.Version)
-			}
-		}
-	}
 	if defaultServer != nil && defaultServer.GetServices() != nil {
 		pluginLogger.Infow("Initializing loaded plugins with services", "count", len(loadedPlugins))
 		if err := registry.InitializeAll(context.Background(), defaultServer.GetServices()); err != nil {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/teranos/QNTX/errors"
@@ -148,6 +149,37 @@ func getLogLevel() string {
 		return "WARN+"
 	}
 	return "INFO+"
+}
+
+// AddFileOutput tees a file core onto the global logger so that everything
+// logged through logger.Logger (including Named children like plugin-loader)
+// is written to the structured log file from this point forward.
+func AddFileOutput(logPath string) error {
+	dir := filepath.Dir(logPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrapf(err, "failed to create log directory %s", dir)
+	}
+
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open log file %s", logPath)
+	}
+
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	encoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("15:04:05.000")
+	encoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
+
+	fileCore := zapcore.NewCore(
+		zapcore.NewConsoleEncoder(encoderConfig),
+		zapcore.AddSync(file),
+		zap.InfoLevel,
+	)
+
+	combined := zapcore.NewTee(Logger.Desugar().Core(), fileCore)
+	Logger = zap.New(combined).Sugar()
+
+	return nil
 }
 
 // Cleanup flushes any buffered log entries.

--- a/server/init.go
+++ b/server/init.go
@@ -73,7 +73,7 @@ func NewQNTXServer(db *sql.DB, dbPath string, verbosity int, initialQuery ...str
 	logPath := cfg.GetLogPath(appcfg.GetServerPort())
 
 	// Create logger with multi-output (console, WebSocket, file)
-	serverLogger, wsCore, wsTransport, err := createServerLogger(verbosity, logPath)
+	serverLogger, wsCore, wsTransport, err := createServerLogger(verbosity)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create logger")
 	}
@@ -497,30 +497,19 @@ func backfillSyncTree(store ats.AttestationStore, tree syncPkg.SyncTree, observe
 }
 
 // createServerLogger creates a multi-output zap logger (console + WebSocket + file)
-func createServerLogger(verbosity int, logPath string) (*zap.SugaredLogger, *wslogs.WebSocketCore, *wslogs.Transport, error) {
+func createServerLogger(verbosity int) (*zap.SugaredLogger, *wslogs.WebSocketCore, *wslogs.Transport, error) {
 	// Create WebSocket log transport
 	wsTransport := wslogs.NewTransport()
 
 	// Create WebSocket core for zap
 	wsCore := wslogs.NewWebSocketCore(logger.VerbosityToLevel(verbosity))
 
-	// Build multi-core logger: console + WebSocket + file (if verbosity >= 2)
-	cores := []zapcore.Core{
-		logger.Logger.Desugar().Core(), // Existing console/file core
+	// Build multi-core logger: global (console + file) + WebSocket
+	// File core is already part of the global logger (added in main.go init)
+	core := zapcore.NewTee(
+		logger.Logger.Desugar().Core(), // Console + file (from global logger)
 		wsCore,                         // WebSocket core for UI
-	}
-
-	// Add file logging for verbosity >= 2
-	if verbosity >= 2 {
-		fileCore, err := createFileCore(logPath, verbosity)
-		if err == nil {
-			cores = append(cores, fileCore)
-		}
-		// Don't fail if file creation fails, just skip file logging
-	}
-
-	// Create tee core (multi-output)
-	core := zapcore.NewTee(cores...)
+	)
 	serverLogger := zap.New(core).Sugar().Named("server")
 
 	return serverLogger, wsCore, wsTransport, nil

--- a/server/server.go
+++ b/server/server.go
@@ -347,7 +347,3 @@ func (s *QNTXServer) GetDB() *sql.DB {
 	return s.db
 }
 
-// GetLogger returns the server's structured logger (writes to console + file + WebSocket)
-func (s *QNTXServer) GetLogger() *zap.SugaredLogger {
-	return s.logger
-}

--- a/server/util.go
+++ b/server/util.go
@@ -4,16 +4,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/gorilla/websocket"
 	appcfg "github.com/teranos/QNTX/am"
 	"github.com/teranos/QNTX/errors"
-	"github.com/teranos/QNTX/logger"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // getAxUpgrader creates a WebSocket upgrader with origin checking from config
@@ -106,31 +101,6 @@ func findAvailablePort(requestedPort int) (int, error) {
 	}
 
 	return 0, errors.Newf("no available ports found (tried %d, %d, %d, and range 56787-56796)", requestedPort, appcfg.DefaultServerPort, appcfg.FallbackServerPort)
-}
-
-// createFileCore creates a zap core for file logging without colors
-func createFileCore(path string, verbosity int) (zapcore.Core, error) {
-	// Ensure directory exists (os.OpenFile doesn't create intermediate directories)
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return nil, errors.Wrapf(err, "failed to create log directory %s", dir)
-	}
-
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open log file %s", path)
-	}
-
-	// Create encoder config for plain file output (no colors)
-	encoderConfig := zap.NewDevelopmentEncoderConfig()
-	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder // No color codes in files
-	encoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("15:04:05.000")
-	encoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
-
-	encoder := zapcore.NewConsoleEncoder(encoderConfig)
-	writer := zapcore.AddSync(file)
-
-	return zapcore.NewCore(encoder, writer, logger.VerbosityToLevel(verbosity)), nil
 }
 
 // extractPathParts extracts path segments after removing a prefix


### PR DESCRIPTION
## Summary
- Global logger gets file output before plugin loading starts
- Plugin-loader logs now visible in structured log file (tmp/qntx-*.log)
- Removes bandaid that re-logged plugin results through server logger

🐛 Generated with [Claude Code](https://claude.com/claude-code)