### PR TITLE
Deduplicate C++ proto generation across plugins

### DIFF
--- a/plugin/grpc/protocol/proto.cmake
+++ b/plugin/grpc/protocol/proto.cmake
@@ -1,0 +1,37 @@
+# Shared C++ proto generation for all plugins.
+# Usage:
+#   include(${CMAKE_SOURCE_DIR}/../../plugin/grpc/protocol/proto.cmake)
+#   generate_proto(domain.proto)
+#   generate_proto(llm.proto)
+#   # then add ${GENERATED_SRCS} to your target and ${PROTO_GEN_DIR} to includes
+#
+# NOTE: Default PROTO_DIR assumes the plugin lives 2 levels below the qntx repo
+# root (e.g. qntx-plugins/gaze/, ctp/werf/). Override PROTO_DIR if this changes.
+
+if(NOT DEFINED PROTO_DIR)
+    set(PROTO_DIR "${CMAKE_SOURCE_DIR}/../../plugin/grpc/protocol")
+endif()
+set(PROTO_GEN_DIR "${CMAKE_BINARY_DIR}/generated")
+file(MAKE_DIRECTORY ${PROTO_GEN_DIR})
+
+function(generate_proto PROTO_FILE)
+    get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
+    set(PROTO_SRC "${PROTO_GEN_DIR}/${PROTO_NAME}.pb.cc")
+    set(PROTO_HDR "${PROTO_GEN_DIR}/${PROTO_NAME}.pb.h")
+    set(GRPC_SRC "${PROTO_GEN_DIR}/${PROTO_NAME}.grpc.pb.cc")
+    set(GRPC_HDR "${PROTO_GEN_DIR}/${PROTO_NAME}.grpc.pb.h")
+
+    add_custom_command(
+        OUTPUT ${PROTO_SRC} ${PROTO_HDR} ${GRPC_SRC} ${GRPC_HDR}
+        COMMAND protobuf::protoc
+            --proto_path=${PROTO_DIR}
+            --cpp_out=${PROTO_GEN_DIR}
+            --grpc_out=${PROTO_GEN_DIR}
+            --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
+            ${PROTO_DIR}/${PROTO_FILE}
+        DEPENDS ${PROTO_DIR}/${PROTO_FILE}
+        COMMENT "Generating C++ protos for ${PROTO_FILE}"
+    )
+
+    set(GENERATED_SRCS ${GENERATED_SRCS} ${PROTO_SRC} ${GRPC_SRC} PARENT_SCOPE)
+endfunction()

--- a/proto.nix
+++ b/proto.nix
@@ -136,25 +136,18 @@
       # Run OCaml generation
       nix run .#generate-proto-ocaml
 
+      # C++ protos are generated at build time via shared proto.cmake
+      # (protoc version must match the linked protobuf library)
+
       echo "✓ All proto files generated"
     '');
   };
 
-  # TODO: generate-proto-cpp
-  # All 5 C++ plugins (gaze, scry, werf, spindle, ipluk) duplicate an identical
-  # generate_proto() CMake function that runs protoc at build time. Instead,
-  # pre-generate C++ proto files into plugin/grpc/protocol/cpp/ like the other
-  # languages, then rewire each plugin's CMakeLists.txt to include them directly.
-  # This removes find_package(protobuf/gRPC) as a build-time dependency from plugins.
-  #
-  # After adding generate-proto-cpp, update:
-  #   - qntx-plugins/gaze/CMakeLists.txt
-  #   - qntx-plugins/scry/CMakeLists.txt
-  #   - ctp/werf/CMakeLists.txt
-  #   - ctp/spindle/CMakeLists.txt
-  #   - ctp/ipluk/CMakeLists.txt
-  #
-  # Related: libstelt — shared C++ library for plugin infrastructure.
+  # C++ proto generation is handled by plugin/grpc/protocol/proto.cmake (shared
+  # cmake include) because protoc version must match the linked protobuf library.
+  # Go, TypeScript, and OCaml don't have this constraint.
+
+  # TODO: libstelt — shared C++ library for plugin infrastructure.
   # All 5 plugins duplicate base64, pdf_extract, LLMClient, ATSClient, and
   # main() boilerplate. libstelt extracts these into a single linkable library.
   # Plugins link against libstelt and only implement domain logic.

--- a/qntx-plugins/gaze/CMakeLists.txt
+++ b/qntx-plugins/gaze/CMakeLists.txt
@@ -47,36 +47,9 @@ find_path(MUPDF_INCLUDE_DIR mupdf/fitz.h REQUIRED)
 find_package(protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 
-# Proto generation — PROTO_DIR can be overridden for sandboxed builds (Nix)
-if(NOT DEFINED PROTO_DIR)
-    set(PROTO_DIR "${CMAKE_SOURCE_DIR}/../../plugin/grpc/protocol")
-endif()
-set(PROTO_GEN_DIR "${CMAKE_BINARY_DIR}/generated")
-file(MAKE_DIRECTORY ${PROTO_GEN_DIR})
-
-function(generate_proto PROTO_FILE)
-    get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
-    set(PROTO_SRC "${PROTO_GEN_DIR}/${PROTO_NAME}.pb.cc")
-    set(PROTO_HDR "${PROTO_GEN_DIR}/${PROTO_NAME}.pb.h")
-    set(GRPC_SRC "${PROTO_GEN_DIR}/${PROTO_NAME}.grpc.pb.cc")
-    set(GRPC_HDR "${PROTO_GEN_DIR}/${PROTO_NAME}.grpc.pb.h")
-
-    add_custom_command(
-        OUTPUT ${PROTO_SRC} ${PROTO_HDR} ${GRPC_SRC} ${GRPC_HDR}
-        COMMAND protobuf::protoc
-            --proto_path=${PROTO_DIR}
-            --cpp_out=${PROTO_GEN_DIR}
-            --grpc_out=${PROTO_GEN_DIR}
-            --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
-            ${PROTO_DIR}/${PROTO_FILE}
-        DEPENDS ${PROTO_DIR}/${PROTO_FILE}
-        COMMENT "Generating C++ protos for ${PROTO_FILE}"
-    )
-
-    set(GENERATED_SRCS ${GENERATED_SRCS} ${PROTO_SRC} ${GRPC_SRC} PARENT_SCOPE)
-endfunction()
-
+# Proto generation — shared function from proto.cmake
 set(GENERATED_SRCS "")
+include(${CMAKE_SOURCE_DIR}/../../plugin/grpc/protocol/proto.cmake)
 generate_proto(domain.proto)
 generate_proto(llm.proto)
 

--- a/qntx-plugins/scry/CMakeLists.txt
+++ b/qntx-plugins/scry/CMakeLists.txt
@@ -63,36 +63,9 @@ find_path(MUPDF_INCLUDE_DIR mupdf/fitz.h REQUIRED)
 find_package(protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 
-# Proto generation — PROTO_DIR can be overridden for sandboxed builds (Nix)
-if(NOT DEFINED PROTO_DIR)
-    set(PROTO_DIR "${CMAKE_SOURCE_DIR}/../../plugin/grpc/protocol")
-endif()
-set(PROTO_GEN_DIR "${CMAKE_BINARY_DIR}/generated")
-file(MAKE_DIRECTORY ${PROTO_GEN_DIR})
-
-function(generate_proto PROTO_FILE)
-    get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
-    set(PROTO_SRC "${PROTO_GEN_DIR}/${PROTO_NAME}.pb.cc")
-    set(PROTO_HDR "${PROTO_GEN_DIR}/${PROTO_NAME}.pb.h")
-    set(GRPC_SRC "${PROTO_GEN_DIR}/${PROTO_NAME}.grpc.pb.cc")
-    set(GRPC_HDR "${PROTO_GEN_DIR}/${PROTO_NAME}.grpc.pb.h")
-
-    add_custom_command(
-        OUTPUT ${PROTO_SRC} ${PROTO_HDR} ${GRPC_SRC} ${GRPC_HDR}
-        COMMAND protobuf::protoc
-            --proto_path=${PROTO_DIR}
-            --cpp_out=${PROTO_GEN_DIR}
-            --grpc_out=${PROTO_GEN_DIR}
-            --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
-            ${PROTO_DIR}/${PROTO_FILE}
-        DEPENDS ${PROTO_DIR}/${PROTO_FILE}
-        COMMENT "Generating C++ protos for ${PROTO_FILE}"
-    )
-
-    set(GENERATED_SRCS ${GENERATED_SRCS} ${PROTO_SRC} ${GRPC_SRC} PARENT_SCOPE)
-endfunction()
-
+# Proto generation — shared function from proto.cmake
 set(GENERATED_SRCS "")
+include(${CMAKE_SOURCE_DIR}/../../plugin/grpc/protocol/proto.cmake)
 generate_proto(domain.proto)
 generate_proto(llm.proto)
 generate_proto(atsstore.proto)


### PR DESCRIPTION
## Summary
- Extract duplicated `generate_proto()` cmake function into shared `plugin/grpc/protocol/proto.cmake`
- Gaze and scry CMakeLists.txt now `include()` the shared file instead of inlining the function
- Remove `generate-proto-cpp` from proto.nix — C++ protobuf requires version match between protoc and linked library, so generation must happen at cmake build time

## CTP plugins
Spindle, werf, and ipluk have matching PRs in their own repos.

## Note
Default `PROTO_DIR` assumes plugin lives 2 levels below qntx root (e.g. `ctp/werf/`). Documented in proto.cmake.