### PR TITLE
Move plugin config provider out of server/

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,3 +9,9 @@
 | [ADR-003](../docs/adr/ADR-003-plugin-communication.md) | Plugin communication patterns |
 | [ADR-004](../docs/adr/ADR-004-plugin-pulse-integration.md) | Plugin-Pulse integration for dynamic async handlers |
 | [ADR-006](../docs/adr/ADR-006-proto-as-source-of-truth.md) | Protocol Buffers as single source of truth for types |
+
+## Configuration
+
+Plugins receive configuration through the `plugin.Config` interface. They don't know where values come from — they just call `config.GetString("model")` or `config.GetString("_llm_endpoint")`.
+
+The implementation that actually resolves those calls lives here in `plugin/config.go`, not in the server. The server passes in service endpoints (gRPC addresses), and the config provider merges them with `am.toml` values. This keeps the server out of plugin concerns — it just hands over addresses at startup and walks away.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -14,4 +14,4 @@
 
 Plugins receive configuration through the `plugin.Config` interface. They don't know where values come from — they just call `config.GetString("model")` or `config.GetString("_llm_endpoint")`.
 
-The implementation that actually resolves those calls lives here in `plugin/config.go`, not in the server. The server passes in service endpoints (gRPC addresses), and the config provider merges them with `am.toml` values. This keeps the server out of plugin concerns — it just hands over addresses at startup and walks away.
+The implementation that actually resolves those calls lives in `plugin/grpc/config_provider.go`, not in the server. The server passes in service endpoints (gRPC addresses), and the config provider merges them with `am.toml` values. This keeps the server out of plugin concerns — it just hands over addresses at startup and walks away.

--- a/plugin/grpc/config_provider.go
+++ b/plugin/grpc/config_provider.go
@@ -1,0 +1,115 @@
+package grpc
+
+import (
+	"strings"
+
+	appcfg "github.com/teranos/QNTX/am"
+	"github.com/teranos/QNTX/plugin"
+)
+
+// NewConfigProvider creates a ConfigProvider that reads from am.toml
+// and injects gRPC service endpoints for plugin discovery.
+// Pass nil endpoints if no services are available.
+func NewConfigProvider(endpoints *ServiceEndpoints) plugin.ConfigProvider {
+	return &configProvider{
+		endpoints: endpoints,
+	}
+}
+
+// configProvider wraps am config with service endpoint injection.
+type configProvider struct {
+	endpoints *ServiceEndpoints
+}
+
+func (p *configProvider) GetPluginConfig(domain string) plugin.Config {
+	return &configWithEndpoints{
+		domain:    domain,
+		endpoints: p.endpoints,
+	}
+}
+
+// configWithEndpoints resolves plugin config keys from am.toml,
+// intercepting underscore-prefixed service keys to return gRPC addresses.
+type configWithEndpoints struct {
+	domain    string
+	endpoints *ServiceEndpoints
+}
+
+func (c *configWithEndpoints) GetString(key string) string {
+	if v, ok := c.endpointValue(key); ok {
+		return v
+	}
+	return appcfg.GetString(c.domain + "." + key)
+}
+
+func (c *configWithEndpoints) GetInt(key string) int {
+	return appcfg.GetInt(c.domain + "." + key)
+}
+
+func (c *configWithEndpoints) GetBool(key string) bool {
+	return appcfg.GetBool(c.domain + "." + key)
+}
+
+func (c *configWithEndpoints) GetStringSlice(key string) []string {
+	return appcfg.GetStringSlice(c.domain + "." + key)
+}
+
+func (c *configWithEndpoints) Get(key string) any {
+	if v, ok := c.endpointValue(key); ok {
+		return v
+	}
+	return appcfg.Get(c.domain + "." + key)
+}
+
+func (c *configWithEndpoints) Set(key string, value any) {
+	appcfg.Set(c.domain+"."+key, value)
+}
+
+func (c *configWithEndpoints) GetKeys() []string {
+	v := appcfg.GetViper()
+	if v == nil {
+		return []string{}
+	}
+
+	allKeys := v.AllKeys()
+	prefix := c.domain + "."
+	var keys []string
+
+	for _, key := range allKeys {
+		if after, ok := strings.CutPrefix(key, prefix); ok {
+			keys = append(keys, after)
+		}
+	}
+
+	return keys
+}
+
+// endpointValue returns a service endpoint value for underscore-prefixed keys.
+func (c *configWithEndpoints) endpointValue(key string) (string, bool) {
+	if c.endpoints == nil {
+		return "", false
+	}
+	switch key {
+	case "_ats_store_endpoint":
+		return c.endpoints.ATSStoreAddress, true
+	case "_queue_endpoint":
+		return c.endpoints.QueueAddress, true
+	case "_schedule_endpoint":
+		return c.endpoints.ScheduleAddress, true
+	case "_file_service_endpoint":
+		return c.endpoints.FileServiceAddress, true
+	case "_llm_endpoint":
+		return c.endpoints.LLMAddress, true
+	case "_embedding_endpoint":
+		return c.endpoints.EmbeddingAddress, true
+	case "_vector_search_endpoint":
+		return c.endpoints.VectorSearchAddress, true
+	case "_ground_endpoint":
+		return c.endpoints.GroundAddress, true
+	case "_search_endpoint":
+		return c.endpoints.SearchAddress, true
+	case "_auth_token":
+		return c.endpoints.AuthToken, true
+	}
+	return "", false
+}

--- a/plugin/grpc/config_provider_test.go
+++ b/plugin/grpc/config_provider_test.go
@@ -1,0 +1,80 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfigProvider_WithoutEndpoints(t *testing.T) {
+	provider := NewConfigProvider(nil)
+	require.NotNil(t, provider)
+
+	config := provider.GetPluginConfig("testdomain")
+	require.NotNil(t, config)
+
+	// Without endpoints, service keys return empty
+	assert.Equal(t, "", config.GetString("_llm_endpoint"))
+}
+
+func TestNewConfigProvider_InjectsEndpoints(t *testing.T) {
+	endpoints := &ServiceEndpoints{
+		ATSStoreAddress:     "localhost:9001",
+		QueueAddress:        "localhost:9002",
+		ScheduleAddress:     "localhost:9003",
+		FileServiceAddress:  "localhost:9004",
+		LLMAddress:          "localhost:9005",
+		EmbeddingAddress:    "localhost:9006",
+		VectorSearchAddress: "localhost:9007",
+		GroundAddress:       "localhost:9008",
+		SearchAddress:       "localhost:9009",
+		AuthToken:           "test-token-123",
+	}
+
+	provider := NewConfigProvider(endpoints)
+	config := provider.GetPluginConfig("anydomain")
+
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"_ats_store_endpoint", "localhost:9001"},
+		{"_queue_endpoint", "localhost:9002"},
+		{"_schedule_endpoint", "localhost:9003"},
+		{"_file_service_endpoint", "localhost:9004"},
+		{"_llm_endpoint", "localhost:9005"},
+		{"_embedding_endpoint", "localhost:9006"},
+		{"_vector_search_endpoint", "localhost:9007"},
+		{"_ground_endpoint", "localhost:9008"},
+		{"_search_endpoint", "localhost:9009"},
+		{"_auth_token", "test-token-123"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			assert.Equal(t, tc.want, config.GetString(tc.key))
+		})
+	}
+}
+
+func TestNewConfigProvider_GetAlsoInjectsEndpoints(t *testing.T) {
+	endpoints := &ServiceEndpoints{
+		LLMAddress: "localhost:5555",
+	}
+
+	provider := NewConfigProvider(endpoints)
+	config := provider.GetPluginConfig("x")
+
+	assert.Equal(t, "localhost:5555", config.Get("_llm_endpoint"))
+}
+
+func TestNewConfigProvider_NonEndpointKeysFallThrough(t *testing.T) {
+	endpoints := &ServiceEndpoints{LLMAddress: "localhost:5555"}
+	provider := NewConfigProvider(endpoints)
+	config := provider.GetPluginConfig("testdomain")
+
+	// Regular keys go through am config (returns zero values in test)
+	assert.Equal(t, 0, config.GetInt("some_number"))
+	assert.Equal(t, false, config.GetBool("some_flag"))
+}

--- a/server/init.go
+++ b/server/init.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/teranos/QNTX/ai/tracker"
@@ -86,7 +85,7 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 	}
 
 	// Create all server dependencies (builder, services, trackers, daemon)
-	deps, err := createServerDependencies(db, atsStore, verbosity, wsCore, wsTransport, serverLogger)
+	deps, err := createServerDependencies(db, atsStore, verbosity, serverLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create server dependencies")
 	}
@@ -180,6 +179,7 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 		bindAddr = "127.0.0.1"
 	}
 	if !appcfg.IsLoopbackAddress(bindAddr) && !deps.config.Auth.Enabled {
+		cancel()
 		return nil, errors.Newf(
 			"auth.enabled must be true when server.bind_address is %q (non-loopback bind exposes all endpoints to the network)",
 			bindAddr,
@@ -300,10 +300,7 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 		}
 
 		// Wrap config provider to inject service endpoints for plugins
-		configProvider := &pluginConfigProvider{
-			base:      &simpleConfigProvider{},
-			endpoints: endpoints,
-		}
+		configProvider := grpcplugin.NewConfigProvider(endpoints)
 
 		services := plugin.NewServiceRegistry(db, serverLogger, atsStore, configProvider, queue)
 
@@ -449,7 +446,7 @@ func createServerLogger(verbosity int) (*zap.SugaredLogger, *wslogs.WebSocketCor
 }
 
 // createServerDependencies creates all components needed for QNTXServer initialization
-func createServerDependencies(db *sql.DB, atsStore ats.AttestationStore, verbosity int, wsCore zapcore.Core, wsTransport *wslogs.Transport, serverLogger *zap.SugaredLogger) (*serverDependencies, error) {
+func createServerDependencies(db *sql.DB, atsStore ats.AttestationStore, verbosity int, serverLogger *zap.SugaredLogger) (*serverDependencies, error) {
 	start := time.Now()
 
 	// Create builder with server logger — atsStore routes attestation queries through Rust FFI
@@ -566,157 +563,3 @@ func setupConfigWatcher(server *QNTXServer, db *sql.DB, serverLogger *zap.Sugare
 	serverLogger.Infow("Config watcher started", "path", configPath)
 }
 
-// simpleConfigProvider provides plugin configuration
-type simpleConfigProvider struct{}
-
-func (p *simpleConfigProvider) GetPluginConfig(domain string) plugin.Config {
-	return &simpleConfig{domain: domain}
-}
-
-// simpleConfig implements plugin.Config using am package
-type simpleConfig struct {
-	domain string
-}
-
-func (c *simpleConfig) GetString(key string) string {
-	return appcfg.GetString(c.domain + "." + key)
-}
-
-func (c *simpleConfig) GetInt(key string) int {
-	return appcfg.GetInt(c.domain + "." + key)
-}
-
-func (c *simpleConfig) GetBool(key string) bool {
-	return appcfg.GetBool(c.domain + "." + key)
-}
-
-func (c *simpleConfig) GetStringSlice(key string) []string {
-	return appcfg.GetStringSlice(c.domain + "." + key)
-}
-
-func (c *simpleConfig) Get(key string) interface{} {
-	return appcfg.Get(c.domain + "." + key)
-}
-
-func (c *simpleConfig) Set(key string, value interface{}) {
-	appcfg.Set(c.domain+"."+key, value)
-}
-
-func (c *simpleConfig) GetKeys() []string {
-	v := appcfg.GetViper()
-	if v == nil {
-		return []string{}
-	}
-
-	allKeys := v.AllKeys()
-	prefix := c.domain + "."
-	var keys []string
-
-	for _, key := range allKeys {
-		if strings.HasPrefix(key, prefix) {
-			// Strip the domain prefix to get the plugin-specific key
-			pluginKey := strings.TrimPrefix(key, prefix)
-			keys = append(keys, pluginKey)
-		}
-	}
-
-	return keys
-}
-
-// pluginConfigProvider wraps a base config provider to inject service endpoints
-type pluginConfigProvider struct {
-	base      plugin.ConfigProvider
-	endpoints *grpcplugin.ServiceEndpoints
-}
-
-func (p *pluginConfigProvider) GetPluginConfig(domain string) plugin.Config {
-	baseConfig := p.base.GetPluginConfig(domain)
-	return &pluginConfigWithEndpoints{
-		base:      baseConfig,
-		endpoints: p.endpoints,
-	}
-}
-
-// pluginConfigWithEndpoints wraps a plugin config to inject service endpoints
-type pluginConfigWithEndpoints struct {
-	base      plugin.Config
-	endpoints *grpcplugin.ServiceEndpoints
-}
-
-func (c *pluginConfigWithEndpoints) GetString(key string) string {
-	// Inject service endpoints for plugins (Issue #138)
-	if c.endpoints != nil {
-		switch key {
-		case "_ats_store_endpoint":
-			return c.endpoints.ATSStoreAddress
-		case "_queue_endpoint":
-			return c.endpoints.QueueAddress
-		case "_schedule_endpoint":
-			return c.endpoints.ScheduleAddress
-		case "_file_service_endpoint":
-			return c.endpoints.FileServiceAddress
-		case "_llm_endpoint":
-			return c.endpoints.LLMAddress
-		case "_embedding_endpoint":
-			return c.endpoints.EmbeddingAddress
-		case "_vector_search_endpoint":
-			return c.endpoints.VectorSearchAddress
-		case "_ground_endpoint":
-			return c.endpoints.GroundAddress
-		case "_search_endpoint":
-			return c.endpoints.SearchAddress
-		case "_auth_token":
-			return c.endpoints.AuthToken
-		}
-	}
-	return c.base.GetString(key)
-}
-
-func (c *pluginConfigWithEndpoints) GetInt(key string) int {
-	return c.base.GetInt(key)
-}
-
-func (c *pluginConfigWithEndpoints) GetBool(key string) bool {
-	return c.base.GetBool(key)
-}
-
-func (c *pluginConfigWithEndpoints) GetStringSlice(key string) []string {
-	return c.base.GetStringSlice(key)
-}
-
-func (c *pluginConfigWithEndpoints) Get(key string) interface{} {
-	// Inject service endpoints for plugins
-	if c.endpoints != nil {
-		switch key {
-		case "_ats_store_endpoint":
-			return c.endpoints.ATSStoreAddress
-		case "_queue_endpoint":
-			return c.endpoints.QueueAddress
-		case "_schedule_endpoint":
-			return c.endpoints.ScheduleAddress
-		case "_file_service_endpoint":
-			return c.endpoints.FileServiceAddress
-		case "_llm_endpoint":
-			return c.endpoints.LLMAddress
-		case "_embedding_endpoint":
-			return c.endpoints.EmbeddingAddress
-		case "_vector_search_endpoint":
-			return c.endpoints.VectorSearchAddress
-		case "_ground_endpoint":
-			return c.endpoints.GroundAddress
-		case "_search_endpoint":
-			return c.endpoints.SearchAddress
-		case "_auth_token":
-			return c.endpoints.AuthToken
-		}
-	}
-	return c.base.Get(key)
-}
-
-func (c *pluginConfigWithEndpoints) Set(key string, value interface{}) {
-	c.base.Set(key, value)
-}
-
-func (c *pluginConfigWithEndpoints) GetKeys() []string {
-	return c.base.GetKeys()
-}


### PR DESCRIPTION
## Summary

- The server shouldn't know how to build plugin configs — that's plugin plumbing. It just passes gRPC endpoints at startup and walks away.
- Previously untested code now has dedicated coverage (endpoint injection, nil safety, am fallthrough).
- Fixed a context leak on early return in NewQNTXServer.

## Test plan

- [x] New tests for config provider behavior
- [x] `make test` passes
- [x] Server boots normally