### PR TITLE
Loom tool turn capture + dreamweave paths + port split

### DIFF
--- a/qntx-plugins/dreamweave/frontend/dev-server.ts
+++ b/qntx-plugins/dreamweave/frontend/dev-server.ts
@@ -14,7 +14,7 @@ import http2 from 'http2'
 
 const execAsync = promisify(exec)
 
-const DREAMWEAVE_PORT = process.env.DREAMWEAVE_PORT || '38701'
+const DREAMWEAVE_PORT = process.env.DREAMWEAVE_PORT || '5178'
 const QNTX_PORT = process.env.QNTX_PORT || '8773'
 const DEV_PORT = 5177
 const distDir = join(import.meta.dir, 'dist')

--- a/qntx-plugins/dreamweave/frontend/src/App.svelte
+++ b/qntx-plugins/dreamweave/frontend/src/App.svelte
@@ -11,6 +11,7 @@
     text: string | null
     word_count: number | null
     turn_count: number | null
+    paths?: Record<string, string>
   }
 
   interface Turn {
@@ -20,6 +21,7 @@
     index: number
     timestamp: number
     branch: string
+    fullPath?: string
   }
 
   interface Session {
@@ -167,7 +169,7 @@
 
   // --- Parse weave text into turns ---
 
-  const SPEAKERS = ['human', 'assistant', 'tool', 'hook', 'session', 'compaction', 'agent', 'task']
+  const SPEAKERS = ['human', 'assistant', 'tool', 'edit', 'read', 'search', 'write', 'hook', 'session', 'compaction', 'agent', 'task']
 
   function isSpeakerLine(s: string): boolean {
     if (s[0] !== '[') return false
@@ -194,13 +196,21 @@
       if (!chunk) continue
       const end = chunk.indexOf('] ')
       if (chunk[0] === '[' && end > 0) {
+        const speaker = chunk.substring(1, end)
+        const text = chunk.substring(end + 2)
+        // Look up full path for file-related turns
+        let fullPath: string | undefined
+        if (weave.paths && (speaker === 'edit' || speaker === 'read' || speaker === 'write' || speaker === 'search')) {
+          fullPath = weave.paths[text]
+        }
         turns.push({
-          speaker: chunk.substring(1, end),
-          text: chunk.substring(end + 2),
+          speaker,
+          text,
           weaveId: weave.id,
           index: i,
           timestamp: weave.timestamp,
           branch: weave.branch,
+          fullPath,
         })
       } else {
         turns.push({
@@ -676,6 +686,10 @@
                       class:human={turn.speaker === 'human'}
                       class:assistant={turn.speaker === 'assistant'}
                       class:tool={turn.speaker === 'tool'}
+                      class:edit={turn.speaker === 'edit'}
+                      class:read={turn.speaker === 'read'}
+                      class:search={turn.speaker === 'search'}
+                      class:write={turn.speaker === 'write'}
                       class:hook={turn.speaker === 'hook'}
                       class:marker={turn.speaker === 'session' || turn.speaker === 'compaction' || turn.speaker === 'agent' || turn.speaker === 'task'}
                       onclick={() => toggle(turn)}
@@ -686,6 +700,12 @@
                       <span class="dw-speaker">[{turn.speaker}]</span>
                       {#if turn.speaker === 'assistant'}
                         <span class="dw-text">{@html renderText(turn.text)}</span>
+                      {:else if turn.fullPath}
+                        <span
+                          class="dw-text dw-path"
+                          title={turn.fullPath}
+                          onclick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(turn.fullPath!) }}
+                        >{turn.text}</span>
                       {:else}
                         <span class="dw-text">{turn.text}</span>
                       {/if}
@@ -1054,6 +1074,35 @@
   .dw-turn.tool .dw-text {
     color: #a9abaa;
     font-size: 8px;
+  }
+
+  .dw-turn.edit,
+  .dw-turn.read,
+  .dw-turn.search,
+  .dw-turn.write {
+    background: #1a1b1a;
+    border-left: 2px solid #5b8dd9;
+    padding-left: 4px;
+    margin: 1px 0;
+  }
+  .dw-turn.edit .dw-speaker { color: #5b8dd9; }
+  .dw-turn.read .dw-speaker { color: #5b8dd9; }
+  .dw-turn.search .dw-speaker { color: #5b8dd9; }
+  .dw-turn.write .dw-speaker { color: #5b8dd9; }
+  .dw-turn.edit .dw-text,
+  .dw-turn.read .dw-text,
+  .dw-turn.search .dw-text,
+  .dw-turn.write .dw-text {
+    color: #a9abaa;
+    font-size: 8px;
+  }
+  .dw-path {
+    cursor: pointer;
+    border-bottom: 1px dotted #3f4140;
+  }
+  .dw-path:hover {
+    color: #dfe1e0;
+    border-bottom-color: #5b8dd9;
   }
 
   .dw-turn.hook {

--- a/qntx-plugins/dreamweave/lib/plugin.ml
+++ b/qntx-plugins/dreamweave/lib/plugin.ml
@@ -151,25 +151,25 @@ let handle_http reqd =
   | _ ->
     respond_json reqd `Not_found {|{"error":"not found"}|}
 
-(* --- Request router --- *)
-
-let route_request reqd =
-  let request = H2.Reqd.request reqd in
-  match request.meth with
-  | `POST ->
-    (match H2.Headers.get request.headers "content-type" with
-     | Some s when String.length s >= 16 && String.sub s 0 16 = "application/grpc" ->
-       Grpc_lwt.Server.Service.handle_request (Lazy.force service) reqd
-     | _ ->
-       handle_http reqd)
-  | _ ->
-    handle_http reqd
-
 (* --- HTTP/2 server --- *)
 
+let http_port = 5178
+
 let serve port =
-  let request_handler _addr reqd =
-    route_request reqd
+  let grpc_handler _addr reqd =
+    let request = H2.Reqd.request reqd in
+    match request.meth with
+    | `POST ->
+      (match H2.Headers.get request.headers "content-type" with
+       | Some s when String.length s >= 16 && String.sub s 0 16 = "application/grpc" ->
+         Grpc_lwt.Server.Service.handle_request (Lazy.force service) reqd
+       | _ ->
+         H2.Reqd.respond_with_string reqd (H2.Response.create `Not_found) "")
+    | _ ->
+      H2.Reqd.respond_with_string reqd (H2.Response.create `Not_found) ""
+  in
+  let http_handler _addr reqd =
+    handle_http reqd
   in
   let error_handler _addr ?request:_ error respond =
     let msg = match error with
@@ -182,9 +182,14 @@ let serve port =
     let body = respond H2.Headers.empty in
     H2.Body.Writer.close body
   in
-  let connection_handler =
+  let grpc_connection =
     H2_lwt_unix.Server.create_connection_handler
-      ~request_handler
+      ~request_handler:grpc_handler
+      ~error_handler
+  in
+  let http_connection =
+    H2_lwt_unix.Server.create_connection_handler
+      ~request_handler:http_handler
       ~error_handler
   in
   let max_attempts = 10 in
@@ -198,7 +203,7 @@ let serve port =
       Lwt.catch
         (fun () ->
           let* _server =
-            Lwt_io.establish_server_with_client_socket listen_addr connection_handler
+            Lwt_io.establish_server_with_client_socket listen_addr grpc_connection
           in
           Lwt.return current_port)
         (fun _exn ->
@@ -207,6 +212,18 @@ let serve port =
   in
   let* actual_port = try_bind 0 port in
   Printf.printf "QNTX_PLUGIN_PORT=%d\n%!" actual_port;
-  Printf.printf "[dreamweave] gRPC + HTTP server listening on port %d\n%!" actual_port;
+  Printf.printf "[dreamweave] gRPC server listening on port %d\n%!" actual_port;
+  (* Start fixed HTTP API server for the frontend *)
+  let http_addr = Unix.(ADDR_INET (inet_addr_loopback, http_port)) in
+  let* _http_server =
+    Lwt.catch
+      (fun () ->
+        let* s = Lwt_io.establish_server_with_client_socket http_addr http_connection in
+        Printf.printf "[dreamweave] HTTP API listening on port %d\n%!" http_port;
+        Lwt.return s)
+      (fun exn ->
+        Printf.eprintf "[dreamweave] Failed to bind HTTP port %d: %s\n%!" http_port (Printexc.to_string exn);
+        Lwt.fail exn)
+  in
   let forever, _ = Lwt.wait () in
   forever

--- a/qntx-plugins/dreamweave/lib/version.ml
+++ b/qntx-plugins/dreamweave/lib/version.ml
@@ -1,1 +1,1 @@
-let value = "0.1.0"
+let value = "0.1.2"

--- a/qntx-plugins/dreamweave/lib/weave.ml
+++ b/qntx-plugins/dreamweave/lib/weave.ml
@@ -19,6 +19,18 @@ let extract_number (fields : Google_types.Struct.Google.Protobuf.Struct.t) key =
   | Some (Some (`Number_value n)) -> Some (int_of_float n)
   | _ -> None
 
+(* Extract a nested Struct as a string→string JSON object *)
+let extract_string_map (fields : Google_types.Struct.Google.Protobuf.Struct.t) key =
+  match List.assoc_opt key fields with
+  | Some (Some (`Struct_value nested)) ->
+    let pairs = List.filter_map (fun (k, v) ->
+      match v with
+      | Some (`String_value s) -> Some (k, `String s)
+      | _ -> None
+    ) nested in
+    `Assoc pairs
+  | _ -> `Assoc []
+
 (* Convert a single attestation to a Yojson object *)
 let attestation_to_json (a : Protocol.Attestation.t) =
   let fields : Google_types.Struct.Google.Protobuf.Struct.t = match a.attributes with
@@ -47,6 +59,7 @@ let attestation_to_json (a : Protocol.Attestation.t) =
     ("turn_count", match extract_number fields "turn_count" with
       | Some n -> `Int n
       | None -> `Null);
+    ("paths", extract_string_map fields "paths");
   ]
 
 (* Convert a list of attestations into a JSON response *)

--- a/qntx-plugins/loom/README.md
+++ b/qntx-plugins/loom/README.md
@@ -1,5 +1,40 @@
 # qntx-loom
 
-Receives conversation events from Graunde over UDP and stitches them into embedding-sized text blocks (weaves).
+Receives conversation events from [Graunde](https://github.com/teranos/graunde) over UDP and stitches them into embedding-sized text blocks (weaves).
 
 **UDP port: 19470** — Graunde sends attestation JSON datagrams here. Fire-and-forget, no response.
+
+## UDP event format
+
+Every datagram is a JSON attestation:
+
+```json
+{
+  "subjects": ["tmp3/QNTX:feat/branch-name"],
+  "predicates": ["UserPromptSubmit"],
+  "contexts": ["session:abc-123"],
+  "attributes": { "prompt": "..." }
+}
+```
+
+Graunde sends these on every hook event via `attestEvent` → `sendToLoom`. Corrective stop hooks additionally send `Hook` predicates via `notifyLoomHook`.
+
+## Turn types
+
+| Predicate | Label | Source |
+|---|---|---|
+| `UserPromptSubmit` | `[human]` | `attributes.prompt` |
+| `Stop` | `[assistant]` | `attributes.last_assistant_message` |
+| `PreToolUse` (Bash) | `[tool]` | `attributes.tool_input.command` (whitelist-filtered) |
+| `PreToolUse` (Edit) | `[edit]` | `attributes.tool_input.file_path` |
+| `PreToolUse` (Read) | `[read]` | `attributes.tool_input.file_path` |
+| `PreToolUse` (Grep/Glob) | `[search]` | `attributes.tool_input.pattern` |
+| `PreToolUse` (Write) | `[write]` | `attributes.tool_input.file_path` |
+| `Hook` | `[hook]` | `attributes.hook_output` |
+| `SessionStart` | `[session]` | `attributes.session_id` |
+| `SessionEnd` | `[session]` | `attributes.session_id` |
+| `PreCompact` | `[compaction]` | static marker |
+| `SubagentStart/Stop` | `[agent]` | `attributes.agent_type` |
+| `TaskCompleted` | `[task]` | `attributes.task_subject` |
+
+Bash `[tool]` turns are filtered by a command whitelist (git, gh, make). All other tool types (Edit, Read, Grep, Glob, Write) are captured with their own labels.

--- a/qntx-plugins/loom/lib/ats_client.ml
+++ b/qntx-plugins/loom/lib/ats_client.ml
@@ -25,7 +25,7 @@ let configure ~ats_endpoint ~token =
 
 (* --- Create a weave attestation --- *)
 
-let create_weave ~branch ~context ~text ~word_count ~turn_count =
+let create_weave ~branch ~context ~text ~word_count ~turn_count ~paths =
   if !endpoint = "" then (
     Printf.eprintf "[loom] ATS client not configured, dropping weave\n%!";
     Lwt.return_error "ATS client not configured"
@@ -41,10 +41,18 @@ let create_weave ~branch ~context ~text ~word_count ~turn_count =
     let number_val n =
       Value.make ~kind:(`Number_value (Float.of_int n)) ()
     in
+    (* Paths: map of file tail → full path, stored as a nested Struct *)
+    let paths_fields = List.map (fun (tail, full) ->
+      (tail, Some (string_val full))
+    ) paths in
+    let paths_val =
+      Value.make ~kind:(`Struct_value (Struct.make ~fields:paths_fields ())) ()
+    in
     let attrs = Struct.make ~fields:[
       ("text", Some (string_val text));
       ("word_count", Some (number_val word_count));
       ("turn_count", Some (number_val turn_count));
+      ("paths", Some paths_val);
     ] () in
 
     let command = Protocol.AttestationCommand.make

--- a/qntx-plugins/loom/lib/plugin.ml
+++ b/qntx-plugins/loom/lib/plugin.ml
@@ -106,6 +106,7 @@ let handle_execute_job raw =
                ~text:block
                ~word_count:(Stitcher.word_count block)
                ~turn_count:result.turn_count
+               ~paths:result.paths
              in
              (match ats_result with
               | Ok () -> ()
@@ -159,6 +160,7 @@ let flush_and_persist () =
         ~text:block
         ~word_count:(Stitcher.word_count block)
         ~turn_count:result.turn_count
+        ~paths:result.paths
       in
       (match ats_result with
        | Ok () -> ()

--- a/qntx-plugins/loom/lib/stitcher.ml
+++ b/qntx-plugins/loom/lib/stitcher.ml
@@ -1,6 +1,6 @@
 (* Stitcher — weaves conversation turns into embedding-ready text blocks
  *
- * Triggered by a watcher on UserPromptSubmit, Stop, and Hook attestations.
+ * Triggered by a watcher on UserPromptSubmit, Stop, Hook, and PreToolUse attestations.
  * Each invocation receives one attestation as JSON payload. The stitcher
  * extracts the conversational text (prompt or last_assistant_message),
  * buffers turns per branch, and emits a "woven" block when the buffer
@@ -32,6 +32,7 @@ let max_chunk_words = 150
 type buffer_entry = {
   context : string;
   turns : string list;
+  paths : (string * string) list;  (* (tail, full_path) for edit/read/write/search turns *)
 }
 
 let buffers : (string, buffer_entry) Hashtbl.t = Hashtbl.create 16
@@ -110,6 +111,55 @@ let extract_tool_command attrs =
      | _ -> None)
   | _ -> None
 
+(* Extract file path tail — last two components for embedding readability *)
+let file_tail path =
+  match String.rindex_opt path '/' with
+  | None -> path
+  | Some i ->
+    let parent_end = i in
+    match String.rindex_from_opt path (parent_end - 1) '/' with
+    | None -> path
+    | Some j -> String.sub path (j + 1) (String.length path - j - 1)
+
+(* Extract tool use as (label, tail_text, full_path option) based on tool_name *)
+let extract_tool_use attrs =
+  let tool_name = match List.assoc_opt "tool_name" attrs with
+    | Some (`String n) -> Some n | _ -> None in
+  let tool_input = match List.assoc_opt "tool_input" attrs with
+    | Some (`Assoc ti) -> Some ti | _ -> None in
+  match tool_name, tool_input with
+  | Some "Edit", Some ti ->
+    (match List.assoc_opt "file_path" ti with
+     | Some (`String fp) -> Some ("edit", file_tail fp, Some fp)
+     | _ -> None)
+  | Some "Read", Some ti ->
+    (match List.assoc_opt "file_path" ti with
+     | Some (`String fp) -> Some ("read", file_tail fp, Some fp)
+     | _ -> None)
+  | Some "Grep", Some ti ->
+    (match List.assoc_opt "pattern" ti with
+     | Some (`String pat) ->
+       let path = match List.assoc_opt "path" ti with
+         | Some (`String p) -> p | _ -> "." in
+       Some ("search", Printf.sprintf "%s in %s" pat (file_tail path), Some path)
+     | _ -> None)
+  | Some "Glob", Some ti ->
+    (match List.assoc_opt "pattern" ti with
+     | Some (`String pat) ->
+       let path = match List.assoc_opt "path" ti with
+         | Some (`String p) -> p | _ -> "." in
+       Some ("search", Printf.sprintf "%s in %s" pat (file_tail path), Some path)
+     | _ -> None)
+  | Some "Write", Some ti ->
+    (match List.assoc_opt "file_path" ti with
+     | Some (`String fp) -> Some ("write", file_tail fp, Some fp)
+     | _ -> None)
+  | Some "Bash", Some ti ->
+    (match List.assoc_opt "command" ti with
+     | Some (`String cmd) when is_weave_worthy_command cmd -> Some ("tool", cmd, None)
+     | _ -> None)
+  | _ -> None
+
 (* Extract the conversational text based on event type.
  * UserPromptSubmit → attributes.prompt
  * Stop → attributes.last_assistant_message
@@ -139,7 +189,10 @@ let extract_text json predicate =
            | Some (`String text) -> Some text
            | _ -> None)
         | "PreToolUse" | "GraundedPreToolUse" ->
-          extract_tool_command attrs
+          (* Tool use handled separately via extract_tool_use for label routing *)
+          (match extract_tool_use attrs with
+           | Some (_, text, _) -> Some text
+           | None -> None)
         | "SessionStart" ->
           (match List.assoc_opt "session_id" attrs with
            | Some (`String id) -> Some (Printf.sprintf "Start Session: %s" id)
@@ -181,6 +234,7 @@ type stitch_result = {
   buffered_words : int;
   emitted : string option;  (* Some block when buffer exceeded max_chunk_words *)
   turn_count : int;          (* Number of turns in the emitted block *)
+  paths : (string * string) list;  (* (tail, full_path) mapping for frontend hover *)
 }
 
 let stitch payload =
@@ -193,7 +247,7 @@ let stitch payload =
   match json with
   | None ->
     Printf.printf "[loom] Skipping malformed payload\n%!";
-    [{ branch = "unknown"; context = "_"; buffered_words = 0; emitted = None; turn_count = 0 }]
+    [{ branch = "unknown"; context = "_"; buffered_words = 0; emitted = None; turn_count = 0; paths = [] }]
   | Some json ->
     let branch = match extract_branch json with Some b -> b | None -> "unknown" in
     let predicate = match extract_predicate json with Some p -> p | None -> "unknown" in
@@ -201,19 +255,35 @@ let stitch payload =
     let text = extract_text json predicate in
     match text with
     | None ->
-      [{ branch; context; buffered_words = 0; emitted = None; turn_count = 0 }]
+      [{ branch; context; buffered_words = 0; emitted = None; turn_count = 0; paths = [] }]
     | Some text ->
-      (* Format the turn with a speaker label *)
+      (* Extract tool use info once for label and path *)
+      let tool_info = match predicate with
+        | "PreToolUse" | "GraundedPreToolUse" ->
+          (match json with
+           | `Assoc fields ->
+             (match List.assoc_opt "attributes" fields with
+              | Some (`Assoc attrs) -> extract_tool_use attrs
+              | _ -> None)
+           | _ -> None)
+        | _ -> None
+      in
       let label = match predicate with
         | "UserPromptSubmit" -> "human"
         | "Stop" -> "assistant"
-        | "PreToolUse" | "GraundedPreToolUse" -> "tool"
+        | "PreToolUse" | "GraundedPreToolUse" ->
+          (match tool_info with Some (lbl, _, _) -> lbl | None -> "tool")
         | "SessionStart" | "SessionEnd" -> "session"
         | "PreCompact" -> "compaction"
         | "SubagentStart" | "SubagentStop" -> "agent"
         | "TaskCompleted" -> "task"
         | "Hook" -> "hook"
         | other -> other
+      in
+      (* Collect path mapping if this turn has one *)
+      let turn_path = match tool_info with
+        | Some (_, tail, Some full) -> [(tail, full)]
+        | _ -> []
       in
       let turn = Printf.sprintf "[%s] %s" label text in
 
@@ -233,7 +303,7 @@ let stitch payload =
              Printf.printf "[loom] Emitting %d-word block for branch %s (branch change to %s)\n%!"
                total_words prev branch;
              [{ branch = prev; context = existing.context; buffered_words = 0;
-                emitted = Some block; turn_count = num_turns }]
+                emitted = Some block; turn_count = num_turns; paths = existing.paths }]
            | _ -> [])
         | _ -> []
       in
@@ -250,26 +320,26 @@ let stitch payload =
               let num_turns = List.length existing.turns in
               Printf.printf "[loom] Emitting %d-word block for branch %s (session start)\n%!"
                 total_words branch;
-              Some (block, existing.context, num_turns)
+              Some (block, existing.context, num_turns, existing.paths)
             | _ -> None
           in
           (* Start fresh buffer with the SessionStart marker *)
-          Hashtbl.replace buffers key { context; turns = [turn] };
+          Hashtbl.replace buffers key { context; turns = [turn]; paths = turn_path };
           match emitted with
-          | Some (block, old_context, num_turns) ->
-            { branch; context = old_context; buffered_words = 0; emitted = Some block; turn_count = num_turns }
+          | Some (block, old_context, num_turns, old_paths) ->
+            { branch; context = old_context; buffered_words = 0; emitted = Some block; turn_count = num_turns; paths = old_paths }
           | None ->
             Printf.printf "[loom] Buffered %d words for branch %s (%d total)\n%!"
               (word_count turn) branch (word_count turn);
-            { branch; context; buffered_words = word_count turn; emitted = None; turn_count = 0 }
+            { branch; context; buffered_words = word_count turn; emitted = None; turn_count = 0; paths = [] }
         ) else (
           (* Get or create buffer for this session, dedup consecutive identical turns *)
           let entry =
             match Hashtbl.find_opt buffers key with
             | Some existing when existing.turns <> [] && List.hd existing.turns = turn ->
               existing (* Skip duplicate *)
-            | Some existing -> { context; turns = turn :: existing.turns }
-            | None -> { context; turns = [turn] }
+            | Some existing -> { context; turns = turn :: existing.turns; paths = turn_path @ existing.paths }
+            | None -> { context; turns = [turn]; paths = turn_path }
           in
           let total_words = buffer_word_count entry.turns in
 
@@ -282,12 +352,12 @@ let stitch payload =
               total_words branch
               (if predicate = "SessionEnd" then "session end" else "threshold");
             let num_turns = List.length entry.turns in
-            { branch; context = entry.context; buffered_words = 0; emitted = Some block; turn_count = num_turns }
+            { branch; context = entry.context; buffered_words = 0; emitted = Some block; turn_count = num_turns; paths = entry.paths }
           ) else (
             Hashtbl.replace buffers key entry;
             Printf.printf "[loom] Buffered %d words for branch %s (%d total)\n%!"
               (word_count turn) branch total_words;
-            { branch; context = entry.context; buffered_words = total_words; emitted = None; turn_count = 0 }
+            { branch; context = entry.context; buffered_words = total_words; emitted = None; turn_count = 0; paths = [] }
           )
         )
       in
@@ -310,7 +380,7 @@ let flush_all () =
       Printf.printf "[loom] Flushing %d-word buffer for %s (shutdown)\n%!"
         total_words key;
       results := { branch; context = entry.context; buffered_words = 0;
-                   emitted = Some block; turn_count = num_turns } :: !results
+                   emitted = Some block; turn_count = num_turns; paths = entry.paths } :: !results
     )
   ) buffers;
   Hashtbl.clear buffers;

--- a/qntx-plugins/loom/lib/udp_listener.ml
+++ b/qntx-plugins/loom/lib/udp_listener.ml
@@ -41,6 +41,7 @@ let start () =
             ~text:block
             ~word_count:(Stitcher.word_count block)
             ~turn_count:result.turn_count
+            ~paths:result.paths
           in
           (match ats_result with
            | Ok () -> ()

--- a/qntx-plugins/loom/lib/version.ml
+++ b/qntx-plugins/loom/lib/version.ml
@@ -1,1 +1,1 @@
-let value = "0.3.19"
+let value = "0.3.21"

--- a/qntx-plugins/loom/test/test_stitcher.ml
+++ b/qntx-plugins/loom/test/test_stitcher.ml
@@ -249,7 +249,7 @@ let test_stitch_missing_text () =
 (* --- result_to_json --- *)
 
 let test_result_to_json_buffered () =
-  let r = Stitcher.{ branch = "main"; context = "session:x"; buffered_words = 42; emitted = None; turn_count = 0 } in
+  let r = Stitcher.{ branch = "main"; context = "session:x"; buffered_words = 42; emitted = None; turn_count = 0; paths = [] } in
   let json = Yojson.Safe.from_string (Stitcher.result_to_json r) in
   match json with
   | `Assoc fields ->
@@ -259,7 +259,7 @@ let test_result_to_json_buffered () =
   | _ -> Alcotest.fail "expected JSON object"
 
 let test_result_to_json_emitted () =
-  let r = Stitcher.{ branch = "main"; context = "session:x"; buffered_words = 0; emitted = Some "hello world"; turn_count = 1 } in
+  let r = Stitcher.{ branch = "main"; context = "session:x"; buffered_words = 0; emitted = Some "hello world"; turn_count = 1; paths = [] } in
   let json = Yojson.Safe.from_string (Stitcher.result_to_json r) in
   match json with
   | `Assoc fields ->
@@ -272,7 +272,7 @@ let test_result_to_json_emitted () =
   | _ -> Alcotest.fail "expected JSON object"
 
 let test_result_to_json_escapes_branch () =
-  let r = Stitcher.{ branch = {|feat/"quoted"|}; context = "session:x"; buffered_words = 10; emitted = None; turn_count = 0 } in
+  let r = Stitcher.{ branch = {|feat/"quoted"|}; context = "session:x"; buffered_words = 10; emitted = None; turn_count = 0; paths = [] } in
   let json_str = Stitcher.result_to_json r in
   (* Must parse as valid JSON — would fail if branch wasn't escaped *)
   let _json = Yojson.Safe.from_string json_str in


### PR DESCRIPTION
## Summary

- Loom captures edit/read/search/write tool turns with file tails in weave text (embedding-friendly) and full paths in a separate `paths` attribute (frontend hover/copy)
- Dreamweave serves `paths` in the weave JSON API and renders them with hover-to-see, click-to-copy
- Dreamweave splits gRPC (dynamic port, plugin range) and HTTP API (fixed :5178) so plugin restarts never break the frontend

## Test plan

- [x] Loom stitcher tests pass (35/35)
- [x] Verified paths attribute appears in weave attestations in database
- [x] Verified dreamweave frontend renders [read] turns with path hover
- [x] Verified port split: gRPC on dynamic port, HTTP API on :5178