### PR TITLE
Plugin watcher registration via InitializeResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ qntx-plugins/scry/vendor/
 qntx-plugins/scry/compile_commands.json
 qntx-plugins/qntx-scry-plugin
 plugin/grpc/ocaml/_build/
+ctp/Voor/_build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Development Workflow
 
-The developer always uses `make dev` to start the development environment with hot-reloading for both backend and frontend. `make dev` builds the Go backend and runs the hot-reloading TypeScript frontend dev server. Ports are configured in `am.toml`.
+The developer always uses `make dev` to start the development environment. `make dev` builds and runs the Go backend and starts the hot-reloading TypeScript frontend dev server. Restart `make dev` to pick up backend changes. Ports are configured in `am.toml`.
 
 **KNOW** the developer is always running the latest version of QNTX. It is **FORBIDDEN** to discuss or question whether the developer has run the latest version. If there is an issue, it is in the code, not with running the latest binary (`make dev` solves this) or configuration (QNTX works without configuration).
 

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ desktop-build: desktop-prepare ## Build production desktop app (requires: cargo 
 		cp web/src-tauri/bin/qntx-$$TARGET target/release/bundle/macos/QNTX.app/Contents/MacOS/
 	@echo "✓ Desktop app built in target/release/bundle/"
 
-proto: ## Generate Go code from protobuf definitions (via Nix)
+proto: ## Generate all proto bindings (Go, TypeScript, OCaml)
 	@nix run .#generate-proto
 
 proto-rust: ## Rust proto types are now generated automatically at build time

--- a/ats/watcher/engine.go
+++ b/ats/watcher/engine.go
@@ -672,6 +672,8 @@ func (e *Engine) drainOnce() {
 			execErr = e.executeWebhook(watcher, &as)
 		case storage.ActionTypeGlyphExecute:
 			execErr = e.executeGlyph(watcher, &as)
+		case storage.ActionTypePluginExecute:
+			execErr = e.executePlugin(watcher, &as)
 		case storage.ActionTypeSemanticMatch:
 			e.queueStore.Complete(entry.ID)
 			continue

--- a/cmd/qntx/main.go
+++ b/cmd/qntx/main.go
@@ -204,6 +204,11 @@ func loadPluginsAsync(cfg *am.Config, pluginLogger *zap.SugaredLogger, registry 
 			pluginLogger.Infow("Successfully initialized all plugins")
 		}
 
+		// Reload watcher engine — plugins may have registered watchers during Initialize
+		if err := defaultServer.ReloadWatchers(); err != nil {
+			pluginLogger.Errorw("Failed to reload watchers after plugin init", "error", err)
+		}
+
 		// Phase 4: Register plugin async handlers with Pulse
 		// Now that plugins are initialized, they've announced their handlers in InitializeResponse
 		// Register these handlers with Pulse's worker pool registry
@@ -258,12 +263,12 @@ func loadPluginsAsync(cfg *am.Config, pluginLogger *zap.SugaredLogger, registry 
 		} else {
 			pluginLogger.Warnw("Cannot register handlers - Pulse daemon not available, will retry")
 			// Retry schedule setup after Pulse starts
-			go retryScheduleSetup(loadedPlugins, pluginLogger)
+			go retryPluginSetup(loadedPlugins, registry, pluginLogger)
 		}
 	} else {
 		pluginLogger.Warnw("Cannot initialize plugins - server or services not available yet, will retry")
 		// Retry when server becomes available
-		go retryScheduleSetup(loadedPlugins, pluginLogger)
+		go retryPluginSetup(loadedPlugins, registry, pluginLogger)
 	}
 
 	// Start health polling — detect plugin crashes and restart automatically
@@ -275,8 +280,8 @@ func loadPluginsAsync(cfg *am.Config, pluginLogger *zap.SugaredLogger, registry 
 }
 
 // retryScheduleSetup waits for Pulse daemon to be ready, then sets up plugin schedules
-func retryScheduleSetup(plugins []plugin.DomainPlugin, logger *zap.SugaredLogger) {
-	// Wait for server and Pulse daemon to be ready
+func retryPluginSetup(plugins []plugin.DomainPlugin, pluginRegistry *plugin.Registry, logger *zap.SugaredLogger) {
+	// Wait for server, services, and Pulse daemon to all be ready
 	for i := 0; i < 30; i++ {
 		time.Sleep(1 * time.Second)
 
@@ -285,13 +290,23 @@ func retryScheduleSetup(plugins []plugin.DomainPlugin, logger *zap.SugaredLogger
 			continue
 		}
 
+		services := defaultServer.GetServices()
+		if services == nil {
+			continue
+		}
+
 		daemon := defaultServer.GetDaemon()
 		if daemon == nil {
 			continue
 		}
 
-		// Daemon is ready, register handlers and set up schedules
-		logger.Infow("Pulse daemon ready, registering handlers and setting up schedules")
+		// Everything ready — Initialize plugins first
+		logger.Infow("Server ready, initializing plugins")
+		if err := pluginRegistry.InitializeAll(context.Background(), services); err != nil {
+			logger.Errorw("Failed to initialize plugins", "error", err)
+		}
+
+		// Now register handlers and schedules (Initialize has populated them)
 		handlerRegistry := daemon.Registry()
 		db := defaultServer.GetDB()
 
@@ -301,7 +316,6 @@ func retryScheduleSetup(plugins []plugin.DomainPlugin, logger *zap.SugaredLogger
 				continue
 			}
 
-			// Register handlers first
 			handlerNames := externalPlugin.GetHandlerNames()
 			for _, handlerName := range handlerNames {
 				logger.Infow("Registering plugin async handler",
@@ -312,29 +326,40 @@ func retryScheduleSetup(plugins []plugin.DomainPlugin, logger *zap.SugaredLogger
 				handlerRegistry.Register(proxyHandler)
 			}
 
-			// Then set up schedules
 			schedules := externalPlugin.GetSchedules()
 			if len(schedules) > 0 {
-				logger.Infow("Setting up schedules for plugin",
-					"plugin", p.Metadata().Name,
-					"count", len(schedules),
-				)
 				if err := grpc.SetupPluginSchedules(db, p.Metadata().Name, schedules, logger); err != nil {
 					logger.Errorw("Failed to setup plugin schedules",
 						"plugin", p.Metadata().Name,
 						"error", err,
 					)
-				} else {
-					logger.Infow("Successfully set up schedules",
-						"plugin", p.Metadata().Name,
-					)
 				}
 			}
 		}
+
+		// Register LLM providers
+		if sm := defaultServer.GetServicesManager(); sm != nil {
+			if llmRouter := sm.GetLLMRouter(); llmRouter != nil {
+				for _, p := range plugins {
+					proxy, ok := p.(*grpc.ExternalDomainProxy)
+					if !ok || !proxy.IsLLMProvider() {
+						continue
+					}
+					llmRouter.RegisterProvider(p.Metadata().Name, proxy.LLMServiceClient())
+				}
+			}
+		}
+
+		// Reload watcher engine — plugins registered watchers during Initialize
+		if err := defaultServer.ReloadWatchers(); err != nil {
+			logger.Errorw("Failed to reload watchers after plugin init", "error", err)
+		}
+
+		logger.Infow("Plugin setup complete")
 		return
 	}
 
-	logger.Errorw("Gave up waiting for Pulse daemon after 30 seconds")
+	logger.Errorw("Gave up waiting for server after 30 seconds")
 }
 
 // findTauriBinary looks for the QNTX Tauri desktop binary.

--- a/docs/adr/ADR-004-plugin-pulse-integration.md
+++ b/docs/adr/ADR-004-plugin-pulse-integration.md
@@ -79,6 +79,13 @@ Extended `domain.proto`:
 - Added `GetDaemon()` for registry access
 - Handlers properly registered with Pulse
 
+### Phase 5: Reactive Watchers (PR #770) ✅
+- Plugins declare `WatcherRegistration` in `InitializeResponse`
+- Core creates watchers during `doInitialize`, idempotent via `CreateOrReplace`
+- Matching attestations routed to plugin via existing `ExecuteJob` RPC
+- Phases 1-4: "do this job" — Phase 5: "tell me when this happens"
+- UI visibility tracked in #771
+
 ## Consequences
 
 ### Positive

--- a/flake.nix
+++ b/flake.nix
@@ -472,6 +472,7 @@
             generate-proto = protoApps.generate-proto;
             generate-proto-go = protoApps.generate-proto-go;
             generate-proto-typescript = protoApps.generate-proto-typescript;
+            generate-proto-ocaml = protoApps.generate-proto-ocaml;
           };
       }
     ));

--- a/plugin/grpc/client.go
+++ b/plugin/grpc/client.go
@@ -40,6 +40,9 @@ type ExternalDomainProxy struct {
 	// llmProvider indicates this plugin implements LLMProvider (populated during Initialize)
 	llmProvider bool
 
+	// Watchers this plugin wants registered (populated during Initialize)
+	watchers []*protocol.WatcherRegistration
+
 	// WebSocket configuration (set via SetWebSocketConfig)
 	keepaliveConfig *KeepaliveConfig
 	wsConfig        *WebSocketConfig
@@ -146,6 +149,11 @@ func (c *ExternalDomainProxy) Client() protocol.DomainPluginServiceClient {
 // IsLLMProvider returns true if this plugin declared LLM provider capability during Initialize.
 func (c *ExternalDomainProxy) IsLLMProvider() bool {
 	return c.llmProvider
+}
+
+// GetWatchers returns the watcher registrations this plugin announced during Initialize.
+func (c *ExternalDomainProxy) GetWatchers() []*protocol.WatcherRegistration {
+	return c.watchers
 }
 
 // LLMServiceClient returns an LLMServiceClient using this plugin's existing gRPC connection.
@@ -288,10 +296,22 @@ func (c *ExternalDomainProxy) doInitialize(ctx context.Context, services plugin.
 	// Store LLM provider capability
 	c.llmProvider = resp.GetLlmProvider()
 
+	// Store and create watcher registrations
+	c.watchers = resp.GetWatchers()
+	if len(c.watchers) > 0 {
+		if err := SetupPluginWatchers(services.Database(), c.metadata.Name, c.watchers, c.logger); err != nil {
+			c.logger.Errorw("Failed to setup plugin watchers",
+				"plugin", c.metadata.Name,
+				"error", err,
+			)
+		}
+	}
+
 	c.logger.Infow("Plugin initialized",
 		"name", c.metadata.Name,
 		"handlers", len(c.handlerNames),
 		"schedules", len(c.schedules),
+		"watchers", len(c.watchers),
 		"llm_provider", c.llmProvider,
 	)
 	return nil

--- a/plugin/grpc/ocaml/proto/atsstore.ml
+++ b/plugin/grpc/ocaml/proto/atsstore.ml
@@ -5,7 +5,7 @@
 (* https://github.com/andersfugmann/ocaml-protoc-plugin *)
 (********************************************************)
 (*
-  Source: atsstore.proto
+  Source: plugin/grpc/protocol/atsstore.proto
   Syntax: proto3
   Parameters:
     debug=false

--- a/plugin/grpc/ocaml/proto/domain.ml
+++ b/plugin/grpc/ocaml/proto/domain.ml
@@ -5,7 +5,7 @@
 (* https://github.com/andersfugmann/ocaml-protoc-plugin *)
 (********************************************************)
 (*
-  Source: domain.proto
+  Source: plugin/grpc/protocol/domain.proto
   Syntax: proto3
   Parameters:
     debug=false
@@ -150,8 +150,24 @@ Provides: Read stored files (for multimodal attachments)</p>
 %}
       *)
 
+      llm_endpoint:string;
+      (**
+{%html:
+<p>llm_endpoint: gRPC endpoint for LLMService
+Provides: Provider-agnostic LLM chat (routed through core to provider plugins)</p>
+%}
+      *)
+
+      embedding_endpoint:string;
+      (**
+{%html:
+<p>embedding_endpoint: gRPC endpoint for EmbeddingService
+Provides: Text-to-vector embedding generation</p>
+%}
+      *)
+
     }
-    val make: ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> unit -> t
+    val make: ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> ?llm_endpoint:string -> ?embedding_endpoint:string -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -170,7 +186,7 @@ Provides: Read stored files (for multimodal attachments)</p>
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> unit -> t
+    type make_t = ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> ?llm_endpoint:string -> ?embedding_endpoint:string -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -619,8 +635,25 @@ QNTX will auto-create schedule.Job entries for these</p>
 %}
       *)
 
+      llm_provider:bool;
+      (**
+{%html:
+<p>llm_provider indicates this plugin implements LLMProvider (Chat RPC).
+Core registers it as an LLM backend in the service mesh.</p>
+%}
+      *)
+
+      watchers:WatcherRegistration.t list;
+      (**
+{%html:
+<p>Watchers this plugin wants registered on its behalf.
+Core creates watchers with action_type=plugin_execute targeting this plugin.
+On match, core calls ExecuteJob with the matching attestation as payload.</p>
+%}
+      *)
+
     }
-    val make: ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> unit -> t
+    val make: ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> ?llm_provider:bool -> ?watchers:WatcherRegistration.t list -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -639,7 +672,94 @@ QNTX will auto-create schedule.Job entries for these</p>
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> unit -> t
+    type make_t = ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> ?llm_provider:bool -> ?watchers:WatcherRegistration.t list -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end
+
+
+  (**
+{%html:
+<p>WatcherRegistration declares a watcher a plugin wants core to manage.
+Core creates/updates the watcher on Initialize and routes matches
+to the plugin via ExecuteJob.</p>
+%}
+  *)
+  and WatcherRegistration : sig
+    type t = {
+      id:string;
+      (**
+{%html:
+<p>Watcher ID (scoped to plugin: &quot;{plugin}-{id}&quot;)</p>
+%}
+      *)
+
+      handler_name:string;
+      (**
+{%html:
+<p>ExecuteJob handler to invoke on match</p>
+%}
+      *)
+
+      subjects:string list;
+      (**
+{%html:
+<p>Structural filter: subjects</p>
+%}
+      *)
+
+      predicates:string list;
+      (**
+{%html:
+<p>Structural filter: predicates</p>
+%}
+      *)
+
+      contexts:string list;
+      (**
+{%html:
+<p>Structural filter: contexts</p>
+%}
+      *)
+
+      actors:string list;
+      (**
+{%html:
+<p>Structural filter: actors</p>
+%}
+      *)
+
+      max_fires_per_second:int;
+      (**
+{%html:
+<p>Rate limit (0 = no action, structural only)</p>
+%}
+      *)
+
+    }
+    val make: ?id:string -> ?handler_name:string -> ?subjects:string list -> ?predicates:string list -> ?contexts:string list -> ?actors:string list -> ?max_fires_per_second:int -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?id:string -> ?handler_name:string -> ?subjects:string list -> ?predicates:string list -> ?contexts:string list -> ?actors:string list -> ?max_fires_per_second:int -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -1367,8 +1487,24 @@ Provides: Read stored files (for multimodal attachments)</p>
 %}
       *)
 
+      llm_endpoint:string;
+      (**
+{%html:
+<p>llm_endpoint: gRPC endpoint for LLMService
+Provides: Provider-agnostic LLM chat (routed through core to provider plugins)</p>
+%}
+      *)
+
+      embedding_endpoint:string;
+      (**
+{%html:
+<p>embedding_endpoint: gRPC endpoint for EmbeddingService
+Provides: Text-to-vector embedding generation</p>
+%}
+      *)
+
     }
-    val make: ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> unit -> t
+    val make: ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> ?llm_endpoint:string -> ?embedding_endpoint:string -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -1387,7 +1523,7 @@ Provides: Read stored files (for multimodal attachments)</p>
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> unit -> t
+    type make_t = ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> ?llm_endpoint:string -> ?embedding_endpoint:string -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -1403,9 +1539,11 @@ Provides: Read stored files (for multimodal attachments)</p>
       config:(string * string) list;
       schedule_endpoint:string;
       file_service_endpoint:string;
+      llm_endpoint:string;
+      embedding_endpoint:string;
     }
-    type make_t = ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> unit -> t
-    let make ?(ats_store_endpoint = {||}) ?(queue_endpoint = {||}) ?(auth_token = {||}) ?(config = []) ?(schedule_endpoint = {||}) ?(file_service_endpoint = {||}) () = { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint }
+    type make_t = ?ats_store_endpoint:string -> ?queue_endpoint:string -> ?auth_token:string -> ?config:(string * string) list -> ?schedule_endpoint:string -> ?file_service_endpoint:string -> ?llm_endpoint:string -> ?embedding_endpoint:string -> unit -> t
+    let make ?(ats_store_endpoint = {||}) ?(queue_endpoint = {||}) ?(auth_token = {||}) ?(config = []) ?(schedule_endpoint = {||}) ?(file_service_endpoint = {||}) ?(llm_endpoint = {||}) ?(embedding_endpoint = {||}) () = { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint; llm_endpoint; embedding_endpoint }
     let merge =
     let merge_ats_store_endpoint = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "ats_store_endpoint", "atsStoreEndpoint"), string, ({||})) ) in
     let merge_queue_endpoint = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "queue_endpoint", "queueEndpoint"), string, ({||})) ) in
@@ -1413,6 +1551,8 @@ Provides: Read stored files (for multimodal attachments)</p>
     let merge_config = Runtime'.Merge.merge Runtime'.Spec.( map ((4, "config", "config"), (string, basic ((2, "value", "value"), string, ({||})))) ) in
     let merge_schedule_endpoint = Runtime'.Merge.merge Runtime'.Spec.( basic ((5, "schedule_endpoint", "scheduleEndpoint"), string, ({||})) ) in
     let merge_file_service_endpoint = Runtime'.Merge.merge Runtime'.Spec.( basic ((6, "file_service_endpoint", "fileServiceEndpoint"), string, ({||})) ) in
+    let merge_llm_endpoint = Runtime'.Merge.merge Runtime'.Spec.( basic ((7, "llm_endpoint", "llmEndpoint"), string, ({||})) ) in
+    let merge_embedding_endpoint = Runtime'.Merge.merge Runtime'.Spec.( basic ((8, "embedding_endpoint", "embeddingEndpoint"), string, ({||})) ) in
     fun t1 t2 -> {
     	ats_store_endpoint = (merge_ats_store_endpoint t1.ats_store_endpoint t2.ats_store_endpoint);
     	queue_endpoint = (merge_queue_endpoint t1.queue_endpoint t2.queue_endpoint);
@@ -1420,22 +1560,24 @@ Provides: Read stored files (for multimodal attachments)</p>
     	config = (merge_config t1.config t2.config);
     	schedule_endpoint = (merge_schedule_endpoint t1.schedule_endpoint t2.schedule_endpoint);
     	file_service_endpoint = (merge_file_service_endpoint t1.file_service_endpoint t2.file_service_endpoint);
+    	llm_endpoint = (merge_llm_endpoint t1.llm_endpoint t2.llm_endpoint);
+    	embedding_endpoint = (merge_embedding_endpoint t1.embedding_endpoint t2.embedding_endpoint);
      }
-    let spec () = Runtime'.Spec.( basic ((1, "ats_store_endpoint", "atsStoreEndpoint"), string, ({||})) ^:: basic ((2, "queue_endpoint", "queueEndpoint"), string, ({||})) ^:: basic ((3, "auth_token", "authToken"), string, ({||})) ^:: map ((4, "config", "config"), (string, basic ((2, "value", "value"), string, ({||})))) ^:: basic ((5, "schedule_endpoint", "scheduleEndpoint"), string, ({||})) ^:: basic ((6, "file_service_endpoint", "fileServiceEndpoint"), string, ({||})) ^:: nil )
+    let spec () = Runtime'.Spec.( basic ((1, "ats_store_endpoint", "atsStoreEndpoint"), string, ({||})) ^:: basic ((2, "queue_endpoint", "queueEndpoint"), string, ({||})) ^:: basic ((3, "auth_token", "authToken"), string, ({||})) ^:: map ((4, "config", "config"), (string, basic ((2, "value", "value"), string, ({||})))) ^:: basic ((5, "schedule_endpoint", "scheduleEndpoint"), string, ({||})) ^:: basic ((6, "file_service_endpoint", "fileServiceEndpoint"), string, ({||})) ^:: basic ((7, "llm_endpoint", "llmEndpoint"), string, ({||})) ^:: basic ((8, "embedding_endpoint", "embeddingEndpoint"), string, ({||})) ^:: nil )
     let to_proto' =
       let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
-      fun writer { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint } -> serialize writer ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint
+      fun writer { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint; llm_endpoint; embedding_endpoint } -> serialize writer ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint llm_endpoint embedding_endpoint
 
     let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
     let from_proto_exn =
-      let constructor ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint = { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint } in
+      let constructor ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint llm_endpoint embedding_endpoint = { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint; llm_endpoint; embedding_endpoint } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
     let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     let to_json options =
       let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
-      fun { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint } -> serialize ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint
+      fun { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint; llm_endpoint; embedding_endpoint } -> serialize ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint llm_endpoint embedding_endpoint
     let from_json_exn =
-      let constructor ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint = { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint } in
+      let constructor ats_store_endpoint queue_endpoint auth_token config schedule_endpoint file_service_endpoint llm_endpoint embedding_endpoint = { ats_store_endpoint; queue_endpoint; auth_token; config; schedule_endpoint; file_service_endpoint; llm_endpoint; embedding_endpoint } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end
@@ -2264,8 +2406,25 @@ QNTX will auto-create schedule.Job entries for these</p>
 %}
       *)
 
+      llm_provider:bool;
+      (**
+{%html:
+<p>llm_provider indicates this plugin implements LLMProvider (Chat RPC).
+Core registers it as an LLM backend in the service mesh.</p>
+%}
+      *)
+
+      watchers:WatcherRegistration.t list;
+      (**
+{%html:
+<p>Watchers this plugin wants registered on its behalf.
+Core creates watchers with action_type=plugin_execute targeting this plugin.
+On match, core calls ExecuteJob with the matching attestation as payload.</p>
+%}
+      *)
+
     }
-    val make: ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> unit -> t
+    val make: ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> ?llm_provider:bool -> ?watchers:WatcherRegistration.t list -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -2284,7 +2443,7 @@ QNTX will auto-create schedule.Job entries for these</p>
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> unit -> t
+    type make_t = ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> ?llm_provider:bool -> ?watchers:WatcherRegistration.t list -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -2296,31 +2455,164 @@ QNTX will auto-create schedule.Job entries for these</p>
     type t = {
       handler_names:string list;
       schedules:ScheduleInfo.t list;
+      llm_provider:bool;
+      watchers:WatcherRegistration.t list;
     }
-    type make_t = ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> unit -> t
-    let make ?(handler_names = []) ?(schedules = []) () = { handler_names; schedules }
+    type make_t = ?handler_names:string list -> ?schedules:ScheduleInfo.t list -> ?llm_provider:bool -> ?watchers:WatcherRegistration.t list -> unit -> t
+    let make ?(handler_names = []) ?(schedules = []) ?(llm_provider = false) ?(watchers = []) () = { handler_names; schedules; llm_provider; watchers }
     let merge =
     let merge_handler_names = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "handler_names", "handlerNames"), string, not_packed) ) in
     let merge_schedules = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "schedules", "schedules"), (message (module ScheduleInfo)), not_packed) ) in
+    let merge_llm_provider = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "llm_provider", "llmProvider"), bool, (false)) ) in
+    let merge_watchers = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "watchers", "watchers"), (message (module WatcherRegistration)), not_packed) ) in
     fun t1 t2 -> {
     	handler_names = (merge_handler_names t1.handler_names t2.handler_names);
     	schedules = (merge_schedules t1.schedules t2.schedules);
+    	llm_provider = (merge_llm_provider t1.llm_provider t2.llm_provider);
+    	watchers = (merge_watchers t1.watchers t2.watchers);
      }
-    let spec () = Runtime'.Spec.( repeated ((1, "handler_names", "handlerNames"), string, not_packed) ^:: repeated ((2, "schedules", "schedules"), (message (module ScheduleInfo)), not_packed) ^:: nil )
+    let spec () = Runtime'.Spec.( repeated ((1, "handler_names", "handlerNames"), string, not_packed) ^:: repeated ((2, "schedules", "schedules"), (message (module ScheduleInfo)), not_packed) ^:: basic ((3, "llm_provider", "llmProvider"), bool, (false)) ^:: repeated ((4, "watchers", "watchers"), (message (module WatcherRegistration)), not_packed) ^:: nil )
     let to_proto' =
       let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
-      fun writer { handler_names; schedules } -> serialize writer handler_names schedules
+      fun writer { handler_names; schedules; llm_provider; watchers } -> serialize writer handler_names schedules llm_provider watchers
 
     let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
     let from_proto_exn =
-      let constructor handler_names schedules = { handler_names; schedules } in
+      let constructor handler_names schedules llm_provider watchers = { handler_names; schedules; llm_provider; watchers } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
     let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     let to_json options =
       let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
-      fun { handler_names; schedules } -> serialize handler_names schedules
+      fun { handler_names; schedules; llm_provider; watchers } -> serialize handler_names schedules llm_provider watchers
     let from_json_exn =
-      let constructor handler_names schedules = { handler_names; schedules } in
+      let constructor handler_names schedules llm_provider watchers = { handler_names; schedules; llm_provider; watchers } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
+    let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
+  end
+
+  and WatcherRegistration : sig
+    type t = {
+      id:string;
+      (**
+{%html:
+<p>Watcher ID (scoped to plugin: &quot;{plugin}-{id}&quot;)</p>
+%}
+      *)
+
+      handler_name:string;
+      (**
+{%html:
+<p>ExecuteJob handler to invoke on match</p>
+%}
+      *)
+
+      subjects:string list;
+      (**
+{%html:
+<p>Structural filter: subjects</p>
+%}
+      *)
+
+      predicates:string list;
+      (**
+{%html:
+<p>Structural filter: predicates</p>
+%}
+      *)
+
+      contexts:string list;
+      (**
+{%html:
+<p>Structural filter: contexts</p>
+%}
+      *)
+
+      actors:string list;
+      (**
+{%html:
+<p>Structural filter: actors</p>
+%}
+      *)
+
+      max_fires_per_second:int;
+      (**
+{%html:
+<p>Rate limit (0 = no action, structural only)</p>
+%}
+      *)
+
+    }
+    val make: ?id:string -> ?handler_name:string -> ?subjects:string list -> ?predicates:string list -> ?contexts:string list -> ?actors:string list -> ?max_fires_per_second:int -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?id:string -> ?handler_name:string -> ?subjects:string list -> ?predicates:string list -> ?contexts:string list -> ?actors:string list -> ?max_fires_per_second:int -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end = struct
+    module This'_ = WatcherRegistration
+    let name () = ".protocol.WatcherRegistration"
+    type t = {
+      id:string;
+      handler_name:string;
+      subjects:string list;
+      predicates:string list;
+      contexts:string list;
+      actors:string list;
+      max_fires_per_second:int;
+    }
+    type make_t = ?id:string -> ?handler_name:string -> ?subjects:string list -> ?predicates:string list -> ?contexts:string list -> ?actors:string list -> ?max_fires_per_second:int -> unit -> t
+    let make ?(id = {||}) ?(handler_name = {||}) ?(subjects = []) ?(predicates = []) ?(contexts = []) ?(actors = []) ?(max_fires_per_second = 0) () = { id; handler_name; subjects; predicates; contexts; actors; max_fires_per_second }
+    let merge =
+    let merge_id = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "id", "id"), string, ({||})) ) in
+    let merge_handler_name = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "handler_name", "handlerName"), string, ({||})) ) in
+    let merge_subjects = Runtime'.Merge.merge Runtime'.Spec.( repeated ((3, "subjects", "subjects"), string, not_packed) ) in
+    let merge_predicates = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "predicates", "predicates"), string, not_packed) ) in
+    let merge_contexts = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "contexts", "contexts"), string, not_packed) ) in
+    let merge_actors = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "actors", "actors"), string, not_packed) ) in
+    let merge_max_fires_per_second = Runtime'.Merge.merge Runtime'.Spec.( basic ((7, "max_fires_per_second", "maxFiresPerSecond"), int32_int, (0)) ) in
+    fun t1 t2 -> {
+    	id = (merge_id t1.id t2.id);
+    	handler_name = (merge_handler_name t1.handler_name t2.handler_name);
+    	subjects = (merge_subjects t1.subjects t2.subjects);
+    	predicates = (merge_predicates t1.predicates t2.predicates);
+    	contexts = (merge_contexts t1.contexts t2.contexts);
+    	actors = (merge_actors t1.actors t2.actors);
+    	max_fires_per_second = (merge_max_fires_per_second t1.max_fires_per_second t2.max_fires_per_second);
+     }
+    let spec () = Runtime'.Spec.( basic ((1, "id", "id"), string, ({||})) ^:: basic ((2, "handler_name", "handlerName"), string, ({||})) ^:: repeated ((3, "subjects", "subjects"), string, not_packed) ^:: repeated ((4, "predicates", "predicates"), string, not_packed) ^:: repeated ((5, "contexts", "contexts"), string, not_packed) ^:: repeated ((6, "actors", "actors"), string, not_packed) ^:: basic ((7, "max_fires_per_second", "maxFiresPerSecond"), int32_int, (0)) ^:: nil )
+    let to_proto' =
+      let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
+      fun writer { id; handler_name; subjects; predicates; contexts; actors; max_fires_per_second } -> serialize writer id handler_name subjects predicates contexts actors max_fires_per_second
+
+    let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
+    let from_proto_exn =
+      let constructor id handler_name subjects predicates contexts actors max_fires_per_second = { id; handler_name; subjects; predicates; contexts; actors; max_fires_per_second } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
+    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
+    let to_json options =
+      let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
+      fun { id; handler_name; subjects; predicates; contexts; actors; max_fires_per_second } -> serialize id handler_name subjects predicates contexts actors max_fires_per_second
+    let from_json_exn =
+      let constructor id handler_name subjects predicates contexts actors max_fires_per_second = { id; handler_name; subjects; predicates; contexts; actors; max_fires_per_second } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end

--- a/plugin/grpc/protocol/domain.pb.go
+++ b/plugin/grpc/protocol/domain.pb.go
@@ -869,7 +869,11 @@ type InitializeResponse struct {
 	Schedules []*ScheduleInfo `protobuf:"bytes,2,rep,name=schedules,proto3" json:"schedules,omitempty"`
 	// llm_provider indicates this plugin implements LLMProvider (Chat RPC).
 	// Core registers it as an LLM backend in the service mesh.
-	LlmProvider   bool `protobuf:"varint,3,opt,name=llm_provider,json=llmProvider,proto3" json:"llm_provider,omitempty"`
+	LlmProvider bool `protobuf:"varint,3,opt,name=llm_provider,json=llmProvider,proto3" json:"llm_provider,omitempty"`
+	// Watchers this plugin wants registered on its behalf.
+	// Core creates watchers with action_type=plugin_execute targeting this plugin.
+	// On match, core calls ExecuteJob with the matching attestation as payload.
+	Watchers      []*WatcherRegistration `protobuf:"bytes,4,rep,name=watchers,proto3" json:"watchers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -925,6 +929,108 @@ func (x *InitializeResponse) GetLlmProvider() bool {
 	return false
 }
 
+func (x *InitializeResponse) GetWatchers() []*WatcherRegistration {
+	if x != nil {
+		return x.Watchers
+	}
+	return nil
+}
+
+// WatcherRegistration declares a watcher a plugin wants core to manage.
+// Core creates/updates the watcher on Initialize and routes matches
+// to the plugin via ExecuteJob.
+type WatcherRegistration struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Id                string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                             // Watcher ID (scoped to plugin: "{plugin}-{id}")
+	HandlerName       string                 `protobuf:"bytes,2,opt,name=handler_name,json=handlerName,proto3" json:"handler_name,omitempty"`                        // ExecuteJob handler to invoke on match
+	Subjects          []string               `protobuf:"bytes,3,rep,name=subjects,proto3" json:"subjects,omitempty"`                                                 // Structural filter: subjects
+	Predicates        []string               `protobuf:"bytes,4,rep,name=predicates,proto3" json:"predicates,omitempty"`                                             // Structural filter: predicates
+	Contexts          []string               `protobuf:"bytes,5,rep,name=contexts,proto3" json:"contexts,omitempty"`                                                 // Structural filter: contexts
+	Actors            []string               `protobuf:"bytes,6,rep,name=actors,proto3" json:"actors,omitempty"`                                                     // Structural filter: actors
+	MaxFiresPerSecond int32                  `protobuf:"varint,7,opt,name=max_fires_per_second,json=maxFiresPerSecond,proto3" json:"max_fires_per_second,omitempty"` // Rate limit (0 = no action, structural only)
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *WatcherRegistration) Reset() {
+	*x = WatcherRegistration{}
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WatcherRegistration) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WatcherRegistration) ProtoMessage() {}
+
+func (x *WatcherRegistration) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WatcherRegistration.ProtoReflect.Descriptor instead.
+func (*WatcherRegistration) Descriptor() ([]byte, []int) {
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *WatcherRegistration) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *WatcherRegistration) GetHandlerName() string {
+	if x != nil {
+		return x.HandlerName
+	}
+	return ""
+}
+
+func (x *WatcherRegistration) GetSubjects() []string {
+	if x != nil {
+		return x.Subjects
+	}
+	return nil
+}
+
+func (x *WatcherRegistration) GetPredicates() []string {
+	if x != nil {
+		return x.Predicates
+	}
+	return nil
+}
+
+func (x *WatcherRegistration) GetContexts() []string {
+	if x != nil {
+		return x.Contexts
+	}
+	return nil
+}
+
+func (x *WatcherRegistration) GetActors() []string {
+	if x != nil {
+		return x.Actors
+	}
+	return nil
+}
+
+func (x *WatcherRegistration) GetMaxFiresPerSecond() int32 {
+	if x != nil {
+		return x.MaxFiresPerSecond
+	}
+	return 0
+}
+
 // ExecuteJobRequest is sent to plugins to execute an async job
 type ExecuteJobRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -938,7 +1044,7 @@ type ExecuteJobRequest struct {
 
 func (x *ExecuteJobRequest) Reset() {
 	*x = ExecuteJobRequest{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[12]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -950,7 +1056,7 @@ func (x *ExecuteJobRequest) String() string {
 func (*ExecuteJobRequest) ProtoMessage() {}
 
 func (x *ExecuteJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[12]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -963,7 +1069,7 @@ func (x *ExecuteJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteJobRequest.ProtoReflect.Descriptor instead.
 func (*ExecuteJobRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{12}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ExecuteJobRequest) GetJobId() string {
@@ -1015,7 +1121,7 @@ type ExecuteJobResponse struct {
 
 func (x *ExecuteJobResponse) Reset() {
 	*x = ExecuteJobResponse{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[13]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1027,7 +1133,7 @@ func (x *ExecuteJobResponse) String() string {
 func (*ExecuteJobResponse) ProtoMessage() {}
 
 func (x *ExecuteJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[13]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1040,7 +1146,7 @@ func (x *ExecuteJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteJobResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteJobResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{13}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ExecuteJobResponse) GetSuccess() bool {
@@ -1113,7 +1219,7 @@ type JobLogEntry struct {
 
 func (x *JobLogEntry) Reset() {
 	*x = JobLogEntry{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[14]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1125,7 +1231,7 @@ func (x *JobLogEntry) String() string {
 func (*JobLogEntry) ProtoMessage() {}
 
 func (x *JobLogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[14]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1138,7 +1244,7 @@ func (x *JobLogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobLogEntry.ProtoReflect.Descriptor instead.
 func (*JobLogEntry) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{14}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *JobLogEntry) GetTimestamp() string {
@@ -1186,7 +1292,7 @@ type GlyphDefResponse struct {
 
 func (x *GlyphDefResponse) Reset() {
 	*x = GlyphDefResponse{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[15]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1198,7 +1304,7 @@ func (x *GlyphDefResponse) String() string {
 func (*GlyphDefResponse) ProtoMessage() {}
 
 func (x *GlyphDefResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[15]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1211,7 +1317,7 @@ func (x *GlyphDefResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlyphDefResponse.ProtoReflect.Descriptor instead.
 func (*GlyphDefResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{15}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GlyphDefResponse) GetGlyphs() []*GlyphDef {
@@ -1248,7 +1354,7 @@ type GlyphDef struct {
 
 func (x *GlyphDef) Reset() {
 	*x = GlyphDef{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[16]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1260,7 +1366,7 @@ func (x *GlyphDef) String() string {
 func (*GlyphDef) ProtoMessage() {}
 
 func (x *GlyphDef) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[16]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1273,7 +1379,7 @@ func (x *GlyphDef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlyphDef.ProtoReflect.Descriptor instead.
 func (*GlyphDef) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{16}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GlyphDef) GetSymbol() string {
@@ -1342,7 +1448,7 @@ type ParseAxQueryRequest struct {
 
 func (x *ParseAxQueryRequest) Reset() {
 	*x = ParseAxQueryRequest{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[17]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1354,7 +1460,7 @@ func (x *ParseAxQueryRequest) String() string {
 func (*ParseAxQueryRequest) ProtoMessage() {}
 
 func (x *ParseAxQueryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[17]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1367,7 +1473,7 @@ func (x *ParseAxQueryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParseAxQueryRequest.ProtoReflect.Descriptor instead.
 func (*ParseAxQueryRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{17}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ParseAxQueryRequest) GetQuery() string {
@@ -1388,7 +1494,7 @@ type ParseAxQueryResponse struct {
 
 func (x *ParseAxQueryResponse) Reset() {
 	*x = ParseAxQueryResponse{}
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[18]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1400,7 +1506,7 @@ func (x *ParseAxQueryResponse) String() string {
 func (*ParseAxQueryResponse) ProtoMessage() {}
 
 func (x *ParseAxQueryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[18]
+	mi := &file_plugin_grpc_protocol_domain_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1413,7 +1519,7 @@ func (x *ParseAxQueryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParseAxQueryResponse.ProtoReflect.Descriptor instead.
 func (*ParseAxQueryResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{18}
+	return file_plugin_grpc_protocol_domain_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ParseAxQueryResponse) GetResult() []byte {
@@ -1511,11 +1617,22 @@ const file_plugin_grpc_protocol_domain_proto_rawDesc = "" +
 	"\x10interval_seconds\x18\x02 \x01(\x05R\x0fintervalSeconds\x12,\n" +
 	"\x12enabled_by_default\x18\x03 \x01(\bR\x10enabledByDefault\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x19\n" +
-	"\bats_code\x18\x05 \x01(\tR\aatsCode\"\x92\x01\n" +
+	"\bats_code\x18\x05 \x01(\tR\aatsCode\"\xcd\x01\n" +
 	"\x12InitializeResponse\x12#\n" +
 	"\rhandler_names\x18\x01 \x03(\tR\fhandlerNames\x124\n" +
 	"\tschedules\x18\x02 \x03(\v2\x16.protocol.ScheduleInfoR\tschedules\x12!\n" +
-	"\fllm_provider\x18\x03 \x01(\bR\vllmProvider\"\xa0\x01\n" +
+	"\fllm_provider\x18\x03 \x01(\bR\vllmProvider\x129\n" +
+	"\bwatchers\x18\x04 \x03(\v2\x1d.protocol.WatcherRegistrationR\bwatchers\"\xe9\x01\n" +
+	"\x13WatcherRegistration\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12!\n" +
+	"\fhandler_name\x18\x02 \x01(\tR\vhandlerName\x12\x1a\n" +
+	"\bsubjects\x18\x03 \x03(\tR\bsubjects\x12\x1e\n" +
+	"\n" +
+	"predicates\x18\x04 \x03(\tR\n" +
+	"predicates\x12\x1a\n" +
+	"\bcontexts\x18\x05 \x03(\tR\bcontexts\x12\x16\n" +
+	"\x06actors\x18\x06 \x03(\tR\x06actors\x12/\n" +
+	"\x14max_fires_per_second\x18\a \x01(\x05R\x11maxFiresPerSecond\"\xa0\x01\n" +
 	"\x11ExecuteJobRequest\x12\x15\n" +
 	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12!\n" +
 	"\fhandler_name\x18\x02 \x01(\tR\vhandlerName\x12\x18\n" +
@@ -1584,7 +1701,7 @@ func file_plugin_grpc_protocol_domain_proto_rawDescGZIP() []byte {
 }
 
 var file_plugin_grpc_protocol_domain_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_plugin_grpc_protocol_domain_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_plugin_grpc_protocol_domain_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_plugin_grpc_protocol_domain_proto_goTypes = []any{
 	(WebSocketMessage_Type)(0),   // 0: protocol.WebSocketMessage.Type
 	(*Empty)(nil),                // 1: protocol.Empty
@@ -1599,55 +1716,57 @@ var file_plugin_grpc_protocol_domain_proto_goTypes = []any{
 	(*ConfigFieldSchema)(nil),    // 10: protocol.ConfigFieldSchema
 	(*ScheduleInfo)(nil),         // 11: protocol.ScheduleInfo
 	(*InitializeResponse)(nil),   // 12: protocol.InitializeResponse
-	(*ExecuteJobRequest)(nil),    // 13: protocol.ExecuteJobRequest
-	(*ExecuteJobResponse)(nil),   // 14: protocol.ExecuteJobResponse
-	(*JobLogEntry)(nil),          // 15: protocol.JobLogEntry
-	(*GlyphDefResponse)(nil),     // 16: protocol.GlyphDefResponse
-	(*GlyphDef)(nil),             // 17: protocol.GlyphDef
-	(*ParseAxQueryRequest)(nil),  // 18: protocol.ParseAxQueryRequest
-	(*ParseAxQueryResponse)(nil), // 19: protocol.ParseAxQueryResponse
-	nil,                          // 20: protocol.InitializeRequest.ConfigEntry
-	nil,                          // 21: protocol.WebSocketMessage.HeadersEntry
-	nil,                          // 22: protocol.HealthResponse.DetailsEntry
-	nil,                          // 23: protocol.ConfigSchemaResponse.FieldsEntry
+	(*WatcherRegistration)(nil),  // 13: protocol.WatcherRegistration
+	(*ExecuteJobRequest)(nil),    // 14: protocol.ExecuteJobRequest
+	(*ExecuteJobResponse)(nil),   // 15: protocol.ExecuteJobResponse
+	(*JobLogEntry)(nil),          // 16: protocol.JobLogEntry
+	(*GlyphDefResponse)(nil),     // 17: protocol.GlyphDefResponse
+	(*GlyphDef)(nil),             // 18: protocol.GlyphDef
+	(*ParseAxQueryRequest)(nil),  // 19: protocol.ParseAxQueryRequest
+	(*ParseAxQueryResponse)(nil), // 20: protocol.ParseAxQueryResponse
+	nil,                          // 21: protocol.InitializeRequest.ConfigEntry
+	nil,                          // 22: protocol.WebSocketMessage.HeadersEntry
+	nil,                          // 23: protocol.HealthResponse.DetailsEntry
+	nil,                          // 24: protocol.ConfigSchemaResponse.FieldsEntry
 }
 var file_plugin_grpc_protocol_domain_proto_depIdxs = []int32{
-	20, // 0: protocol.InitializeRequest.config:type_name -> protocol.InitializeRequest.ConfigEntry
+	21, // 0: protocol.InitializeRequest.config:type_name -> protocol.InitializeRequest.ConfigEntry
 	6,  // 1: protocol.HTTPRequest.headers:type_name -> protocol.HTTPHeader
 	6,  // 2: protocol.HTTPResponse.headers:type_name -> protocol.HTTPHeader
 	0,  // 3: protocol.WebSocketMessage.type:type_name -> protocol.WebSocketMessage.Type
-	21, // 4: protocol.WebSocketMessage.headers:type_name -> protocol.WebSocketMessage.HeadersEntry
-	22, // 5: protocol.HealthResponse.details:type_name -> protocol.HealthResponse.DetailsEntry
-	23, // 6: protocol.ConfigSchemaResponse.fields:type_name -> protocol.ConfigSchemaResponse.FieldsEntry
+	22, // 4: protocol.WebSocketMessage.headers:type_name -> protocol.WebSocketMessage.HeadersEntry
+	23, // 5: protocol.HealthResponse.details:type_name -> protocol.HealthResponse.DetailsEntry
+	24, // 6: protocol.ConfigSchemaResponse.fields:type_name -> protocol.ConfigSchemaResponse.FieldsEntry
 	11, // 7: protocol.InitializeResponse.schedules:type_name -> protocol.ScheduleInfo
-	15, // 8: protocol.ExecuteJobResponse.log_entries:type_name -> protocol.JobLogEntry
-	17, // 9: protocol.GlyphDefResponse.glyphs:type_name -> protocol.GlyphDef
-	10, // 10: protocol.ConfigSchemaResponse.FieldsEntry.value:type_name -> protocol.ConfigFieldSchema
-	1,  // 11: protocol.DomainPluginService.Metadata:input_type -> protocol.Empty
-	3,  // 12: protocol.DomainPluginService.Initialize:input_type -> protocol.InitializeRequest
-	1,  // 13: protocol.DomainPluginService.Shutdown:input_type -> protocol.Empty
-	4,  // 14: protocol.DomainPluginService.HandleHTTP:input_type -> protocol.HTTPRequest
-	7,  // 15: protocol.DomainPluginService.HandleWebSocket:input_type -> protocol.WebSocketMessage
-	1,  // 16: protocol.DomainPluginService.Health:input_type -> protocol.Empty
-	1,  // 17: protocol.DomainPluginService.ConfigSchema:input_type -> protocol.Empty
-	1,  // 18: protocol.DomainPluginService.RegisterGlyphs:input_type -> protocol.Empty
-	13, // 19: protocol.DomainPluginService.ExecuteJob:input_type -> protocol.ExecuteJobRequest
-	18, // 20: protocol.DomainPluginService.ParseAxQuery:input_type -> protocol.ParseAxQueryRequest
-	2,  // 21: protocol.DomainPluginService.Metadata:output_type -> protocol.MetadataResponse
-	12, // 22: protocol.DomainPluginService.Initialize:output_type -> protocol.InitializeResponse
-	1,  // 23: protocol.DomainPluginService.Shutdown:output_type -> protocol.Empty
-	5,  // 24: protocol.DomainPluginService.HandleHTTP:output_type -> protocol.HTTPResponse
-	7,  // 25: protocol.DomainPluginService.HandleWebSocket:output_type -> protocol.WebSocketMessage
-	8,  // 26: protocol.DomainPluginService.Health:output_type -> protocol.HealthResponse
-	9,  // 27: protocol.DomainPluginService.ConfigSchema:output_type -> protocol.ConfigSchemaResponse
-	16, // 28: protocol.DomainPluginService.RegisterGlyphs:output_type -> protocol.GlyphDefResponse
-	14, // 29: protocol.DomainPluginService.ExecuteJob:output_type -> protocol.ExecuteJobResponse
-	19, // 30: protocol.DomainPluginService.ParseAxQuery:output_type -> protocol.ParseAxQueryResponse
-	21, // [21:31] is the sub-list for method output_type
-	11, // [11:21] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	13, // 8: protocol.InitializeResponse.watchers:type_name -> protocol.WatcherRegistration
+	16, // 9: protocol.ExecuteJobResponse.log_entries:type_name -> protocol.JobLogEntry
+	18, // 10: protocol.GlyphDefResponse.glyphs:type_name -> protocol.GlyphDef
+	10, // 11: protocol.ConfigSchemaResponse.FieldsEntry.value:type_name -> protocol.ConfigFieldSchema
+	1,  // 12: protocol.DomainPluginService.Metadata:input_type -> protocol.Empty
+	3,  // 13: protocol.DomainPluginService.Initialize:input_type -> protocol.InitializeRequest
+	1,  // 14: protocol.DomainPluginService.Shutdown:input_type -> protocol.Empty
+	4,  // 15: protocol.DomainPluginService.HandleHTTP:input_type -> protocol.HTTPRequest
+	7,  // 16: protocol.DomainPluginService.HandleWebSocket:input_type -> protocol.WebSocketMessage
+	1,  // 17: protocol.DomainPluginService.Health:input_type -> protocol.Empty
+	1,  // 18: protocol.DomainPluginService.ConfigSchema:input_type -> protocol.Empty
+	1,  // 19: protocol.DomainPluginService.RegisterGlyphs:input_type -> protocol.Empty
+	14, // 20: protocol.DomainPluginService.ExecuteJob:input_type -> protocol.ExecuteJobRequest
+	19, // 21: protocol.DomainPluginService.ParseAxQuery:input_type -> protocol.ParseAxQueryRequest
+	2,  // 22: protocol.DomainPluginService.Metadata:output_type -> protocol.MetadataResponse
+	12, // 23: protocol.DomainPluginService.Initialize:output_type -> protocol.InitializeResponse
+	1,  // 24: protocol.DomainPluginService.Shutdown:output_type -> protocol.Empty
+	5,  // 25: protocol.DomainPluginService.HandleHTTP:output_type -> protocol.HTTPResponse
+	7,  // 26: protocol.DomainPluginService.HandleWebSocket:output_type -> protocol.WebSocketMessage
+	8,  // 27: protocol.DomainPluginService.Health:output_type -> protocol.HealthResponse
+	9,  // 28: protocol.DomainPluginService.ConfigSchema:output_type -> protocol.ConfigSchemaResponse
+	17, // 29: protocol.DomainPluginService.RegisterGlyphs:output_type -> protocol.GlyphDefResponse
+	15, // 30: protocol.DomainPluginService.ExecuteJob:output_type -> protocol.ExecuteJobResponse
+	20, // 31: protocol.DomainPluginService.ParseAxQuery:output_type -> protocol.ParseAxQueryResponse
+	22, // [22:32] is the sub-list for method output_type
+	12, // [12:22] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_plugin_grpc_protocol_domain_proto_init() }
@@ -1655,14 +1774,14 @@ func file_plugin_grpc_protocol_domain_proto_init() {
 	if File_plugin_grpc_protocol_domain_proto != nil {
 		return
 	}
-	file_plugin_grpc_protocol_domain_proto_msgTypes[12].OneofWrappers = []any{}
+	file_plugin_grpc_protocol_domain_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_grpc_protocol_domain_proto_rawDesc), len(file_plugin_grpc_protocol_domain_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   23,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/plugin/grpc/protocol/domain.proto
+++ b/plugin/grpc/protocol/domain.proto
@@ -188,6 +188,25 @@ message InitializeResponse {
   // llm_provider indicates this plugin implements LLMProvider (Chat RPC).
   // Core registers it as an LLM backend in the service mesh.
   bool llm_provider = 3;
+
+  // Watchers this plugin wants registered on its behalf.
+  // Core creates watchers with action_type=plugin_execute targeting this plugin.
+  // On match, core calls ExecuteJob with the matching attestation as payload.
+  // Watcher ID is scoped to the plugin: "{plugin_name}-{watcher_id}".
+  repeated WatcherRegistration watchers = 4;
+}
+
+// WatcherRegistration declares a watcher a plugin wants core to manage.
+// Core creates/updates the watcher during Initialize and routes matches
+// to the plugin via ExecuteJob.
+message WatcherRegistration {
+  string id = 1;                    // Watcher ID (scoped: "{plugin}-{id}")
+  string handler_name = 2;          // ExecuteJob handler to invoke on match
+  repeated string subjects = 3;     // Structural filter: subjects
+  repeated string predicates = 4;   // Structural filter: predicates
+  repeated string contexts = 5;     // Structural filter: contexts
+  repeated string actors = 6;       // Structural filter: actors
+  int32 max_fires_per_second = 7;   // Rate limit (0 = no action, structural only)
 }
 
 // ExecuteJobRequest is sent to plugins to execute an async job

--- a/plugin/grpc/protocol/domain.proto
+++ b/plugin/grpc/protocol/domain.proto
@@ -192,15 +192,14 @@ message InitializeResponse {
   // Watchers this plugin wants registered on its behalf.
   // Core creates watchers with action_type=plugin_execute targeting this plugin.
   // On match, core calls ExecuteJob with the matching attestation as payload.
-  // Watcher ID is scoped to the plugin: "{plugin_name}-{watcher_id}".
   repeated WatcherRegistration watchers = 4;
 }
 
 // WatcherRegistration declares a watcher a plugin wants core to manage.
-// Core creates/updates the watcher during Initialize and routes matches
+// Core creates/updates the watcher on Initialize and routes matches
 // to the plugin via ExecuteJob.
 message WatcherRegistration {
-  string id = 1;                    // Watcher ID (scoped: "{plugin}-{id}")
+  string id = 1;                    // Watcher ID (scoped to plugin: "{plugin}-{id}")
   string handler_name = 2;          // ExecuteJob handler to invoke on match
   repeated string subjects = 3;     // Structural filter: subjects
   repeated string predicates = 4;   // Structural filter: predicates

--- a/plugin/grpc/watchers.go
+++ b/plugin/grpc/watchers.go
@@ -1,0 +1,74 @@
+package grpc
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/ats/watcher"
+	"github.com/teranos/QNTX/errors"
+	"github.com/teranos/QNTX/plugin/grpc/protocol"
+	"go.uber.org/zap"
+)
+
+// SetupPluginWatchers creates or replaces watchers announced by a plugin.
+// Called during plugin initialization to register plugin-declared watchers.
+// Uses CreateOrReplace for idempotency — safe across plugin restarts.
+func SetupPluginWatchers(db *sql.DB, pluginName string, registrations []*protocol.WatcherRegistration, logger *zap.SugaredLogger) error {
+	if len(registrations) == 0 {
+		return nil
+	}
+
+	logger.Infow("Setting up plugin watchers",
+		"plugin", pluginName,
+		"count", len(registrations),
+	)
+
+	ws := storage.NewWatcherStore(db)
+	ctx := context.Background()
+
+	for _, reg := range registrations {
+		watcherID := fmt.Sprintf("%s-%s", pluginName, reg.Id)
+
+		actionData, err := json.Marshal(watcher.PluginExecuteAction{
+			PluginName:  pluginName,
+			HandlerName: reg.HandlerName,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to marshal action data for watcher %s", watcherID)
+		}
+
+		w := &storage.Watcher{
+			ID:   watcherID,
+			Name: fmt.Sprintf("%s/%s", pluginName, reg.Id),
+			Filter: types.AxFilter{
+				Subjects:   reg.Subjects,
+				Predicates: reg.Predicates,
+				Contexts:   reg.Contexts,
+				Actors:     reg.Actors,
+			},
+			ActionType:        storage.ActionTypePluginExecute,
+			ActionData:        string(actionData),
+			MaxFiresPerSecond: int(reg.MaxFiresPerSecond),
+			Enabled:           true,
+		}
+
+		if err := ws.CreateOrReplace(ctx, w); err != nil {
+			return errors.Wrapf(err, "failed to create watcher %s for plugin %s", watcherID, pluginName)
+		}
+
+		logger.Infow("Registered plugin watcher",
+			"plugin", pluginName,
+			"watcher_id", watcherID,
+			"handler", reg.HandlerName,
+			"predicates", reg.Predicates,
+			"contexts", reg.Contexts,
+			"max_fires_per_second", reg.MaxFiresPerSecond,
+		)
+	}
+
+	return nil
+}

--- a/proto.nix
+++ b/proto.nix
@@ -99,6 +99,28 @@
     '');
   };
 
+  generate-proto-ocaml = {
+    type = "app";
+    program = toString (pkgs.writeShellScript "generate-proto-ocaml" ''
+      set -e
+      echo "Generating OCaml proto code..."
+
+      PROTOC_GEN_OCAML="$HOME/.opam/5.2.1/bin/protoc-gen-ocaml"
+      if ! [ -x "$PROTOC_GEN_OCAML" ]; then
+        echo "⚠ protoc-gen-ocaml not found at $PROTOC_GEN_OCAML — skipping OCaml proto generation"
+        exit 0
+      fi
+
+      ${pkgs.protobuf}/bin/protoc \
+        --plugin=protoc-gen-ocaml="$PROTOC_GEN_OCAML" \
+        --ocaml_out=plugin/grpc/ocaml/proto/ \
+        plugin/grpc/protocol/domain.proto \
+        plugin/grpc/protocol/atsstore.proto
+
+      echo "✓ OCaml proto files generated in plugin/grpc/ocaml/proto/"
+    '');
+  };
+
   generate-proto = {
     type = "app";
     program = toString (pkgs.writeShellScript "generate-proto" ''
@@ -110,6 +132,9 @@
 
       # Run TypeScript generation
       nix run .#generate-proto-typescript
+
+      # Run OCaml generation
+      nix run .#generate-proto-ocaml
 
       echo "✓ All proto files generated"
     '');

--- a/server/server.go
+++ b/server/server.go
@@ -356,6 +356,14 @@ func (s *QNTXServer) GetServicesManager() *grpcplugin.ServicesManager {
 	return s.servicesManager
 }
 
+// ReloadWatchers reloads the watcher engine's in-memory map from the database.
+func (s *QNTXServer) ReloadWatchers() error {
+	if s.watcherEngine == nil {
+		return nil
+	}
+	return s.watcherEngine.ReloadWatchers()
+}
+
 // getAttestationByID retrieves a single attestation through the attestation store (Rust FFI).
 // Falls back to Go's *sql.DB if the store doesn't support direct get.
 func (s *QNTXServer) getAttestationByID(id string) (*types.As, error) {


### PR DESCRIPTION
Plugins declare watchers in `InitializeResponse`. Core creates them in the DB during `Initialize` and routes matching attestations to the plugin via `ExecuteJob`.

Before this PR, plugins had no way to subscribe to attestation events. The only path was manual watcher creation through the API. Now a plugin declares what it cares about in proto, and the wiring is automatic.

Watchers are created inside `doInitialize`, the moment the plugin responds. No timing dependency on server readiness. `CreateOrReplace` ensures idempotency across restarts.

`make proto` now generates Go, TypeScript, and OCaml bindings in one command.

Also fixes CLAUDE.md: `make dev` does not hot-reload the backend.

Adds Phase 5 (Reactive Watchers) to ADR-004.

## Watcher lineage

#359 → #424 → #455 → #466 → #515 → #564 → #619 → **#770**

Reactive watchers → frontend errors → meld pipelines → live execution → dedup embeddings → coalesce reloads → persistent queue → **plugin-declared watchers**

## E2E proof

Voor v0.2.0 declares a watcher on predicate `nominated` with handler `triage`:

```
voor  [voor v0.2.0] [voor] ExecuteJob handler=triage job_id=watcher-... (461 bytes payload)
```

## Limitation

Plugin watchers are not yet visible in the UI (#771).