### PR TITLE
Namespace plugin handler names to prevent registry collisions

### DIFF
--- a/cmd/qntx/main.go
+++ b/cmd/qntx/main.go
@@ -302,8 +302,9 @@ func loadPluginsAsync(cfg *am.Config, pluginLogger *zap.SugaredLogger, registry 
 				meta := p.Metadata()
 				for _, handlerName := range externalPlugin.GetHandlerNames() {
 					pluginLogger.Debugw("Registering plugin async handler",
-						"plugin", meta.Name, "handler", handlerName)
-					proxyHandler := grpc.NewPluginProxyHandler(handlerName, externalPlugin, db, pluginLogger)
+						"plugin", meta.Name, "handler", handlerName,
+						"registry_key", grpc.PluginHandlerName(meta.Name, handlerName))
+					proxyHandler := grpc.NewPluginProxyHandler(meta.Name, handlerName, externalPlugin, db, pluginLogger)
 					handlerRegistry.Register(proxyHandler)
 				}
 
@@ -449,8 +450,9 @@ func retryPluginSetup(plugins []plugin.DomainPlugin, pluginRegistry *plugin.Regi
 			meta := p.Metadata()
 			for _, handlerName := range externalPlugin.GetHandlerNames() {
 				logger.Debugw("Registering plugin async handler",
-					"plugin", meta.Name, "handler", handlerName)
-				proxyHandler := grpc.NewPluginProxyHandler(handlerName, externalPlugin, db, logger)
+					"plugin", meta.Name, "handler", handlerName,
+					"registry_key", grpc.PluginHandlerName(meta.Name, handlerName))
+				proxyHandler := grpc.NewPluginProxyHandler(meta.Name, handlerName, externalPlugin, db, logger)
 				handlerRegistry.Register(proxyHandler)
 			}
 			schedules := externalPlugin.GetSchedules()

--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -829,9 +829,10 @@ func (m *PluginManager) registerRestarted(ctx context.Context, name string, regi
 
 	if m.handlerRegistry != nil {
 		for _, handlerName := range proxy.GetHandlerNames() {
-			proxyHandler := NewPluginProxyHandler(handlerName, proxy, m.db, m.logger)
+			proxyHandler := NewPluginProxyHandler(name, handlerName, proxy, m.db, m.logger)
 			m.handlerRegistry.Replace(proxyHandler)
-			m.logger.Debugw("Re-registered plugin async handler", "plugin", name, "handler", handlerName)
+			m.logger.Debugw("Re-registered plugin async handler", "plugin", name, "handler", handlerName,
+				"registry_key", PluginHandlerName(name, handlerName))
 		}
 	}
 

--- a/plugin/grpc/pulse_handler.go
+++ b/plugin/grpc/pulse_handler.go
@@ -19,16 +19,26 @@ import (
 // - PluginProxyHandler routes job to Python plugin via ExecuteJob RPC
 // - Plugin executes script and returns result
 // - Handler updates job state (progress, cost, error) and writes logs to task_logs
+// PluginHandlerName returns the namespaced registry key for a plugin handler.
+// This is the single source of truth for the naming convention.
+func PluginHandlerName(pluginName, handlerName string) string {
+	return pluginName + "/" + handlerName
+}
+
 type PluginProxyHandler struct {
-	handlerName string
+	pluginName  string // plugin that owns this handler
+	handlerName string // raw name the plugin uses internally
 	plugin      *ExternalDomainProxy
 	db          *sql.DB
 	logger      *zap.SugaredLogger
 }
 
 // NewPluginProxyHandler creates a handler that forwards execution to a plugin.
-func NewPluginProxyHandler(handlerName string, plugin *ExternalDomainProxy, db *sql.DB, logger *zap.SugaredLogger) *PluginProxyHandler {
+// The registry key is automatically namespaced as "pluginName/handlerName"
+// so multiple plugins can declare the same raw handler name without collision.
+func NewPluginProxyHandler(pluginName, handlerName string, plugin *ExternalDomainProxy, db *sql.DB, logger *zap.SugaredLogger) *PluginProxyHandler {
 	return &PluginProxyHandler{
+		pluginName:  pluginName,
 		handlerName: handlerName,
 		plugin:      plugin,
 		db:          db,
@@ -36,9 +46,9 @@ func NewPluginProxyHandler(handlerName string, plugin *ExternalDomainProxy, db *
 	}
 }
 
-// Name returns the handler identifier (e.g., "python.script", "python.webhook").
+// Name returns the namespaced registry key (e.g. "duif/route-changed").
 func (h *PluginProxyHandler) Name() string {
-	return h.handlerName
+	return PluginHandlerName(h.pluginName, h.handlerName)
 }
 
 // Execute forwards the job to the plugin for execution.
@@ -46,7 +56,7 @@ func (h *PluginProxyHandler) Execute(ctx context.Context, job *async.Job) error 
 	timeout := int64(300) // TODO: Make configurable or derive from job
 	req := &protocol.ExecuteJobRequest{
 		JobId:       job.ID,
-		HandlerName: h.handlerName,
+		HandlerName: h.handlerName, // raw name — the plugin doesn't know about namespacing
 		Payload:     job.Payload,
 		TimeoutSecs: &timeout,
 	}

--- a/plugin/grpc/pulse_handler_test.go
+++ b/plugin/grpc/pulse_handler_test.go
@@ -28,11 +28,7 @@ func TestWriteLogs(t *testing.T) {
 	}
 	require.NoError(t, store.CreateJob(job))
 
-	handler := &PluginProxyHandler{
-		handlerName: "test.handler",
-		db:          db,
-		logger:      logger,
-	}
+	handler := NewPluginProxyHandler("test", "handler", nil, db, logger)
 
 	entries := []*protocol.JobLogEntry{
 		{
@@ -81,15 +77,33 @@ func TestWriteLogs(t *testing.T) {
 	assert.Equal(t, `{"items_synced": 42}`, *logs[1].metadata)
 }
 
+// Two plugins both declare a handler with the same raw name.
+// The constructor namespaces the registry key as "pluginName/handlerName"
+// so both coexist without collision.
+func TestTwoPluginsSameHandlerName(t *testing.T) {
+	registry := async.NewHandlerRegistry()
+	db := qntxtest.CreateTestDB(t)
+	logger := zaptest.NewLogger(t).Sugar()
+
+	rawName := "data-sync"
+
+	gazeHandler := NewPluginProxyHandler("gaze", rawName, nil, db, logger)
+	registry.Register(gazeHandler)
+
+	scryHandler := NewPluginProxyHandler("scry", rawName, nil, db, logger)
+	registry.Register(scryHandler) // must not panic
+
+	assert.True(t, registry.Has("gaze/data-sync"))
+	assert.True(t, registry.Has("scry/data-sync"))
+	assert.False(t, registry.Has("data-sync"), "raw name must not appear in registry")
+	assert.Equal(t, 2, len(registry.Names()))
+}
+
 func TestWriteLogsEmpty(t *testing.T) {
 	db := qntxtest.CreateTestDB(t)
 	logger := zaptest.NewLogger(t).Sugar()
 
-	handler := &PluginProxyHandler{
-		handlerName: "test.handler",
-		db:          db,
-		logger:      logger,
-	}
+	handler := NewPluginProxyHandler("test", "handler", nil, db, logger)
 
 	// Empty entries should be a no-op (no panic, no DB writes)
 	handler.writeLogs("JOB_nonexistent", nil)

--- a/plugin/grpc/schedules.go
+++ b/plugin/grpc/schedules.go
@@ -25,6 +25,48 @@ func SetupPluginSchedules(db *sql.DB, pluginName string, schedules []*protocol.S
 		"count", len(schedules),
 	)
 
+	// Build set of namespaced handler names this plugin currently declares
+	declaredHandlers := make(map[string]bool, len(schedules))
+	for _, s := range schedules {
+		if s.IntervalSeconds > 0 || s.EnabledByDefault {
+			declaredHandlers[PluginHandlerName(pluginName, s.HandlerName)] = true
+		}
+	}
+
+	// Prune stale schedules owned by this plugin that are no longer declared.
+	// Metadata contains {"plugin":"<name>"} — match on that.
+	pluginMeta := fmt.Sprintf(`"plugin":"%s"`, pluginName)
+	rows, err := db.Query(`
+		SELECT id, handler_name FROM scheduled_pulse_jobs
+		WHERE state != 'deleted' AND metadata LIKE '%' || ? || '%'
+	`, pluginMeta)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list schedules for pruning plugin %s", pluginName)
+	}
+	defer rows.Close()
+
+	var staleIDs []string
+	for rows.Next() {
+		var id, handlerName string
+		if err := rows.Scan(&id, &handlerName); err != nil {
+			return errors.Wrapf(err, "failed to scan schedule row for plugin %s", pluginName)
+		}
+		if !declaredHandlers[handlerName] {
+			staleIDs = append(staleIDs, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrapf(err, "failed to iterate schedules for plugin %s", pluginName)
+	}
+
+	for _, id := range staleIDs {
+		if _, err := db.Exec(`UPDATE scheduled_pulse_jobs SET state = 'deleted', updated_at = ? WHERE id = ?`, time.Now(), id); err != nil {
+			logger.Warnw("Failed to prune stale plugin schedule", "plugin", pluginName, "schedule_id", id, "error", err)
+		} else {
+			logger.Infow("Pruned stale plugin schedule", "plugin", pluginName, "schedule_id", id)
+		}
+	}
+
 	for _, s := range schedules {
 		// Skip disabled schedules (interval <= 0 and not enabled by default)
 		if s.IntervalSeconds <= 0 && !s.EnabledByDefault {
@@ -38,11 +80,12 @@ func SetupPluginSchedules(db *sql.DB, pluginName string, schedules []*protocol.S
 		// Check if schedule already exists
 		var existingID string
 		var existingInterval int
+		namespacedHandler := PluginHandlerName(pluginName, s.HandlerName)
 		err := db.QueryRow(`
 			SELECT id, interval_seconds
 			FROM scheduled_pulse_jobs
 			WHERE handler_name = ?
-		`, s.HandlerName).Scan(&existingID, &existingInterval)
+		`, namespacedHandler).Scan(&existingID, &existingInterval)
 
 		if err == sql.ErrNoRows {
 			// Create new schedule
@@ -122,7 +165,7 @@ func createPluginSchedule(db *sql.DB, pluginName string, s *protocol.ScheduleInf
 	`,
 		jobID,
 		s.AtsCode,
-		s.HandlerName,
+		PluginHandlerName(pluginName, s.HandlerName),
 		nil, // No payload for plugin schedules
 		"",  // No source URL
 		s.IntervalSeconds,

--- a/plugin/grpc/schedules_test.go
+++ b/plugin/grpc/schedules_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	qntxtest "github.com/teranos/QNTX/internal/testing"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"github.com/teranos/QNTX/pulse/schedule"
-	qntxtest "github.com/teranos/QNTX/internal/testing"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -35,7 +35,7 @@ func TestSetupPluginSchedules(t *testing.T) {
 	require.Len(t, jobs, 1)
 
 	job := jobs[0]
-	assert.Equal(t, "test.handler", job.HandlerName)
+	assert.Equal(t, "testplugin/test.handler", job.HandlerName)
 	assert.Equal(t, 3600, job.IntervalSeconds)
 	assert.Equal(t, schedule.StateActive, job.State)
 	assert.Equal(t, "ats{test.handler}", job.ATSCode)
@@ -162,9 +162,9 @@ func TestSetupPluginSchedules_MultipleSchedules(t *testing.T) {
 	// Find jobs by handler name
 	var job1, job2 *schedule.Job
 	for i := range jobs {
-		if jobs[i].HandlerName == "test.handler1" {
+		if jobs[i].HandlerName == "testplugin/test.handler1" {
 			job1 = jobs[i]
-		} else if jobs[i].HandlerName == "test.handler2" {
+		} else if jobs[i].HandlerName == "testplugin/test.handler2" {
 			job2 = jobs[i]
 		}
 	}

--- a/pulse/async/grace_test.go
+++ b/pulse/async/grace_test.go
@@ -372,10 +372,19 @@ func TestGRACEGradualRecovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	pollInterval := 100 * time.Millisecond
 	wp := NewWorkerPoolWithContext(ctx, db, cfg, WorkerPoolConfig{
 		Workers:            1,
 		GracefulStartPhase: 10 * time.Second, // Test mode: 10s phases (warm start = 2s, slow start = 30s)
+		PollInterval:       &pollInterval,
 	}, zap.NewNop().Sugar())
+
+	// Register handler so recovered jobs can actually execute and complete
+	wp.Registry().Register(&GRACETestHandler{
+		taskDuration: 10 * time.Millisecond,
+		totalTasks:   1,
+	})
+
 	wp.Start()
 	defer wp.Stop()
 

--- a/pulse/async/handler.go
+++ b/pulse/async/handler.go
@@ -42,9 +42,11 @@ type JobHandler interface {
 // Thread-safe for concurrent handler registration and lookup.
 //
 // ARCHITECTURE: Generic handler registry
-// - Handlers register by name (e.g., "data.batch-import", "ml.inference")
-// - Infrastructure routes jobs by HandlerName, not domain-specific types
-// - Domain packages own handler names and payload structures
+//   - Handlers register by name (e.g., "data.batch-import", "ml.inference")
+//   - Infrastructure routes jobs by HandlerName, not domain-specific types
+//   - Domain packages own handler names and payload structures
+//   - Plugin handlers MUST be namespaced as "pluginName/handlerName" (e.g. "duif/route-changed")
+//     to prevent collisions when multiple plugins declare the same raw handler name.
 type HandlerRegistry struct {
 	handlers map[string]JobHandler // Handler name -> handler
 	mu       sync.RWMutex
@@ -122,6 +124,11 @@ func NewRegistryExecutor(registry *HandlerRegistry, fallback JobExecutor) *Regis
 	}
 }
 
+// ErrHandlerNotRegistered is returned when no handler exists for a job's handler name.
+// The worker uses this to re-queue the job instead of permanently failing it,
+// since the handler may not be registered yet (e.g. plugins still loading at boot).
+var ErrHandlerNotRegistered = errors.New("handler not registered")
+
 // Execute implements JobExecutor by dispatching to registered handlers.
 func (e *RegistryExecutor) Execute(ctx context.Context, job *Job) error {
 	if job.HandlerName == "" {
@@ -138,5 +145,5 @@ func (e *RegistryExecutor) Execute(ctx context.Context, job *Job) error {
 		return e.fallback.Execute(ctx, job)
 	}
 
-	return errors.Newf("no handler registered for handler name: %s", job.HandlerName)
+	return errors.Wrapf(ErrHandlerNotRegistered, "%s", job.HandlerName)
 }

--- a/pulse/async/worker.go
+++ b/pulse/async/worker.go
@@ -584,6 +584,17 @@ func (wp *WorkerPool) processNextJob() error {
 			}
 			return nil // Return nil to avoid logging as error
 		default:
+			// Handler not registered yet (e.g. plugins still loading) — re-queue
+			if errors.Is(err, ErrHandlerNotRegistered) {
+				wp.logger.SugaredLogger.Debugw("Handler not registered yet, re-queuing job",
+					"job_id", job.ID, "handler", job.HandlerName)
+				job.Status = JobStatusQueued
+				if updateErr := wp.queue.UpdateJob(job); updateErr != nil {
+					wp.logger.SugaredLogger.Errorw("Failed to re-queue job for missing handler",
+						"job_id", job.ID, "error", updateErr)
+				}
+				return nil
+			}
 			// Real error - fail the job
 			return errors.Wrapf(wp.queue.FailJob(job.ID, err), "failed to mark job %s as failed (handler: %s)", job.ID, job.HandlerName)
 		}


### PR DESCRIPTION
## Summary

- Multiple plugins declaring the same handler name (e.g. `route-changed`) caused a panic at boot
- Registry keys are now `pluginName/handlerName`, constructed by `PluginHandlerName()` — single source of truth
- Stale un-namespaced schedules are pruned on boot
- Jobs dispatched before handlers are registered are re-queued instead of permanently failed

## Test plan

- [x] `make test` passes (Go + 663 frontend tests)
- [x] `TestTwoPluginsSameHandlerName` proves two plugins with same raw handler name coexist
- [x] Verified in `make dev`: no panic, stale schedule pruned, `duif/poll_inbox` runs correctly