### PR TITLE
Condense per-attestation embedding logs into ticker summary

### DIFF
--- a/ats/storage/embedding_store.go
+++ b/ats/storage/embedding_store.go
@@ -514,7 +514,9 @@ func (s *EmbeddingStore) UpdateClusterAssignments(assignments []ClusterAssignmen
 		return errors.Wrap(err, "failed to commit cluster assignments")
 	}
 
-	s.logger.Info("updated cluster assignments", zap.Int("count", len(assignments)))
+	if len(assignments) > 1 {
+		s.logger.Info("updated cluster assignments", zap.Int("count", len(assignments)))
+	}
 	return nil
 }
 

--- a/pulse/schedule/ticker.go
+++ b/pulse/schedule/ticker.go
@@ -45,6 +45,11 @@ type CreationStats interface {
 	DrainCreationCounts() (total int, topPredicateContexts []string)
 }
 
+// EmbeddingStats drains accumulated embedding activity counters.
+type EmbeddingStats interface {
+	DrainEmbeddingCounts() (embedded int, clusterCounts []string, noise int)
+}
+
 // Ticker manages periodic execution of scheduled ATS jobs
 // Runs every second to check for jobs that need execution
 type Ticker struct {
@@ -64,6 +69,7 @@ type Ticker struct {
 	lastActiveWork  int // Track last active work count to detect changes
 	evictionStats   EvictionStats
 	creationStats   CreationStats
+	embeddingStats  EmbeddingStats
 }
 
 // TickerConfig contains configuration for the Pulse ticker
@@ -109,6 +115,11 @@ func (t *Ticker) SetEvictionStats(es EvictionStats) {
 // SetCreationStats injects a creation counter for periodic summary logging.
 func (t *Ticker) SetCreationStats(cs CreationStats) {
 	t.creationStats = cs
+}
+
+// SetEmbeddingStats injects an embedding counter for periodic summary logging.
+func (t *Ticker) SetEmbeddingStats(es EmbeddingStats) {
+	t.embeddingStats = es
 }
 
 // Start begins the ticker loop
@@ -247,7 +258,13 @@ func (t *Ticker) logActivitySummary() {
 		evictionEvents, evicted = t.evictionStats.DrainEvictionCounts()
 	}
 
-	if created == 0 && evictionEvents == 0 {
+	var embedded, noise int
+	var clusterCounts []string
+	if t.embeddingStats != nil {
+		embedded, clusterCounts, noise = t.embeddingStats.DrainEmbeddingCounts()
+	}
+
+	if created == 0 && evictionEvents == 0 && embedded == 0 {
 		return
 	}
 
@@ -258,11 +275,21 @@ func (t *Ticker) logActivitySummary() {
 	if evictionEvents > 0 {
 		parts = append(parts, fmt.Sprintf("evicted %d", evicted))
 	}
+	if embedded > 0 {
+		embPart := fmt.Sprintf("embedded %d", embedded)
+		if noise > 0 {
+			embPart += fmt.Sprintf(" (%d noise)", noise)
+		}
+		parts = append(parts, embPart)
+	}
 
 	msg := strings.Join(parts, ", ")
 
 	if len(topPCs) > 0 {
 		msg += " (top: " + strings.Join(topPCs, ", ") + ")"
+	}
+	if len(clusterCounts) > 0 {
+		msg += " [clusters: " + strings.Join(clusterCounts, ", ") + "]"
 	}
 
 	t.pulseLog.Infow(msg)

--- a/server/embeddings_handlers.go
+++ b/server/embeddings_handlers.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	appcfg "github.com/teranos/QNTX/am"
@@ -665,6 +667,7 @@ func (s *QNTXServer) SetupEmbeddingService() {
 
 	storage.RegisterObserver(observer)
 	s.embeddingClusterInvalidator = observer.InvalidateClusterCache
+	s.embeddingStats = observer
 
 	s.logger.Infow("Embedding service initialized",
 		"path", modelPath,
@@ -702,6 +705,12 @@ type EmbeddingObserver struct {
 	// The watcher engine uses this to run semantic matching with the pre-computed
 	// embedding, eliminating redundant GenerateEmbedding FFI calls.
 	onEmbedded func(as *types.As, embedding []float32)
+
+	// Periodic summary counters (drained by ticker)
+	embedded      atomic.Int64
+	clusterHits   sync.Map // cluster display name (string) → *atomic.Int64
+	clusterNoise  atomic.Int64
+	clusterLabels sync.Map // cluster_id (int) → label (string), refreshed with centroid cache
 }
 
 // InvalidateClusterCache clears cached centroids so the next prediction reloads from DB.
@@ -765,7 +774,9 @@ func (o *EmbeddingObserver) OnAttestationCreated(as *types.As) {
 		return
 	}
 
-	o.logger.Infow("Auto-embedded attestation",
+	o.embedded.Add(1)
+
+	o.logger.Debugw("Auto-embedded attestation",
 		"attestation_id", as.ID,
 		"text_length", len(text),
 		"inference_ms", result.InferenceMS)
@@ -805,6 +816,9 @@ func (o *EmbeddingObserver) predictCluster(embeddingID, attestationID string, em
 		o.clusterCache = loaded
 		o.clusterMu.Unlock()
 		centroids = loaded
+
+		// Refresh cluster label cache
+		o.refreshClusterLabels()
 	}
 
 	clusterID, prob, err := o.embeddingStore.PredictCluster(
@@ -821,6 +835,7 @@ func (o *EmbeddingObserver) predictCluster(embeddingID, attestationID string, em
 	}
 
 	if clusterID == storage.ClusterNoise {
+		o.clusterNoise.Add(1)
 		return // below threshold, stays as noise
 	}
 
@@ -835,7 +850,12 @@ func (o *EmbeddingObserver) predictCluster(embeddingID, attestationID string, em
 		return
 	}
 
-	o.logger.Infow("Predicted cluster for new embedding",
+	// Track cluster hit for periodic summary
+	name := o.clusterDisplayName(clusterID)
+	val, _ := o.clusterHits.LoadOrStore(name, &atomic.Int64{})
+	val.(*atomic.Int64).Add(1)
+
+	o.logger.Debugw("Predicted cluster for new embedding",
 		"attestation_id", attestationID,
 		"embedding_id", embeddingID,
 		"cluster_id", clusterID,
@@ -856,6 +876,64 @@ func (o *EmbeddingObserver) extractRichText(as *types.As) string {
 	}
 
 	return extractRichTextFromAttributes(as.Attributes, richFields)
+}
+
+// clusterDisplayName returns a human-readable name for a cluster ID.
+// Uses the cached label if available, falls back to "cluster:<id>".
+func (o *EmbeddingObserver) clusterDisplayName(clusterID int) string {
+	if label, ok := o.clusterLabels.Load(clusterID); ok {
+		return label.(string)
+	}
+	return "cluster:" + strconv.Itoa(clusterID)
+}
+
+// refreshClusterLabels loads cluster labels from the DB into the label cache.
+func (o *EmbeddingObserver) refreshClusterLabels() {
+	clusters, err := o.embeddingStore.GetActiveClusterIdentities()
+	if err != nil {
+		o.logger.Debugw("Failed to refresh cluster labels", "error", err)
+		return
+	}
+	for _, c := range clusters {
+		if c.Label != nil && *c.Label != "" {
+			o.clusterLabels.Store(c.ID, *c.Label)
+		}
+	}
+}
+
+// DrainEmbeddingCounts atomically reads and resets embedding activity counters.
+// Returns total embedded, cluster assignment breakdown, and noise count.
+func (o *EmbeddingObserver) DrainEmbeddingCounts() (embedded int, clusterCounts []string, noise int) {
+	embedded = int(o.embedded.Swap(0))
+	noise = int(o.clusterNoise.Swap(0))
+
+	var pairs []pairCount
+	o.clusterHits.Range(func(key, value any) bool {
+		count := value.(*atomic.Int64).Swap(0)
+		if count > 0 {
+			pairs = append(pairs, pairCount{Key: key.(string), Count: count})
+		}
+		if count == 0 {
+			o.clusterHits.Delete(key)
+		}
+		return true
+	})
+
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].Count > pairs[j].Count
+	})
+
+	// Show top 5 clusters
+	limit := 5
+	if len(pairs) < limit {
+		limit = len(pairs)
+	}
+	clusterCounts = make([]string, limit)
+	for i := 0; i < limit; i++ {
+		clusterCounts[i] = formatPairCount(pairs[i])
+	}
+
+	return embedded, clusterCounts, noise
 }
 
 // extractRichTextFromAttributes extracts text from the named rich fields in an

--- a/server/init.go
+++ b/server/init.go
@@ -400,6 +400,9 @@ func NewQNTXServer(db *sql.DB, dbPath string, verbosity int, initialQuery ...str
 	// Initialize embedding service for semantic search (optional)
 	server.graundeDBPath = deps.config.GraundeDBPath
 	server.SetupEmbeddingService()
+	if server.embeddingStats != nil {
+		ticker.SetEmbeddingStats(server.embeddingStats)
+	}
 	server.setupEmbeddingReclusterSchedule(deps.config)
 	server.setupEmbeddingReprojectSchedule(deps.config)
 	server.setupClusterLabelSchedule(deps.config)

--- a/server/server.go
+++ b/server/server.go
@@ -121,7 +121,8 @@ type QNTXServer struct {
 		Close() error
 	}
 	embeddingStore              *storage.EmbeddingStore
-	embeddingClusterInvalidator func() // called after re-cluster to invalidate centroid cache
+	embeddingClusterInvalidator func()                  // called after re-cluster to invalidate centroid cache
+	embeddingStats              schedule.EmbeddingStats // drained by ticker for periodic summary
 	graundeDBPath               string
 }
 


### PR DESCRIPTION
## Summary

- Per-attestation "Auto-embedded" and "Predicted cluster" logs downgraded to Debug
- Per-prediction "updated cluster assignments count=1" suppressed (batch count=1540 still logs)
- Embedding activity drains through existing Pulse ticker summary (every 50 ticks), showing cluster distribution with labels when available

Before:
```
updated cluster assignments  count=1
updated cluster assignments  count=1
updated cluster assignments  count=1
... (49 times)
```

After:
```
Created 75, evicted 9, embedded 49 [clusters: Technology & Software(24), cluster:30(16), cluster:46(2)]
```

## Test plan

- [x] `make test` passes
- [x] Run `make dev`, trigger attestation creation (prompt glyph), verify no per-attestation embedding spam
- [ ] Verify ticker summary line includes embedding counts and cluster names
- [ ] Verify batch re-cluster still logs "updated cluster assignments count=N" for N > 1