### PR TITLE
Database glyph: historical eviction chart

### DIFF
--- a/docs/plans/rust-db-ownership-phase2.md
+++ b/docs/plans/rust-db-ownership-phase2.md
@@ -1,22 +1,22 @@
 # Rust DB Ownership — Phase 2
 
-Phase 1 (PR #691) moved enforcement from Go to Rust's single `rusqlite` connection, eliminating the dual-connection `SQLITE_CORRUPT` root cause. Phase 2 removes the remaining Go `*sql.DB` touchpoints on the attestations table and cleans up dead code.
+Phase 1 (PR #691) moved enforcement from Go to Rust's single `rusqlite` connection, eliminating the dual-connection `SQLITE_CORRUPT` root cause. Phase 2 removes the remaining Go `*sql.DB` touchpoints on the attestations table and cleans up dead code. Phase 3 (PR #712, v0.25.0) made Rust the sole SQLite driver — all Go SQL routes through Rust via `database/sql/driver`.
 
-## 2.1 Delete `as` command
+## 2.1 Delete `as` command — DONE
 
-Remove `cmd/qntx/commands/as.go` and its registration in `cmd/qntx/main.go`. The CLI attestation creation path is deprecated.
+Deleted prior to Phase 3. Parser (`ats/parser/as.go`) remains, still used by `ats/ix`.
 
-## 2.2 Remove warning logic
+## 2.2 Remove warning logic — DONE
 
-Delete `bounded_store_warnings.go`, `bounded_store_warnings_test.go`, `StorageWarning` type, and all `CheckStorageStatus` calls (`batch.go`). Warnings predicted when evictions *would* happen — we now accept evictions and observe them after the fact.
+Deleted prior to Phase 3. `bounded_store_warnings.go`, `StorageWarning` type, `CheckStorageStatus` calls all removed.
 
-## 2.3 Remove Go-side telemetry dead code
+## 2.3 Remove Go-side telemetry dead code — DONE
 
-Delete `logStorageWarning` and `nullIfEmpty` from `bounded_store_telemetry.go`. Rust writes `storage_events` directly since Phase 1. If the file becomes empty, delete it.
+`logStorageWarning` and `bounded_store_telemetry.go` deleted. `nullIfEmpty` remains in `bounded_store.go`, still used by `watcher_store.go`.
 
-## 2.4 Route `GetStorageStats` through Rust FFI
+## 2.4 Route `GetStorageStats` through Rust FFI — DONE
 
-`BoundedStore.GetStorageStats()` still queries via Go's `*sql.DB`. Replace with the existing `RustStore.GetStorageStats()` FFI call (`storage_get_stats`). This removes the last Go SQL query against the attestations table.
+Already routed through Rust: `RustBackedStore.GetStorageStats()` → `RustStore.GetStorageStats()` → Rust FFI. No Go `*sql.DB` queries remain against the attestations table.
 
 ## 2.5 Deprecate old db stats window, add eviction observability to database glyph
 
@@ -24,10 +24,6 @@ Delete `logStorageWarning` and `nullIfEmpty` from `bounded_store_telemetry.go`. 
 - Ensure the database glyph (`default-glyphs.ts`) shows the same data
 - Make evictions observable in the glyph — the `storage-eviction.ts` and `storage-warning.ts` handlers currently just `console.log`; surface eviction counts/details in the database glyph
 
-## 2.6 Update docs
+## 2.6 Update docs — NOT NEEDED
 
-Update `docs/architecture/bounded-storage.md`:
-- Code organization section references `bounded_store_enforcement.go` (deleted in Phase 1)
-- Enforcement flow diagram shows Go path (now Rust)
-- Testing section uses `qntx as` commands (deleted in 2.1)
-- Remove warning-related guidance
+`docs/architecture/bounded-storage.md` is accurate. Enforcement flow already shows Rust path. No references to deleted code.

--- a/server/client.go
+++ b/server/client.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -855,6 +856,57 @@ func (c *Client) handleGetDatabaseStats() {
 		storageBackend = "rust"
 	}
 
+	// Get recent eviction events from storage_events table
+	var recentEvictions []map[string]interface{}
+	evictionRows, err := c.server.db.Query(`
+		SELECT event_type, actor, context, entity, deletions_count, limit_value, timestamp
+		FROM storage_events
+		WHERE event_type != 'storage_warning'
+		ORDER BY id DESC
+		LIMIT 1000
+	`)
+	if err == nil {
+		defer evictionRows.Close()
+		for evictionRows.Next() {
+			var (
+				eventType      string
+				actor          sql.NullString
+				ctx            sql.NullString
+				entity         sql.NullString
+				deletionsCount int
+				limitValue     sql.NullInt64
+				timestamp      string
+			)
+			if err := evictionRows.Scan(&eventType, &actor, &ctx, &entity, &deletionsCount, &limitValue, &timestamp); err != nil {
+				continue
+			}
+			limit := int(limitValue.Int64)
+			if !limitValue.Valid {
+				limit = 0
+			}
+			var message string
+			switch eventType {
+			case "actor_context_limit":
+				message = fmt.Sprintf("Evicted %d old attestations for %s/%s (limit: %d)", deletionsCount, actor.String, ctx.String, limit)
+			case "actor_contexts_limit":
+				message = fmt.Sprintf("Evicted %d attestations for actor %s (contexts limit: %d)", deletionsCount, actor.String, limit)
+			case "entity_actors_limit":
+				message = fmt.Sprintf("Evicted %d attestations for entity %s (actors limit: %d)", deletionsCount, entity.String, limit)
+			default:
+				message = fmt.Sprintf("Evicted %d attestations (%s)", deletionsCount, eventType)
+			}
+			recentEvictions = append(recentEvictions, map[string]interface{}{
+				"event_type":      eventType,
+				"actor":           actor.String,
+				"context":         ctx.String,
+				"entity":          entity.String,
+				"deletions_count": deletionsCount,
+				"message":         message,
+				"timestamp":       timestamp,
+			})
+		}
+	}
+
 	// Send stats to client with enhanced field information
 	c.sendJSON(map[string]interface{}{
 		"type":               "database_stats",
@@ -867,6 +919,7 @@ func (c *Client) handleGetDatabaseStats() {
 		"unique_subjects":    uniqueSubjects,
 		"unique_contexts":    uniqueContexts,
 		"rich_fields":        richFieldsWithStats,
+		"recent_evictions":   recentEvictions,
 	})
 
 	c.server.logger.Infow("Database stats sent",

--- a/web/ts/default-glyphs.ts
+++ b/web/ts/default-glyphs.ts
@@ -59,6 +59,7 @@ import { sendMessage } from './websocket';
 import { apiFetch } from './api';
 import { escapeHtml } from './html-utils';
 import { DB } from '@generated/sym.js';
+import { seedEvictions, recordEviction as recordEvictionEvent, getEvictionSummary, hasEvictions, renderEvictionChart } from './eviction-chart';
 import { log, SEG } from './logger.ts';
 import { formatBuildTime } from './components/tooltip.ts';
 import type { VersionMessage, SystemCapabilitiesMessage, SyncStatusMessage } from '../types/websocket';
@@ -310,27 +311,6 @@ phone = "http://phone.local:877"</pre>
 let dbStatsElement: HTMLElement | null = null;
 let dbStats: any = null;
 
-// Eviction tracking — recent evictions shown in database glyph
-interface EvictionRecord {
-    event_type: string;
-    actor: string;
-    context: string;
-    entity: string;
-    deletions_count: number;
-    message: string;
-    timestamp: number;
-}
-const recentEvictions: EvictionRecord[] = [];
-const MAX_EVICTIONS = 20;
-
-function formatTimeAgo(ts: number): string {
-    const seconds = Math.floor((Date.now() - ts) / 1000);
-    if (seconds < 60) return `${seconds}s ago`;
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    return `${hours}h ago`;
-}
 
 // Self diagnostics state
 let selfElement: HTMLElement | null = null;
@@ -339,19 +319,16 @@ let selfCapabilities: SystemCapabilitiesMessage | null = null;
 
 export function updateDatabaseStats(stats: any): void {
     dbStats = stats;
+    if (stats.recent_evictions) {
+        seedEvictions(stats.recent_evictions);
+    }
     if (dbStatsElement) {
         renderDbStats();
     }
 }
 
 export function recordEviction(data: { event_type: string; actor: string; context: string; entity: string; deletions_count: number; message: string }): void {
-    recentEvictions.unshift({
-        ...data,
-        timestamp: Date.now(),
-    });
-    if (recentEvictions.length > MAX_EVICTIONS) {
-        recentEvictions.length = MAX_EVICTIONS;
-    }
+    recordEvictionEvent(data);
     if (dbStatsElement) {
         renderDbStats();
     }
@@ -408,24 +385,16 @@ function renderDbStats(): void {
         `;
     }
 
-    // Build eviction section
+    // Build eviction section — bar chart aggregated by hour
     let evictionSection = '';
-    if (recentEvictions.length > 0) {
-        const totalEvicted = recentEvictions.reduce((sum, e) => sum + e.deletions_count, 0);
-        const evictionRows = recentEvictions.slice(0, 10).map(e => {
-            const ago = formatTimeAgo(e.timestamp);
-            return `<div class="glyph-row" style="font-size: 0.85em; opacity: 0.85;">
-                <span class="glyph-label" style="min-width: auto;">${ago}</span>
-                <span class="glyph-value">${e.message}</span>
-            </div>`;
-        }).join('');
-
+    if (hasEvictions()) {
+        const summary = getEvictionSummary();
         evictionSection = `
             <div class="glyph-row" style="margin-top: 8px; border-top: 1px solid var(--border-color, #333); padding-top: 8px;">
-                <span class="glyph-label">Evictions (session):</span>
-                <span class="glyph-value">${recentEvictions.length} events, ${totalEvicted.toLocaleString()} attestations</span>
+                <span class="glyph-label">Evictions:</span>
+                <span class="glyph-value">${summary.count} events, ${summary.totalEvicted.toLocaleString()} attestations evicted</span>
             </div>
-            ${evictionRows}
+            <div class="eviction-chart-container"></div>
         `;
     }
 
@@ -471,6 +440,12 @@ function renderDbStats(): void {
             }
         });
     });
+
+    // Render eviction bar chart
+    const chartContainer = dbStatsElement.querySelector('.eviction-chart-container');
+    if (chartContainer && hasEvictions()) {
+        renderEvictionChart(chartContainer as HTMLElement);
+    }
 }
 
 function renderSelf(): void {

--- a/web/ts/eviction-chart.ts
+++ b/web/ts/eviction-chart.ts
@@ -1,0 +1,136 @@
+/**
+ * Eviction Chart — D3 bar chart showing eviction history over time.
+ * Used by the database glyph to visualize bounded storage enforcement.
+ */
+
+import * as d3 from 'd3';
+
+export interface EvictionRecord {
+    event_type: string;
+    actor: string;
+    context: string;
+    entity: string;
+    deletions_count: number;
+    message: string;
+    timestamp: number;
+}
+
+const MAX_EVICTIONS = 1000;
+const evictions: EvictionRecord[] = [];
+
+/** Seed eviction history from backend response (called once on glyph open). */
+export function seedEvictions(records: Array<{ event_type: string; actor: string; context: string; entity: string; deletions_count: number; message: string; timestamp: string }>): void {
+    if (evictions.length > 0 || !records || records.length === 0) return;
+    for (const ev of records) {
+        evictions.push({
+            event_type: ev.event_type,
+            actor: ev.actor,
+            context: ev.context,
+            entity: ev.entity,
+            deletions_count: ev.deletions_count,
+            message: ev.message,
+            timestamp: new Date(ev.timestamp).getTime(),
+        });
+    }
+}
+
+/** Record a live eviction from WebSocket. */
+export function recordEviction(data: { event_type: string; actor: string; context: string; entity: string; deletions_count: number; message: string }): void {
+    evictions.unshift({
+        ...data,
+        timestamp: Date.now(),
+    });
+    if (evictions.length > MAX_EVICTIONS) {
+        evictions.length = MAX_EVICTIONS;
+    }
+}
+
+/** Get summary stats for the eviction header row. */
+export function getEvictionSummary(): { count: number; totalEvicted: number } {
+    return {
+        count: evictions.length,
+        totalEvicted: evictions.reduce((sum, e) => sum + e.deletions_count, 0),
+    };
+}
+
+/** Returns true if there are evictions to display. */
+export function hasEvictions(): boolean {
+    return evictions.length > 0;
+}
+
+/** Render the eviction bar chart into the given container element. */
+export function renderEvictionChart(container: HTMLElement): void {
+    container.innerHTML = '';
+
+    if (evictions.length === 0) return;
+
+    // Aggregate evictions into hourly buckets
+    const buckets = new Map<number, number>();
+    for (const ev of evictions) {
+        const hour = Math.floor(ev.timestamp / 3600000) * 3600000;
+        buckets.set(hour, (buckets.get(hour) ?? 0) + ev.deletions_count);
+    }
+
+    const data = Array.from(buckets.entries())
+        .map(([time, count]) => ({ time: new Date(time), count }))
+        .sort((a, b) => a.time.getTime() - b.time.getTime());
+
+    if (data.length === 0) return;
+
+    const width = 360;
+    const height = 80;
+    const margin = { top: 8, right: 8, bottom: 20, left: 30 };
+    const innerW = width - margin.left - margin.right;
+    const innerH = height - margin.top - margin.bottom;
+
+    const svg = d3.select(container)
+        .append('svg')
+        .attr('viewBox', `0 0 ${width} ${height}`)
+        .style('width', '100%')
+        .style('height', 'auto')
+        .style('border-radius', '4px');
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    const barWidth = Math.max(4, Math.min(20, innerW / data.length - 2));
+
+    const xScale = d3.scaleTime()
+        .domain(d3.extent(data, d => d.time) as [Date, Date])
+        .range([barWidth / 2, innerW - barWidth / 2]);
+
+    const yScale = d3.scaleLinear()
+        .domain([0, d3.max(data, d => d.count) ?? 1])
+        .nice()
+        .range([innerH, 0]);
+
+    // Bars
+    g.selectAll('rect')
+        .data(data)
+        .enter()
+        .append('rect')
+        .attr('x', d => xScale(d.time) - barWidth / 2)
+        .attr('y', d => yScale(d.count))
+        .attr('width', barWidth)
+        .attr('height', d => innerH - yScale(d.count))
+        .attr('fill', '#ef4444')
+        .attr('opacity', 0.7)
+        .attr('rx', 1);
+
+    // X axis
+    g.append('g')
+        .attr('transform', `translate(0,${innerH})`)
+        .call(d3.axisBottom(xScale).ticks(4).tickFormat(d => d3.timeFormat('%H:%M')(d as Date)))
+        .selectAll('text')
+        .attr('fill', '#94a3b8')
+        .style('font-size', '9px');
+
+    // Y axis
+    g.append('g')
+        .call(d3.axisLeft(yScale).ticks(3).tickFormat(d3.format('d')))
+        .selectAll('text')
+        .attr('fill', '#94a3b8')
+        .style('font-size', '9px');
+
+    // Style axis lines
+    svg.selectAll('.domain, .tick line').attr('stroke', '#334155');
+}


### PR DESCRIPTION
Phase 2.5 of Rust DB ownership plan.

- Evictions load from `storage_events` table on glyph open (up to 1000) instead of only tracking the current browser session
- D3 bar chart aggregates evictions by hour
- Extracted `eviction-chart.ts` from `default-glyphs.ts`
- Updated phase 2 plan doc — all items complete except this one (now done)

## Test plan

- [x] `make test` passes
- [x] Manual: db glyph shows historical evictions on fresh page load