### PR TITLE
sync: batch signature rejection logs

### DIFF
--- a/ats/signing/signing_test.go
+++ b/ats/signing/signing_test.go
@@ -3,11 +3,13 @@ package signing
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/mr-tron/base58"
 	"github.com/teranos/QNTX/ats/types"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func testAttestation() *types.As {
@@ -154,5 +156,197 @@ func TestDecodeDIDKeyInvalidFormat(t *testing.T) {
 	_, err := DecodeDIDKey("not-a-did")
 	if err == nil {
 		t.Fatal("DecodeDIDKey should reject invalid format")
+	}
+}
+
+// TestSignVerifyJSONRoundTrip simulates the full sign → DB store → wire → verify path.
+// Attributes are marshaled to JSON (as in the Rust FFI boundary) and unmarshaled back,
+// which can change types (e.g. nested structures). The canonical JSON must match.
+func TestSignVerifyJSONRoundTrip(t *testing.T) {
+	signer := testSigner()
+	as := &types.As{
+		ID:         "AS-MODELAMA-WEAVE-TEST-ABCD1234",
+		Subjects:   []string{"model:llama-3.2-1b"},
+		Predicates: []string{"Weave"},
+		Contexts:   []string{"test-ctx"},
+		Actors:     []string{"AS-MODELAMA-WEAVE-TEST-ABCD1234"},
+		Timestamp:  time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Source:     "llama-cpp",
+		Attributes: map[string]interface{}{
+			"prompt":          "hello",
+			"text":            "world",
+			"model":           "llama-3.2-1b",
+			"token_count":     float64(5),
+			"mean_confidence": float64(0.95),
+			"mean_entropy":    float64(2.3),
+			"weave_source":    "llama-cpp",
+			"source_version":  "0.18.1",
+			"tokens": []interface{}{
+				map[string]interface{}{
+					"text":       "hello",
+					"position":   float64(0),
+					"confidence": float64(0.9),
+					"entropy":    float64(1.5),
+					"top_gap":    float64(0.3),
+					"top_k": []interface{}{
+						map[string]interface{}{"text": "hello", "prob": float64(0.9)},
+						map[string]interface{}{"text": "world", "prob": float64(0.1)},
+					},
+				},
+			},
+		},
+	}
+
+	// Sign
+	if err := signer.Sign(as); err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	signedCanonical, _ := CanonicalJSON(as)
+
+	// Simulate DB roundtrip: marshal to JSON, unmarshal back (like fromRustJSON)
+	type ffiAttestation struct {
+		ID         string                 `json:"id,omitempty"`
+		Subjects   []string               `json:"subjects,omitempty"`
+		Predicates []string               `json:"predicates,omitempty"`
+		Contexts   []string               `json:"contexts,omitempty"`
+		Actors     []string               `json:"actors,omitempty"`
+		Timestamp  int64                  `json:"timestamp,omitempty"`
+		Source     string                 `json:"source,omitempty"`
+		Attributes map[string]interface{} `json:"attributes,omitempty"`
+		CreatedAt  int64                  `json:"created_at,omitempty"`
+		Signature  []byte                 `json:"signature,omitempty"`
+		SignerDID  string                 `json:"signer_did,omitempty"`
+	}
+
+	ffi := ffiAttestation{
+		ID:         as.ID,
+		Subjects:   as.Subjects,
+		Predicates: as.Predicates,
+		Contexts:   as.Contexts,
+		Actors:     as.Actors,
+		Timestamp:  as.Timestamp.UnixMilli(),
+		Source:     as.Source,
+		Attributes: as.Attributes,
+		CreatedAt:  as.CreatedAt.UnixMilli(),
+		Signature:  as.Signature,
+		SignerDID:  as.SignerDID,
+	}
+	jsonBytes, err := json.Marshal(ffi)
+	if err != nil {
+		t.Fatalf("marshal to FFI JSON failed: %v", err)
+	}
+
+	var ffi2 ffiAttestation
+	if err := json.Unmarshal(jsonBytes, &ffi2); err != nil {
+		t.Fatalf("unmarshal from FFI JSON failed: %v", err)
+	}
+
+	roundTripped := &types.As{
+		ID:         ffi2.ID,
+		Subjects:   ffi2.Subjects,
+		Predicates: ffi2.Predicates,
+		Contexts:   ffi2.Contexts,
+		Actors:     ffi2.Actors,
+		Timestamp:  time.UnixMilli(ffi2.Timestamp),
+		Source:     ffi2.Source,
+		Attributes: ffi2.Attributes,
+		CreatedAt:  time.UnixMilli(ffi2.CreatedAt),
+		Signature:  ffi2.Signature,
+		SignerDID:  ffi2.SignerDID,
+	}
+
+	// Verify after roundtrip
+	roundTrippedCanonical, _ := CanonicalJSON(roundTripped)
+	if string(signedCanonical) != string(roundTrippedCanonical) {
+		t.Fatalf("canonical JSON differs after DB roundtrip:\n  sign: %s\n  verify: %s", signedCanonical, roundTrippedCanonical)
+	}
+
+	if err := Verify(roundTripped); err != nil {
+		t.Fatalf("Verify failed after DB roundtrip: %v", err)
+	}
+}
+
+// TestSignVerifyProtoRoundTrip simulates the full sign → DB → proto wire → verify path
+// including the structpb.Struct conversion that happens during sync.
+func TestSignVerifyProtoRoundTrip(t *testing.T) {
+	signer := testSigner()
+	as := &types.As{
+		ID:         "AS-MODELAMA-WEAVE-TEST-EFGH5678",
+		Subjects:   []string{"model:llama-3.2-1b"},
+		Predicates: []string{"Weave"},
+		Contexts:   []string{"test-ctx"},
+		Actors:     []string{"AS-MODELAMA-WEAVE-TEST-EFGH5678"},
+		Timestamp:  time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Source:     "llama-cpp",
+		Attributes: map[string]interface{}{
+			"prompt":          "hello",
+			"text":            "world",
+			"model":           "llama-3.2-1b",
+			"token_count":     float64(5),
+			"mean_confidence": float64(0.95),
+			"mean_entropy":    float64(2.3),
+			"weave_source":    "llama-cpp",
+			"source_version":  "0.18.1",
+			"tokens": []interface{}{
+				map[string]interface{}{
+					"text":       "hello",
+					"position":   float64(0),
+					"confidence": float64(0.9),
+					"entropy":    float64(1.5),
+					"top_gap":    float64(0.3),
+					"top_k": []interface{}{
+						map[string]interface{}{"text": "hello", "prob": float64(0.9)},
+						map[string]interface{}{"text": "world", "prob": float64(0.1)},
+					},
+				},
+			},
+		},
+	}
+
+	// Sign
+	if err := signer.Sign(as); err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	signedCanonical, _ := CanonicalJSON(as)
+
+	// Simulate proto wire roundtrip: map → structpb.Struct → JSON → structpb.Struct → map
+	attrs, err := structpb.NewStruct(as.Attributes)
+	if err != nil {
+		t.Fatalf("structpb.NewStruct failed: %v", err)
+	}
+
+	// Marshal via structpb JSON (what happens during WebSocket sync)
+	attrJSON, err := attrs.MarshalJSON()
+	if err != nil {
+		t.Fatalf("structpb MarshalJSON failed: %v", err)
+	}
+
+	// Unmarshal back
+	var attrs2 structpb.Struct
+	if err := attrs2.UnmarshalJSON(attrJSON); err != nil {
+		t.Fatalf("structpb UnmarshalJSON failed: %v", err)
+	}
+
+	// Convert back to Go map (like ToTypes does)
+	roundTripped := &types.As{
+		ID:         as.ID,
+		Subjects:   as.Subjects,
+		Predicates: as.Predicates,
+		Contexts:   as.Contexts,
+		Actors:     as.Actors,
+		Timestamp:  as.Timestamp,
+		Source:     as.Source,
+		Attributes: attrs2.AsMap(),
+		Signature:  as.Signature,
+		SignerDID:  as.SignerDID,
+	}
+
+	roundTrippedCanonical, _ := CanonicalJSON(roundTripped)
+	if string(signedCanonical) != string(roundTrippedCanonical) {
+		t.Fatalf("canonical JSON differs after proto roundtrip:\n  sign: %s\n  verify: %s", signedCanonical, roundTrippedCanonical)
+	}
+
+	if err := Verify(roundTripped); err != nil {
+		t.Fatalf("Verify failed after proto roundtrip: %v", err)
 	}
 }

--- a/server/sync_handler.go
+++ b/server/sync_handler.go
@@ -379,8 +379,12 @@ func (s *QNTXServer) syncAllPeers(ctx context.Context, st *syncTickState) {
 		}
 		syncedNames = append(syncedNames, name)
 
-		if sent > 0 || received > 0 {
-			transferred = append(transferred, fmt.Sprintf("%s ↑%d↓%d", name, sent, received))
+		if sent > 0 || received > 0 || peer.SignatureRejects > 0 {
+			detail := fmt.Sprintf("%s ↑%d↓%d", name, sent, received)
+			if peer.SignatureRejects > 0 {
+				detail += fmt.Sprintf(" ✗%d sig", peer.SignatureRejects)
+			}
+			transferred = append(transferred, detail)
 		}
 	}
 

--- a/sync/peer.go
+++ b/sync/peer.go
@@ -73,8 +73,9 @@ type Peer struct {
 	RemoteName string
 
 	// Stats tracked during reconciliation
-	sent     int
-	received int
+	sent             int
+	received         int
+	SignatureRejects int // attestations rejected for invalid signature
 
 	// Populated after Reconcile if the remote peer sent budget data
 	RemoteBudget *PeerBudget
@@ -337,11 +338,14 @@ func (p *Peer) receiveAttestations(ctx context.Context) error {
 
 			// Verify signature if present — reject tampered attestations
 			if err := signing.Verify(as); err != nil {
-				p.logger.Warnw("Rejecting synced attestation with invalid signature",
-					"id", as.ID,
-					"signer_did", as.SignerDID,
-					"error", err,
-				)
+				p.SignatureRejects++
+				if p.SignatureRejects == 1 {
+					p.logger.Debugw("Signature rejection sample",
+						"id", as.ID,
+						"signer_did", as.SignerDID,
+						"error", err,
+					)
+				}
 				continue
 			}
 

--- a/sync/peer_test.go
+++ b/sync/peer_test.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -11,8 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mr-tron/base58"
 	"github.com/teranos/QNTX/ats"
+	"github.com/teranos/QNTX/ats/signing"
 	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/plugin/grpc/protocol"
 
 	"go.uber.org/zap"
 )
@@ -520,6 +525,96 @@ func TestWireRoundtrip(t *testing.T) {
 	}
 	if back.Attributes["color"] != "blue" {
 		t.Fatal("attributes not preserved")
+	}
+}
+
+func testSigner() *signing.Signer {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	buf := make([]byte, 2+len(pub))
+	buf[0] = 0xed
+	buf[1] = 0x01
+	copy(buf[2:], pub)
+	did := "did:key:z" + base58.Encode(buf)
+	return signing.NewSigner(priv, did)
+}
+
+// TestSignedWireJSONRoundTrip tests the full path: sign → toWire → JSON marshal/unmarshal → fromWire → verify.
+// This is exactly the path sync takes. Protobuf v1.35+ uses protojson for MarshalJSON which
+// changes field names to camelCase and serializes int64 as strings.
+func TestSignedWireJSONRoundTrip(t *testing.T) {
+	// Create and sign attestation with weave-like attributes (same as llama-cpp plugin)
+	as := &types.As{
+		ID:         "AS-MODELAMA-WEAVE-TEST-ROUNDTRIP",
+		Subjects:   []string{"model:llama-3.2-1b"},
+		Predicates: []string{"Weave"},
+		Contexts:   []string{"test-ctx"},
+		Actors:     []string{"AS-MODELAMA-WEAVE-TEST-ROUNDTRIP"},
+		Timestamp:  time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+		Source:     "llama-cpp",
+		Attributes: map[string]interface{}{
+			"prompt":          "hello world",
+			"text":            "response text",
+			"model":           "llama-3.2-1b",
+			"token_count":     float64(5),
+			"mean_confidence": float64(0.95),
+			"mean_entropy":    float64(2.3),
+			"weave_source":    "llama-cpp",
+			"source_version":  "0.18.1",
+			"tokens": []interface{}{
+				map[string]interface{}{
+					"text":       "hello",
+					"position":   float64(0),
+					"confidence": float64(0.9),
+					"entropy":    float64(1.5),
+					"top_gap":    float64(0.3),
+					"top_k": []interface{}{
+						map[string]interface{}{"text": "hello", "prob": float64(0.9)},
+						map[string]interface{}{"text": "world", "prob": float64(0.1)},
+					},
+				},
+			},
+		},
+	}
+
+	signer := testSigner()
+	if err := signer.Sign(as); err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	signedCanonical, _ := signing.CanonicalJSON(as)
+	t.Logf("signed canonical: %s", signedCanonical)
+
+	// Convert to proto wire format (same as sendAttestations)
+	protoAtt, err := toWire(as)
+	if err != nil {
+		t.Fatalf("toWire failed: %v", err)
+	}
+
+	// JSON roundtrip through chanConn (same as WebSocket sync)
+	jsonBytes, err := json.Marshal(protoAtt)
+	if err != nil {
+		t.Fatalf("json.Marshal of proto attestation failed: %v", err)
+	}
+	t.Logf("wire JSON (first 500 chars): %.500s", string(jsonBytes))
+
+	var protoAtt2 protocol.Attestation
+	if err := json.Unmarshal(jsonBytes, &protoAtt2); err != nil {
+		t.Fatalf("json.Unmarshal of proto attestation failed: %v", err)
+	}
+
+	// Convert back to types.As (same as receiveAttestations)
+	back := fromWire(&protoAtt2)
+
+	backCanonical, _ := signing.CanonicalJSON(back)
+	t.Logf("roundtripped canonical: %s", backCanonical)
+
+	if string(signedCanonical) != string(backCanonical) {
+		t.Fatalf("canonical JSON differs after wire roundtrip:\n  signed:      %s\n  roundtripped: %s", signedCanonical, backCanonical)
+	}
+
+	// Verify signature after full wire roundtrip
+	if err := signing.Verify(back); err != nil {
+		t.Fatalf("Verify failed after wire roundtrip: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Signature rejection warnings during sync flooded the console — one WARN per attestation, every tick, for every peer with divergent signatures
- Now counted per reconciliation and surfaced in the existing sync tick summary: `peer8771 ↑0↓0 ✗3 sig`
- First rejection per session logged at DEBUG with full details for diagnosis
- Root cause: peers running different code versions produce different canonical JSON, so signatures from one node fail verification on another

## Roundtrip tests

Added tests proving signatures survive:
- JSON marshal/unmarshal roundtrip (simulating Rust FFI store)
- Full proto wire roundtrip (simulating sync WebSocket: `toWire` → `json.Marshal` → `json.Unmarshal` → `fromWire` → `Verify`)
- structpb.Struct conversion roundtrip

All pass — the rejection is a cross-node version issue, not a serialization bug.

## Test plan

- [x] `go test ./sync/ ./ats/signing/` — all pass
- [x] `make test` — only pre-existing `TestTemporalAggregation_WithSinceFilter` failure (unrelated)
- [ ] Run with peers on different versions, confirm summary line appears instead of per-attestation flood