### PR TITLE
stream glyph: top-K token popup on hover

### DIFF
--- a/docs/research/inference-internals.md
+++ b/docs/research/inference-internals.md
@@ -141,7 +141,7 @@ Transport is gRPC server streaming (`StreamChat` RPC). The Go layer adapts the g
 
 **Step 3 — Confidence heatmap.** *(done)* Stream glyph (`stream-glyph.ts`) renders each token as a `<span>` with `background-color` mapped from confidence via `confidenceToColor()` — linear HSL interpolation, amber glow at low confidence, transparent at high. Multiplexer pattern: one WebSocket handler routes `llm_stream` messages to many glyph instances by `job_id`. Follow-ups from a stream glyph spawn a new stream glyph with live heatmap (spawn-before-fetch pattern). Token data persists to canvas state across page refresh. Shared follow-up infrastructure (`glyph-followup.ts`) between result and stream glyphs.
 
-**Step 4 — Top-K popup.** Hover/click interaction on heatmapped tokens. Shows the decision space at that position.
+**Step 4 — Top-K popup.** *(done)* Hover interaction on heatmapped tokens (`token-popup.ts`). Shows signal values (P, H, Δ) and top-K candidates with horizontal probability bars. Chosen token highlighted. Event delegation on the output container — one listener for all tokens. Popup is viewport-constrained (flips up/left at edges). Data comes from `data-*` attributes already on each token span from Step 3.
 
 **Step 5 — Entropy sparkline.** Macro view of the generation's certainty profile. SVG strip.
 
@@ -181,7 +181,7 @@ Could LLM embeddings plug into the same HDBSCAN/UMAP infra? Technically yes — 
 ### Tier 1 Visualizations
 
 - [x] Confidence heatmap — color token spans by P(chosen) or entropy
-- [ ] Top-K alternatives popup — hover/click a token to see candidates + probability bars
+- [x] Top-K alternatives popup — hover a token to see signal data + candidate probability bars
 - [ ] Entropy sparkline — rolling SVG line chart of entropy per token position
 - [ ] Runner-up ghost trail — inline muted annotation of second-place tokens
 

--- a/web/css/glyph/token-popup.css
+++ b/web/css/glyph/token-popup.css
@@ -1,0 +1,81 @@
+/**
+ * Token popup — hover overlay showing signal data and top-K candidates.
+ *
+ * Appears on mouseenter over a token span in stream glyph output.
+ * Fixed position, viewport-constrained.
+ */
+.token-popup {
+    position: fixed;
+    z-index: 100000;
+    background: var(--bg-dark-hover);
+    border: 1px solid var(--border-on-dark);
+    padding: 6px 8px;
+    font-family: monospace;
+    font-size: var(--font-size-sm);
+    color: var(--text-on-dark);
+    pointer-events: none;
+    min-width: 180px;
+    max-width: 320px;
+}
+
+.token-popup-signals {
+    display: flex;
+    gap: 10px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+    font-size: 11px;
+    white-space: nowrap;
+}
+
+.token-popup-candidates {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.token-popup-candidate {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: 18px;
+}
+
+.token-popup-candidate.token-popup-chosen {
+    color: #fff;
+}
+
+.token-popup-candidate:not(.token-popup-chosen) {
+    color: var(--text-secondary);
+}
+
+.token-popup-token-text {
+    width: 72px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-align: right;
+    flex-shrink: 0;
+    font-size: 11px;
+}
+
+.token-popup-bar-track {
+    flex: 1;
+    height: 10px;
+    background: rgba(255, 255, 255, 0.05);
+    position: relative;
+}
+
+.token-popup-bar {
+    height: 100%;
+    background: hsla(30, 100%, 50%, 0.7);
+}
+
+.token-popup-chosen .token-popup-bar {
+    background: hsla(30, 100%, 60%, 0.9);
+}
+
+.token-popup-prob {
+    width: 40px;
+    text-align: right;
+    flex-shrink: 0;
+    font-size: 11px;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,7 @@
     <!-- Glyph system styles -->
     <link rel="stylesheet" href="/css/glyph/title-bar.css">
     <link rel="stylesheet" href="/css/glyph/followup.css">
+    <link rel="stylesheet" href="/css/glyph/token-popup.css">
     <link rel="stylesheet" href="/css/glyph/tray.css">
     <link rel="stylesheet" href="/css/glyph/resize.css">
     <link rel="stylesheet" href="/css/glyph/states/dot.css">

--- a/web/ts/components/glyph/stream-glyph.ts
+++ b/web/ts/components/glyph/stream-glyph.ts
@@ -10,7 +10,7 @@
  *
  * Persists token data to canvas state so content survives page refresh.
  *
- * TODO: Token hover/click popup showing signal data (entropy, top_gap, top-k candidates) — data is on each span already
+ * Token hover popup showing signal data and top-K candidates — see token-popup.ts
  * TODO: Copy button (result glyph has one, stream glyph doesn't)
  * TODO: Factor entropy and top_gap into color mapping, not just confidence
  * TODO: Window morph support (separate PR)
@@ -27,6 +27,7 @@ import { uiState } from '../../state/ui';
 import { registerHandler, unregisterHandler } from '../../websocket';
 import { apiFetch } from '../../api';
 import { createFollowUpZone, type FollowUpRequest, type FollowUpControls } from './glyph-followup';
+import { createTokenPopup } from './token-popup';
 
 // ── Multiplexer ─────────────────────────────────────────────────────
 
@@ -208,6 +209,21 @@ export function createStreamGlyph(glyph: Glyph, promptGlyphId: string, promptTex
         output.appendChild(renderToken(token));
     }
 
+    // Token hover popup — event delegation on the output container
+    const popup = createTokenPopup();
+    output.addEventListener('mouseenter', (e: MouseEvent) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'SPAN' && target.dataset.confidence) {
+            popup.show(target as HTMLSpanElement);
+        }
+    }, true);
+    output.addEventListener('mouseleave', (e: MouseEvent) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'SPAN') {
+            popup.hide();
+        }
+    }, true);
+
     /** Persist current tokens to canvas state */
     function persistContent(): void {
         const content: StreamGlyphContent = { tokens, model: streamModel, prompt: promptText };
@@ -255,6 +271,7 @@ export function createStreamGlyph(glyph: Glyph, promptGlyphId: string, promptTex
     // Cleanup
     storeCleanup(element, () => {
         if (promptGlyphId) unsubscribeStream(promptGlyphId);
+        popup.destroy();
     });
 
     return element;

--- a/web/ts/components/glyph/token-popup.ts
+++ b/web/ts/components/glyph/token-popup.ts
@@ -1,0 +1,135 @@
+/**
+ * Token Popup — hover overlay for stream glyph tokens.
+ *
+ * Shows signal data (confidence, entropy, top_gap) and top-K candidate
+ * tokens with probability bars. One popup instance per stream glyph,
+ * positioned near the hovered span, viewport-constrained.
+ */
+
+import type { LLMTokenCandidate } from '@generated/server';
+
+export interface TokenPopup {
+    show(span: HTMLSpanElement): void;
+    hide(): void;
+    destroy(): void;
+}
+
+/** Escape whitespace characters for display */
+function escapeToken(text: string): string {
+    let out = '';
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (ch === '\n') { out += '\\n'; }
+        else if (ch === '\t') { out += '\\t'; }
+        else if (ch === '\r') { out += '\\r'; }
+        else { out += ch; }
+    }
+    return out;
+}
+
+export function createTokenPopup(): TokenPopup {
+    const el = document.createElement('div');
+    el.className = 'token-popup';
+    el.style.display = 'none';
+    document.body.appendChild(el);
+
+    function show(span: HTMLSpanElement): void {
+        const confidence = span.dataset.confidence;
+        if (!confidence) return;
+
+        const entropy = span.dataset.entropy ?? '—';
+        const topGap = span.dataset.topGap ?? '—';
+        const topKRaw = span.dataset.topK;
+
+        let candidates: LLMTokenCandidate[] = [];
+        if (topKRaw) {
+            try { candidates = JSON.parse(topKRaw); } catch { /* skip */ }
+        }
+
+        // Build content
+        el.innerHTML = '';
+
+        // Signal row
+        const signals = document.createElement('div');
+        signals.className = 'token-popup-signals';
+        const conf = parseFloat(confidence);
+        const ent = parseFloat(entropy);
+        const gap = parseFloat(topGap);
+        signals.textContent = [
+            `P=${isNaN(conf) ? '—' : conf.toFixed(3)}`,
+            `H=${isNaN(ent) ? '—' : ent.toFixed(2)}`,
+            `Δ=${isNaN(gap) ? '—' : gap.toFixed(3)}`,
+        ].join('  ');
+        el.appendChild(signals);
+
+        // Candidates
+        if (candidates.length > 0) {
+            const list = document.createElement('div');
+            list.className = 'token-popup-candidates';
+
+            const chosenText = span.textContent ?? '';
+
+            for (const c of candidates) {
+                const row = document.createElement('div');
+                row.className = 'token-popup-candidate';
+                if (c.text === chosenText) row.classList.add('token-popup-chosen');
+
+                const tokenText = document.createElement('span');
+                tokenText.className = 'token-popup-token-text';
+                tokenText.textContent = escapeToken(c.text);
+                row.appendChild(tokenText);
+
+                const barTrack = document.createElement('div');
+                barTrack.className = 'token-popup-bar-track';
+                const bar = document.createElement('div');
+                bar.className = 'token-popup-bar';
+                bar.style.width = `${(c.prob * 100).toFixed(1)}%`;
+                barTrack.appendChild(bar);
+                row.appendChild(barTrack);
+
+                const prob = document.createElement('span');
+                prob.className = 'token-popup-prob';
+                prob.textContent = c.prob.toFixed(3);
+                row.appendChild(prob);
+
+                list.appendChild(row);
+            }
+
+            el.appendChild(list);
+        }
+
+        // Position near the span, viewport-constrained
+        el.style.display = '';
+        const spanRect = span.getBoundingClientRect();
+        const popupWidth = el.offsetWidth;
+        const popupHeight = el.offsetHeight;
+        const margin = 4;
+
+        let left = spanRect.left;
+        let top = spanRect.bottom + margin;
+
+        // Flip up if near bottom
+        if (top + popupHeight > window.innerHeight - margin) {
+            top = spanRect.top - popupHeight - margin;
+        }
+
+        // Constrain horizontal
+        if (left + popupWidth > window.innerWidth - margin) {
+            left = window.innerWidth - popupWidth - margin;
+        }
+        if (left < margin) left = margin;
+
+        el.style.left = `${left}px`;
+        el.style.top = `${top}px`;
+    }
+
+    function hide(): void {
+        el.style.display = 'none';
+    }
+
+    function destroy(): void {
+        el.remove();
+    }
+
+    return { show, hide, destroy };
+}


### PR DESCRIPTION
## Summary

- Hover any heatmapped token in a stream glyph to see the model's decision space at that position
- Popup shows signal values (confidence, entropy, top_gap) and top-K candidates with horizontal probability bars
- Chosen token highlighted, viewport-constrained positioning

## Test plan

- [x] Run prompt against llama-cpp, hover tokens in the stream glyph
- [x] Verify popup shows signal values and candidate bars
- [x] Verify popup flips near viewport edges
- [x] Verify popup works on restored (persisted) stream glyphs
- [x] `make test` passes