### PR TITLE
Extract remaining embedding code into server/embeddings/

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -27,6 +27,6 @@ there is this thing called typegen that generates the api documentation, you can
 
 ## Embeddings Sub-package (`server/embeddings/`)
 
-The embedding handlers (semantic search, clustering, projection, observer) are being extracted from the server root into `server/embeddings/`. The server currently has ~2,600 lines of embedding code scattered across 6 files, all behind the `cgo && rustembeddings` build tag.
+Embedding code lives in `server/embeddings/` — HTTP handlers, clustering logic, projection, the auto-embed observer. The server root keeps only thin wiring: `SetupEmbeddingService` (populates server fields), `callReducePlugin`/`projectToCanvas` (plugin registry coupling, passed as callbacks), and schedule setup methods that register Pulse handlers.
 
-The `embeddingService` interface in QNTXServer already defines the contract. The extraction creates an `EmbeddingsHandler` struct that receives its dependencies (db, store, service, atsStore, logger) at construction — same pattern as `canvasHandler`. The server wires it up in init and delegates HTTP handlers to it.
+Everything else — the actual domain logic — lives in the sub-package. Handler struct receives dependencies at construction (same pattern as canvasHandler). Pulse functions (`RunHDBSCANClustering`, `RunAllProjections`) take all deps as explicit params, no server coupling. The observer is self-contained with callback hooks for watcher integration and projection.

--- a/server/embeddings/cluster_handler.go
+++ b/server/embeddings/cluster_handler.go
@@ -1,6 +1,6 @@
 //go:build cgo && rustembeddings
 
-package server
+package embeddings
 
 import (
 	"encoding/json"
@@ -12,27 +12,27 @@ import (
 	"github.com/teranos/QNTX/ats/storage"
 )
 
-// ClusterRequest represents a clustering API request
+// ClusterRequest represents a clustering API request.
 type ClusterRequest struct {
 	MinClusterSize        int      `json:"min_cluster_size,omitempty"`
 	ClusterThreshold      *float64 `json:"cluster_threshold,omitempty"`
 	ClusterMatchThreshold *float64 `json:"cluster_match_threshold,omitempty"`
 }
 
-// ClusterResponse represents the result of a clustering operation
+// ClusterResponse represents the result of a clustering operation.
 type ClusterResponse struct {
 	Summary *storage.ClusterSummary `json:"summary"`
 	TimeMS  float64                 `json:"time_ms"`
 }
 
-// HandleEmbeddingCluster runs HDBSCAN clustering on all stored embeddings (POST /api/embeddings/cluster)
-func (s *QNTXServer) HandleEmbeddingCluster(w http.ResponseWriter, r *http.Request) {
+// HandleCluster runs HDBSCAN clustering on all stored embeddings (POST /api/embeddings/cluster).
+func (h *Handler) HandleCluster(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	if s.embeddingService == nil || s.embeddingStore == nil {
+	if h.Service == nil || h.Store == nil {
 		http.Error(w, "Embedding service not available", http.StatusServiceUnavailable)
 		return
 	}
@@ -60,18 +60,19 @@ func (s *QNTXServer) HandleEmbeddingCluster(w http.ResponseWriter, r *http.Reque
 	projectCtx := "project:" + filepath.Join(filepath.Base(filepath.Dir(cwd)), filepath.Base(cwd))
 
 	result, err := RunHDBSCANClustering(
-		s.embeddingStore,
-		s.embeddingService,
-		s.embeddingClusterInvalidator,
+		h.Store,
+		h.Service,
+		h.Invalidator,
 		minClusterSize,
 		clusterMatchThreshold,
-		s.atsStore,
+		h.ATSStore,
 		projectCtx,
-		s.groundDBPath,
-		s.logger,
+		h.GroundDBPath,
+		h.GroundWrite,
+		h.Logger,
 	)
 	if err != nil {
-		s.logger.Errorw("HDBSCAN clustering failed", "error", err)
+		h.Logger.Errorw("HDBSCAN clustering failed", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -79,17 +80,17 @@ func (s *QNTXServer) HandleEmbeddingCluster(w http.ResponseWriter, r *http.Reque
 	// Persist parameters only after successful clustering
 	if req.MinClusterSize > 0 {
 		if err := appcfg.UpdateEmbeddingsMinClusterSize(req.MinClusterSize); err != nil {
-			s.logger.Warnw("Failed to persist min_cluster_size", "error", err)
+			h.Logger.Warnw("Failed to persist min_cluster_size", "error", err)
 		}
 	}
 	if req.ClusterThreshold != nil {
 		if err := appcfg.UpdateEmbeddingsClusterThreshold(*req.ClusterThreshold); err != nil {
-			s.logger.Warnw("Failed to persist cluster_threshold", "error", err)
+			h.Logger.Warnw("Failed to persist cluster_threshold", "error", err)
 		}
 	}
 	if req.ClusterMatchThreshold != nil {
 		if err := appcfg.UpdateEmbeddingsClusterMatchThreshold(*req.ClusterMatchThreshold); err != nil {
-			s.logger.Warnw("Failed to persist cluster_match_threshold", "error", err)
+			h.Logger.Warnw("Failed to persist cluster_match_threshold", "error", err)
 		}
 	}
 
@@ -100,6 +101,6 @@ func (s *QNTXServer) HandleEmbeddingCluster(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		s.logger.Errorw("Failed to encode cluster response", "error", err)
+		h.Logger.Errorw("Failed to encode cluster response", "error", err)
 	}
 }

--- a/server/embeddings/clustering.go
+++ b/server/embeddings/clustering.go
@@ -1,0 +1,599 @@
+//go:build cgo && rustembeddings
+
+package embeddings
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/teranos/QNTX/ats"
+	"github.com/teranos/QNTX/ats/attrs"
+	"github.com/teranos/QNTX/ats/embeddings/embeddings"
+	"github.com/teranos/QNTX/ats/identity"
+	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/errors"
+	vanity "github.com/teranos/vanity-id"
+	"go.uber.org/zap"
+)
+
+// EmbeddingClusterResult holds the outcome of a clustering run.
+type EmbeddingClusterResult struct {
+	Summary *storage.ClusterSummary
+	TimeMS  float64
+}
+
+// clusterMatchResult holds the output of stable cluster matching.
+type clusterMatchResult struct {
+	mapping map[int]int // hdbscan_label → stable_id
+	events  []storage.ClusterEvent
+}
+
+// cosineSimilarityF32 computes cosine similarity between two float32 slices.
+func cosineSimilarityF32(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		fa, fb := float64(a[i]), float64(b[i])
+		dot += fa * fb
+		normA += fa * fa
+		normB += fb * fb
+	}
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0
+	}
+	return dot / denom
+}
+
+// matchClusters matches new HDBSCAN centroids against previous centroids by cosine similarity.
+// Returns a mapping from raw HDBSCAN label to stable cluster ID, plus lifecycle events.
+// The cluster_runs row for runID must already exist (FK constraint).
+func matchClusters(
+	runID string,
+	oldCentroids []storage.ClusterCentroid,
+	newCentroids [][]float32,
+	threshold float64,
+	store *storage.EmbeddingStore,
+	svc EmbeddingServiceForClustering,
+	logger *zap.SugaredLogger,
+) (*clusterMatchResult, error) {
+	result := &clusterMatchResult{
+		mapping: make(map[int]int, len(newCentroids)),
+	}
+
+	// First run or no old centroids: all births
+	if len(oldCentroids) == 0 {
+		for i := range newCentroids {
+			stableID, err := store.CreateCluster(runID)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to create cluster for HDBSCAN label %d", i)
+			}
+			result.mapping[i] = stableID
+			result.events = append(result.events, storage.ClusterEvent{
+				RunID:     runID,
+				EventType: "birth",
+				ClusterID: stableID,
+			})
+		}
+		logger.Infow("First clustering run: all births",
+			"run_id", runID,
+			"n_births", len(newCentroids))
+		return result, nil
+	}
+
+	// Deserialize old centroids
+	oldVecs := make([][]float32, len(oldCentroids))
+	for i, oc := range oldCentroids {
+		vec, err := svc.DeserializeEmbedding(oc.Centroid)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to deserialize old centroid for cluster %d", oc.ClusterID)
+		}
+		oldVecs[i] = vec
+	}
+
+	// Build similarity pairs
+	type simPair struct {
+		newIdx int
+		oldIdx int
+		sim    float64
+	}
+	var pairs []simPair
+	for ni, nv := range newCentroids {
+		for oi, ov := range oldVecs {
+			sim := cosineSimilarityF32(nv, ov)
+			if sim >= threshold {
+				pairs = append(pairs, simPair{ni, oi, sim})
+			}
+		}
+	}
+
+	// Greedy best-first matching
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].sim > pairs[j].sim })
+
+	usedNew := make(map[int]bool)
+	usedOld := make(map[int]bool)
+
+	for _, p := range pairs {
+		if usedNew[p.newIdx] || usedOld[p.oldIdx] {
+			continue
+		}
+		usedNew[p.newIdx] = true
+		usedOld[p.oldIdx] = true
+
+		stableID := oldCentroids[p.oldIdx].ClusterID
+		result.mapping[p.newIdx] = stableID
+
+		sim := p.sim
+		result.events = append(result.events, storage.ClusterEvent{
+			RunID:      runID,
+			EventType:  "stable",
+			ClusterID:  stableID,
+			Similarity: &sim,
+		})
+
+		if err := store.UpdateClusterLastSeen(stableID, runID); err != nil {
+			return nil, errors.Wrapf(err, "failed to update last_seen for cluster %d", stableID)
+		}
+	}
+
+	// Unmatched new → birth
+	for i := range newCentroids {
+		if usedNew[i] {
+			continue
+		}
+		stableID, err := store.CreateCluster(runID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create cluster for unmatched HDBSCAN label %d", i)
+		}
+		result.mapping[i] = stableID
+		result.events = append(result.events, storage.ClusterEvent{
+			RunID:     runID,
+			EventType: "birth",
+			ClusterID: stableID,
+		})
+	}
+
+	// Unmatched old → death
+	for i, oc := range oldCentroids {
+		if usedOld[i] {
+			continue
+		}
+		if err := store.DissolveCluster(oc.ClusterID, runID); err != nil {
+			return nil, errors.Wrapf(err, "failed to dissolve cluster %d", oc.ClusterID)
+		}
+		result.events = append(result.events, storage.ClusterEvent{
+			RunID:     runID,
+			EventType: "death",
+			ClusterID: oc.ClusterID,
+		})
+	}
+
+	var nStable, nBirth, nDeath int
+	for _, ev := range result.events {
+		switch ev.EventType {
+		case "stable":
+			nStable++
+		case "birth":
+			nBirth++
+		case "death":
+			nDeath++
+		}
+	}
+	logger.Infow("Cluster matching complete",
+		"run_id", runID,
+		"stable", nStable,
+		"births", nBirth,
+		"deaths", nDeath)
+
+	return result, nil
+}
+
+// RunHDBSCANClustering executes HDBSCAN on all stored embeddings, matches new clusters
+// against previous centroids for stable identity, and writes results to DB.
+// Shared by the HTTP handler and the Pulse recluster handler.
+func RunHDBSCANClustering(
+	store *storage.EmbeddingStore,
+	svc EmbeddingServiceForClustering,
+	invalidator func(),
+	minClusterSize int,
+	clusterMatchThreshold float64,
+	atsStore ats.AttestationStore,
+	projectCtx string,
+	groundDBPath string,
+	groundWrite GroundWriteFunc,
+	logger *zap.SugaredLogger,
+) (*EmbeddingClusterResult, error) {
+	startTime := time.Now()
+
+	// Sweep stale embeddings before clustering so HDBSCAN operates on clean data
+	swept, err := store.SweepStaleEmbeddings()
+	if err != nil {
+		logger.Warnw("Stale embedding sweep failed, continuing with clustering", "error", err)
+	} else if swept > 0 {
+		logger.Infow("Swept stale embeddings before clustering", "count", swept)
+	}
+
+	// Read all embedding vectors
+	ids, blobs, err := store.GetAllEmbeddingVectors()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read embedding vectors for clustering")
+	}
+
+	if len(ids) < 2 {
+		return nil, errors.Newf("need at least 2 embeddings to cluster, have %d", len(ids))
+	}
+
+	// Deserialize blobs into flat float32 array
+	var dims int
+	flat := make([]float32, 0, len(blobs)*384) // pre-allocate assuming 384d
+	for i, blob := range blobs {
+		vec, err := svc.DeserializeEmbedding(blob)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to deserialize embedding %s (blob_len=%d)", ids[i], len(blob))
+		}
+		if i == 0 {
+			dims = len(vec)
+		}
+		flat = append(flat, vec...)
+	}
+
+	// Run HDBSCAN
+	result, err := embeddings.ClusterHDBSCAN(flat, len(ids), dims, minClusterSize)
+	if err != nil {
+		return nil, errors.Wrapf(err, "HDBSCAN failed (n_points=%d, dims=%d, min_cluster_size=%d)", len(ids), dims, minClusterSize)
+	}
+
+	// Create run record first — clusters and events reference it via FK
+	runID, _ := vanity.GenerateRandomID(12)
+	runID = "CR_" + runID
+	clusterRun := &storage.ClusterRun{
+		ID:             runID,
+		NPoints:        len(ids),
+		NClusters:      result.NClusters,
+		NNoise:         result.NNoise,
+		MinClusterSize: minClusterSize,
+		DurationMS:     0, // updated at end
+		CreatedAt:      time.Now().UTC(),
+	}
+	if err := store.CreateClusterRun(clusterRun); err != nil {
+		return nil, errors.Wrapf(err, "failed to create cluster run %s", runID)
+	}
+
+	// Load previous centroids for stable matching
+	oldCentroids, err := store.GetAllClusterCentroids()
+	if err != nil {
+		logger.Warnw("Failed to load old centroids for matching, treating as first run", "error", err)
+		oldCentroids = nil
+	}
+
+	// Match new centroids against old for stable identity
+	matchResult, err := matchClusters(runID, oldCentroids, result.Centroids, clusterMatchThreshold, store, svc, logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "cluster matching failed")
+	}
+
+	// Build assignments using stable IDs (mapping[rawLabel] instead of raw labels)
+	assignments := make([]storage.ClusterAssignment, len(ids))
+	memberCounts := make(map[int]int) // stable_id → count
+	for i, id := range ids {
+		rawLabel := int(result.Labels[i])
+		stableID := rawLabel // default: keep raw (-1 stays -1)
+		if rawLabel >= 0 {
+			if mapped, ok := matchResult.mapping[rawLabel]; ok {
+				stableID = mapped
+			}
+			memberCounts[stableID]++
+		}
+		assignments[i] = storage.ClusterAssignment{
+			ID:          id,
+			ClusterID:   stableID,
+			Probability: float64(result.Probabilities[i]),
+		}
+	}
+
+	if err := store.UpdateClusterAssignments(assignments); err != nil {
+		return nil, errors.Wrapf(err, "failed to save %d cluster assignments", len(assignments))
+	}
+
+	// Save cluster centroids with stable IDs (PredictCluster keeps working)
+	if len(result.Centroids) > 0 {
+		centroidModels := make([]storage.ClusterCentroid, 0, len(result.Centroids))
+		snapshots := make([]storage.ClusterSnapshot, 0, len(result.Centroids))
+
+		for rawLabel, centroid := range result.Centroids {
+			blob, err := svc.SerializeEmbedding(centroid)
+			if err != nil {
+				logger.Errorw("Failed to serialize centroid",
+					"raw_label", rawLabel,
+					"error", err)
+				continue
+			}
+
+			stableID := matchResult.mapping[rawLabel]
+			centroidModels = append(centroidModels, storage.ClusterCentroid{
+				ClusterID: stableID,
+				Centroid:  blob,
+				NMembers:  memberCounts[stableID],
+			})
+			snapshots = append(snapshots, storage.ClusterSnapshot{
+				ClusterID: stableID,
+				RunID:     runID,
+				Centroid:  blob,
+				NMembers:  memberCounts[stableID],
+			})
+		}
+
+		if err := store.SaveClusterCentroids(centroidModels); err != nil {
+			logger.Errorw("Failed to save cluster centroids",
+				"count", len(centroidModels),
+				"error", err)
+		}
+
+		// Add zero-member snapshots for dissolved clusters so timeline shows deaths
+		for _, ev := range matchResult.events {
+			if ev.EventType == "death" {
+				snapshots = append(snapshots, storage.ClusterSnapshot{
+					ClusterID: ev.ClusterID,
+					RunID:     runID,
+					Centroid:  []byte{},
+					NMembers:  0,
+				})
+			}
+		}
+
+		if err := store.SaveClusterSnapshots(snapshots); err != nil {
+			logger.Errorw("Failed to save cluster snapshots",
+				"count", len(snapshots),
+				"error", err)
+		}
+
+		if invalidator != nil {
+			invalidator()
+		}
+	}
+
+	// Record events and update run duration
+	timeMS := float64(time.Since(startTime).Milliseconds())
+
+	if err := store.UpdateClusterRunDuration(runID, int(timeMS)); err != nil {
+		logger.Errorw("Failed to update cluster run duration", "run_id", runID, "error", err)
+	}
+
+	if err := store.RecordClusterEvents(matchResult.events); err != nil {
+		logger.Errorw("Failed to record cluster events", "run_id", runID, "error", err)
+	}
+
+	if atsStore != nil {
+		for _, ev := range matchResult.events {
+			if ev.EventType == "stable" {
+				continue
+			}
+			emitClusterLifecycleAttestation(atsStore, ev, memberCounts[ev.ClusterID], runID, projectCtx, logger)
+		}
+		emitClusterDeferredNews(store, atsStore, matchResult.events, memberCounts, swept, runID, projectCtx, groundDBPath, groundWrite, logger)
+	}
+
+	summary, err := store.GetClusterSummary()
+	if err != nil {
+		return nil, errors.Wrap(err, "clustering succeeded but failed to read summary")
+	}
+
+	logger.Infow("HDBSCAN clustering complete",
+		"run_id", runID,
+		"n_points", len(ids),
+		"n_clusters", result.NClusters,
+		"n_noise", result.NNoise,
+		"min_cluster_size", minClusterSize,
+		"time_ms", timeMS)
+
+	return &EmbeddingClusterResult{
+		Summary: summary,
+		TimeMS:  timeMS,
+	}, nil
+}
+
+type clusterLifecycleAttrs struct {
+	RunID    string `attr:"run_id"`
+	NMembers int    `attr:"n_members,omitempty"`
+}
+
+func emitClusterLifecycleAttestation(atsStore ats.AttestationStore, ev storage.ClusterEvent, nMembers int, runID string, projectCtx string, logger *zap.SugaredLogger) {
+	predicate := ev.EventType
+	if ev.EventType == "birth" {
+		predicate = "born"
+	} else if ev.EventType == "death" {
+		predicate = "died"
+	}
+
+	subject := fmt.Sprintf("cluster:%d", ev.ClusterID)
+	asid, err := identity.GenerateASUID("AS", subject, predicate, projectCtx)
+	if err != nil {
+		logger.Warnw("Failed to generate ASID for cluster lifecycle attestation",
+			"cluster_id", ev.ClusterID, "event", ev.EventType, "error", err)
+		return
+	}
+
+	now := time.Now()
+	as := &types.As{
+		ID:         asid,
+		Subjects:   []string{subject},
+		Predicates: []string{predicate},
+		Contexts:   []string{projectCtx},
+		Actors:     []string{"qntx@embeddings"},
+		Timestamp:  now,
+		Source:     "cluster-lifecycle",
+		Attributes: attrs.From(clusterLifecycleAttrs{
+			RunID:    runID,
+			NMembers: nMembers,
+		}),
+		CreatedAt: now,
+	}
+
+	if err := atsStore.CreateAttestation(as); err != nil {
+		logger.Warnw("Failed to create cluster lifecycle attestation",
+			"cluster_id", ev.ClusterID, "event", predicate, "asid", asid, "error", err)
+	} else {
+		logger.Infow("Created cluster lifecycle attestation",
+			"asid", asid, "cluster_id", ev.ClusterID, "event", predicate)
+	}
+}
+
+// getUndeliveredDetail returns the detail text from the most recent undelivered
+// deferred:cluster-update attestation. Returns empty string if all news has been
+// delivered or no prior news exists.
+//
+// Delivery acks are written by Ground into Ground's DB, so we check there.
+func getUndeliveredDetail(atsStore ats.AttestationStore, projectCtx string, groundDBPath string) string {
+	// Find the latest deferred:cluster-update in QNTX's store
+	deferred, err := atsStore.GetAttestations(ats.AttestationFilter{
+		Predicates: []string{"deferred:cluster-update"},
+		Contexts:   []string{projectCtx},
+		Limit:      1,
+	})
+	if err != nil || len(deferred) == 0 {
+		return ""
+	}
+
+	// Check Ground's DB for delivery ack
+	if groundDBPath != "" {
+		db, err := sql.Open("sqlite3", groundDBPath+"?_journal_mode=WAL&_busy_timeout=5000&mode=ro")
+		if err == nil {
+			defer db.Close()
+			var ackTS string
+			err = db.QueryRow(`SELECT timestamp FROM attestations
+				WHERE predicates LIKE '%delivered:cluster-update%'
+				AND contexts LIKE ?
+				ORDER BY rowid DESC LIMIT 1`, "%"+projectCtx+"%").Scan(&ackTS)
+			if err == nil {
+				// Ack exists — news was delivered
+				return ""
+			}
+		}
+	}
+
+	// Extract detail from the undelivered news
+	if detail, ok := deferred[0].Attributes["detail"].(string); ok {
+		return detail
+	}
+	return ""
+}
+
+// emitClusterDeferredNews writes a deferred message attestation for Ground to pick up
+// on Stop. If there's undelivered news from a previous run, accumulates by prepending it.
+func emitClusterDeferredNews(embStore *storage.EmbeddingStore, atsStore ats.AttestationStore, events []storage.ClusterEvent, memberCounts map[int]int, staleSwept int, runID string, projectCtx string, groundDBPath string, groundWrite GroundWriteFunc, logger *zap.SugaredLogger) {
+	type birthInfo struct {
+		clusterID int
+		nMembers  int
+	}
+	var births []birthInfo
+	var deaths []int
+
+	for _, ev := range events {
+		switch ev.EventType {
+		case "birth":
+			births = append(births, birthInfo{ev.ClusterID, memberCounts[ev.ClusterID]})
+		case "death":
+			deaths = append(deaths, ev.ClusterID)
+		}
+	}
+	if len(births) == 0 && len(deaths) == 0 && staleSwept == 0 {
+		return
+	}
+
+	// Sort births by member count descending — show the biggest first
+	sort.Slice(births, func(i, j int) bool { return births[i].nMembers > births[j].nMembers })
+
+	var detail string
+
+	// Header
+	switch {
+	case len(births) > 0 && len(deaths) > 0:
+		detail = fmt.Sprintf("Embedding topology: %d born, %d died.", len(births), len(deaths))
+	case len(births) > 0:
+		detail = fmt.Sprintf("%d new cluster(s) emerged.", len(births))
+	case len(deaths) > 0:
+		detail = fmt.Sprintf("%d cluster(s) dissolved.", len(deaths))
+	}
+
+	// Show all births with sample texts
+	for _, b := range births {
+		detail += fmt.Sprintf(" cluster:%d (%d members)", b.clusterID, b.nMembers)
+		samples, err := embStore.SampleClusterTexts(b.clusterID, 2)
+		if err == nil && len(samples) > 0 {
+			detail += " — "
+			for j, s := range samples {
+				if len(s) > 60 {
+					s = s[:60] + "..."
+				}
+				if j > 0 {
+					detail += "; "
+				}
+				detail += s
+			}
+		}
+		detail += "."
+	}
+
+	// Deaths
+	if len(deaths) > 0 {
+		detail += " Dissolved: "
+		for i, d := range deaths {
+			if i > 0 {
+				detail += ", "
+			}
+			detail += fmt.Sprintf("cluster:%d", d)
+		}
+		detail += "."
+	}
+
+	if staleSwept > 0 {
+		detail += fmt.Sprintf(" Swept %d stale embeddings (source attestations deleted).", staleSwept)
+	}
+
+	// Accumulate: if there's undelivered news from a previous run, prepend it
+	if prior := getUndeliveredDetail(atsStore, projectCtx, groundDBPath); prior != "" {
+		detail = prior + " " + detail
+		logger.Infow("Accumulating with undelivered prior news")
+	}
+
+	asid, err := identity.GenerateASUID("AS", "embeddings", "deferred:cluster-update", projectCtx)
+	if err != nil {
+		logger.Warnw("Failed to generate ASID for cluster deferred news", "error", err)
+		return
+	}
+
+	now := time.Now()
+	as := &types.As{
+		ID:         asid,
+		Subjects:   []string{"embeddings"},
+		Predicates: []string{"deferred:cluster-update"},
+		Contexts:   []string{projectCtx},
+		Actors:     []string{"qntx@embeddings"},
+		Timestamp:  now,
+		Source:     "cluster-lifecycle",
+		Attributes: map[string]any{
+			"event":  "cluster-update",
+			"detail": detail,
+			"after":  now.Unix(),
+		},
+		CreatedAt: now,
+	}
+
+	if err := atsStore.CreateAttestation(as); err != nil {
+		logger.Warnw("Failed to create cluster deferred news",
+			"asid", asid, "error", err)
+	} else {
+		logger.Infow("Deferred cluster news for Ground",
+			"asid", asid, "births", len(births), "deaths", len(deaths))
+	}
+
+	if groundWrite != nil {
+		groundWrite(groundDBPath, as, logger)
+	}
+}

--- a/server/embeddings/handler.go
+++ b/server/embeddings/handler.go
@@ -32,14 +32,20 @@ type Service interface {
 // ReduceFunc calls the reduce plugin via gRPC for projection operations.
 type ReduceFunc func(ctx context.Context, method, path string, body []byte) ([]byte, error)
 
+// GroundWriteFunc writes an attestation to Ground's standalone database.
+type GroundWriteFunc func(dbPath string, as *types.As, logger *zap.SugaredLogger)
+
 // Handler handles HTTP requests for the embedding service.
 type Handler struct {
-	DB          *sql.DB
-	Store       *storage.EmbeddingStore
-	Service     Service
-	ATSStore    ats.AttestationStore
-	Logger      *zap.SugaredLogger
-	CallReduce  ReduceFunc // optional: for projection via reduce plugin
+	DB           *sql.DB
+	Store        *storage.EmbeddingStore
+	Service      Service
+	ATSStore     ats.AttestationStore
+	Logger       *zap.SugaredLogger
+	CallReduce   ReduceFunc      // optional: for projection via reduce plugin
+	Invalidator  func()          // cluster cache invalidation callback
+	GroundDBPath string          // for cluster lifecycle attestations
+	GroundWrite  GroundWriteFunc // writes deferred news to Ground's DB
 }
 
 // getAttestationByID retrieves a single attestation through the attestation store (Rust FFI).

--- a/server/embeddings/observer.go
+++ b/server/embeddings/observer.go
@@ -1,0 +1,313 @@
+//go:build cgo && rustembeddings
+
+package embeddings
+
+import (
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/teranos/QNTX/ats/embeddings/embeddings"
+	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/errors"
+	"go.uber.org/zap"
+)
+
+// EmbeddingObserver automatically embeds attestations that contain rich text.
+// Implements storage.AttestationObserver — called asynchronously in a goroutine
+// by notifyObservers, so errors are logged but don't block attestation creation.
+// Only attestations with non-empty rich string fields (message, description, etc.)
+// trigger embedding; structural-only attestations are silently skipped.
+type EmbeddingObserver struct {
+	embeddingService interface {
+		GenerateEmbedding(text string) (*embeddings.EmbeddingResult, error)
+		SerializeEmbedding(embedding []float32) ([]byte, error)
+		DeserializeEmbedding(data []byte) ([]float32, error)
+		ComputeSimilarity(a, b []float32) (float32, error)
+		GetModelInfo() (*embeddings.ModelInfo, error)
+	}
+	embeddingStore   *storage.EmbeddingStore
+	richStore        *storage.BoundedStore // Reused across calls for 5-min rich field cache
+	logger           *zap.SugaredLogger
+	clusterMu        sync.RWMutex
+	clusterCache     []storage.ClusterCentroid // loaded once, refreshed on re-cluster
+	clusterThreshold float32                   // minimum similarity for cluster assignment
+	projectFunc      func(embeddingID string, embedding []float32)
+
+	// onEmbedded is called after an attestation is successfully embedded and stored.
+	// The watcher engine uses this to run semantic matching with the pre-computed
+	// embedding, eliminating redundant GenerateEmbedding FFI calls.
+	onEmbedded func(as *types.As, embedding []float32)
+
+	// Periodic summary counters (drained by ticker)
+	embedded      atomic.Int64
+	clusterHits   sync.Map // cluster display name (string) → *atomic.Int64
+	clusterNoise  atomic.Int64
+	clusterLabels sync.Map // cluster_id (int) → label (string), refreshed with centroid cache
+}
+
+// NewEmbeddingObserver creates an observer with the given dependencies.
+func NewEmbeddingObserver(
+	svc interface {
+		GenerateEmbedding(text string) (*embeddings.EmbeddingResult, error)
+		SerializeEmbedding(embedding []float32) ([]byte, error)
+		DeserializeEmbedding(data []byte) ([]float32, error)
+		ComputeSimilarity(a, b []float32) (float32, error)
+		GetModelInfo() (*embeddings.ModelInfo, error)
+	},
+	embStore *storage.EmbeddingStore,
+	richStore *storage.BoundedStore,
+	logger *zap.SugaredLogger,
+	clusterThreshold float32,
+	projectFunc func(embeddingID string, embedding []float32),
+) *EmbeddingObserver {
+	return &EmbeddingObserver{
+		embeddingService: svc,
+		embeddingStore:   embStore,
+		richStore:        richStore,
+		logger:           logger,
+		clusterThreshold: clusterThreshold,
+		projectFunc:      projectFunc,
+	}
+}
+
+// SetOnEmbedded sets the callback invoked after successful embedding storage.
+func (o *EmbeddingObserver) SetOnEmbedded(fn func(as *types.As, embedding []float32)) {
+	o.onEmbedded = fn
+}
+
+// InvalidateClusterCache clears cached centroids so the next prediction reloads from DB.
+func (o *EmbeddingObserver) InvalidateClusterCache() {
+	o.clusterMu.Lock()
+	o.clusterCache = nil
+	o.clusterMu.Unlock()
+}
+
+// OnAttestationCreated selectively embeds attestations with rich text content.
+func (o *EmbeddingObserver) OnAttestationCreated(as *types.As) {
+	text := o.extractRichText(as)
+	if text == "" {
+		return
+	}
+
+	// Check if already embedded
+	existing, err := o.embeddingStore.GetBySource("attestation", as.ID)
+	if err != nil {
+		o.logger.Warnw("Failed to check existing embedding",
+			"error", errors.Wrapf(err, "attestation %s", as.ID))
+		return
+	}
+	if existing != nil {
+		return
+	}
+
+	// Generate embedding via Rust FFI (~80ms)
+	result, err := o.embeddingService.GenerateEmbedding(text)
+	if err != nil {
+		o.logger.Warnw("Failed to generate embedding",
+			"error", errors.Wrapf(err, "attestation %s (%d chars)", as.ID, len(text)))
+		return
+	}
+
+	blob, err := o.embeddingService.SerializeEmbedding(result.Embedding)
+	if err != nil {
+		o.logger.Warnw("Failed to serialize embedding",
+			"error", errors.Wrapf(err, "attestation %s (%d dimensions)", as.ID, len(result.Embedding)))
+		return
+	}
+
+	modelInfo, err := o.embeddingService.GetModelInfo()
+	if err != nil {
+		o.logger.Warnw("Failed to get model info",
+			"error", errors.Wrapf(err, "attestation %s", as.ID))
+		return
+	}
+
+	model := &storage.EmbeddingModel{
+		SourceType: "attestation",
+		SourceID:   as.ID,
+		Text:       text,
+		Embedding:  blob,
+		Model:      modelInfo.Name,
+		Dimensions: modelInfo.Dimensions,
+	}
+	if err := o.embeddingStore.Save(model); err != nil {
+		o.logger.Warnw("Failed to save embedding",
+			"error", errors.Wrapf(err, "attestation %s", as.ID))
+		return
+	}
+
+	o.embedded.Add(1)
+
+	o.logger.Debugw("Auto-embedded attestation",
+		"attestation_id", as.ID,
+		"text_length", len(text),
+		"inference_ms", result.InferenceMS)
+
+	// Notify watcher engine with the pre-computed embedding for semantic matching
+	if o.onEmbedded != nil {
+		o.onEmbedded(as, result.Embedding)
+	}
+
+	// Predict cluster assignment for the new embedding
+	o.predictCluster(model.ID, as.ID, result.Embedding)
+
+	// Project to 2D canvas if reduce plugin is available
+	if o.projectFunc != nil {
+		o.projectFunc(model.ID, result.Embedding)
+	}
+}
+
+// predictCluster assigns the embedding to the nearest cluster centroid.
+func (o *EmbeddingObserver) predictCluster(embeddingID, attestationID string, embedding []float32) {
+	// Lazy-load centroids from DB
+	o.clusterMu.RLock()
+	centroids := o.clusterCache
+	o.clusterMu.RUnlock()
+
+	if centroids == nil {
+		loaded, err := o.embeddingStore.GetAllClusterCentroids()
+		if err != nil {
+			o.logger.Warnw("Failed to load cluster centroids",
+				"error", errors.Wrapf(err, "attestation %s", attestationID))
+			return
+		}
+		if len(loaded) == 0 {
+			return // no clusters yet
+		}
+		o.clusterMu.Lock()
+		o.clusterCache = loaded
+		o.clusterMu.Unlock()
+		centroids = loaded
+
+		// Refresh cluster label cache
+		o.refreshClusterLabels()
+	}
+
+	clusterID, prob, err := o.embeddingStore.PredictCluster(
+		embedding,
+		centroids,
+		o.embeddingService.DeserializeEmbedding,
+		o.embeddingService.ComputeSimilarity,
+		o.clusterThreshold,
+	)
+	if err != nil {
+		o.logger.Warnw("Failed to predict cluster",
+			"error", errors.Wrapf(err, "attestation %s", attestationID))
+		return
+	}
+
+	if clusterID == storage.ClusterNoise {
+		o.clusterNoise.Add(1)
+		return // below threshold, stays as noise
+	}
+
+	err = o.embeddingStore.UpdateClusterAssignments([]storage.ClusterAssignment{{
+		ID:          embeddingID,
+		ClusterID:   clusterID,
+		Probability: prob,
+	}})
+	if err != nil {
+		o.logger.Warnw("Failed to save predicted cluster assignment",
+			"error", errors.Wrapf(err, "attestation %s embedding %s cluster %d", attestationID, embeddingID, clusterID))
+		return
+	}
+
+	// Track cluster hit for periodic summary
+	name := o.clusterDisplayName(clusterID)
+	val, _ := o.clusterHits.LoadOrStore(name, &atomic.Int64{})
+	val.(*atomic.Int64).Add(1)
+
+	o.logger.Debugw("Predicted cluster for new embedding",
+		"attestation_id", attestationID,
+		"embedding_id", embeddingID,
+		"cluster_id", clusterID,
+		"similarity", prob)
+}
+
+// extractRichText returns the concatenated rich text fields from an attestation's
+// attributes. Returns empty string if no rich text is found — this is the
+// selective gate that prevents embedding structural-only attestations.
+func (o *EmbeddingObserver) extractRichText(as *types.As) string {
+	if as.Attributes == nil || len(as.Attributes) == 0 {
+		return ""
+	}
+
+	richFields := o.richStore.GetDiscoveredRichFields()
+	if len(richFields) == 0 {
+		return ""
+	}
+
+	return ExtractRichTextFromAttributes(as.Attributes, richFields)
+}
+
+// clusterDisplayName returns a human-readable name for a cluster ID.
+// Uses the cached label if available, falls back to "cluster:<id>".
+func (o *EmbeddingObserver) clusterDisplayName(clusterID int) string {
+	if label, ok := o.clusterLabels.Load(clusterID); ok {
+		return label.(string)
+	}
+	return "cluster:" + strconv.Itoa(clusterID)
+}
+
+// refreshClusterLabels loads cluster labels from the DB into the label cache.
+func (o *EmbeddingObserver) refreshClusterLabels() {
+	clusters, err := o.embeddingStore.GetActiveClusterIdentities()
+	if err != nil {
+		o.logger.Debugw("Failed to refresh cluster labels", "error", err)
+		return
+	}
+	for _, c := range clusters {
+		if c.Label != nil && *c.Label != "" {
+			o.clusterLabels.Store(c.ID, *c.Label)
+		}
+	}
+}
+
+// pairCount is a helper for sorting cluster hit counts.
+type pairCount struct {
+	Key   string
+	Count int64
+}
+
+func formatPairCount(pc pairCount) string {
+	return pc.Key + "(" + strconv.FormatInt(pc.Count, 10) + ")"
+}
+
+// DrainEmbeddingCounts atomically reads and resets embedding activity counters.
+// Returns total embedded, cluster assignment breakdown, and noise count.
+func (o *EmbeddingObserver) DrainEmbeddingCounts() (embedded int, clusterCounts []string, noise int) {
+	embedded = int(o.embedded.Swap(0))
+	noise = int(o.clusterNoise.Swap(0))
+
+	var pairs []pairCount
+	o.clusterHits.Range(func(key, value any) bool {
+		count := value.(*atomic.Int64).Swap(0)
+		if count > 0 {
+			pairs = append(pairs, pairCount{Key: key.(string), Count: count})
+		}
+		if count == 0 {
+			o.clusterHits.Delete(key)
+		}
+		return true
+	})
+
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].Count > pairs[j].Count
+	})
+
+	// Show top 5 clusters
+	limit := 5
+	if len(pairs) < limit {
+		limit = len(pairs)
+	}
+	clusterCounts = make([]string, limit)
+	for i := 0; i < limit; i++ {
+		clusterCounts[i] = formatPairCount(pairs[i])
+	}
+
+	return embedded, clusterCounts, noise
+}
+

--- a/server/embeddings/observer_test.go
+++ b/server/embeddings/observer_test.go
@@ -1,6 +1,6 @@
 //go:build cgo && rustembeddings
 
-package server
+package embeddings
 
 import (
 	"encoding/json"

--- a/server/embeddings/project_handler.go
+++ b/server/embeddings/project_handler.go
@@ -1,0 +1,57 @@
+//go:build cgo && rustembeddings
+
+package embeddings
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	appcfg "github.com/teranos/QNTX/am"
+)
+
+// HandleProject runs configured projection methods on all embeddings.
+// POST /api/embeddings/project
+func (h *Handler) HandleProject(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.Service == nil || h.Store == nil {
+		http.Error(w, "Embedding service not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	methods := appcfg.GetStringSlice("embeddings.projection_methods")
+	if len(methods) == 0 {
+		methods = []string{"umap"}
+	}
+
+	var params *ProjectionParams
+	if r.Body != nil {
+		var req ProjectionParams
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+			if req.NNeighbors != nil || req.MinDist != nil || req.Perplexity != nil {
+				params = &req
+			}
+		}
+	}
+
+	startTime := time.Now()
+	results, err := RunAllProjections(r.Context(), methods, h.Store, h.Service, h.CallReduce, h.Logger, params)
+	if err != nil {
+		h.Logger.Errorw("Projection failed", "methods", methods, "error", err)
+		http.Error(w, fmt.Sprintf("Projection failed: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	totalMS := float64(time.Since(startTime).Milliseconds())
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"results":  results,
+		"total_ms": totalMS,
+	})
+}

--- a/server/embeddings/projection.go
+++ b/server/embeddings/projection.go
@@ -1,0 +1,182 @@
+//go:build cgo && rustembeddings
+
+package embeddings
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/errors"
+	"go.uber.org/zap"
+)
+
+// EmbeddingServiceForClustering is the subset of the embedding service needed for clustering and projection.
+type EmbeddingServiceForClustering interface {
+	DeserializeEmbedding(data []byte) ([]float32, error)
+	SerializeEmbedding(embedding []float32) ([]byte, error)
+}
+
+// ProjectionResult holds the outcome of a single-method projection run.
+type ProjectionResult struct {
+	Method  string  `json:"method"`
+	NPoints int     `json:"n_points"`
+	FitMS   int64   `json:"fit_ms"`
+	TimeMS  float64 `json:"time_ms"`
+}
+
+// ProjectionParams holds per-method tuning parameters for dimensionality reduction.
+type ProjectionParams struct {
+	NComponents *int     `json:"n_components,omitempty"` // Output dimensions (default 3)
+	NNeighbors  *int     `json:"n_neighbors,omitempty"`  // UMAP: local vs global (default 15)
+	MinDist     *float64 `json:"min_dist,omitempty"`     // UMAP: cluster tightness (default 0.1)
+	Perplexity  *float64 `json:"perplexity,omitempty"`   // t-SNE: local vs global (default 30)
+}
+
+// validProjectionMethods filters unknown methods, logging warnings for skipped ones.
+var knownMethods = map[string]bool{"umap": true, "tsne": true, "pca": true}
+
+func validProjectionMethods(methods []string, logger *zap.SugaredLogger) []string {
+	var valid []string
+	for _, m := range methods {
+		if knownMethods[m] {
+			valid = append(valid, m)
+		} else {
+			logger.Warnw("Skipping unknown projection method", "method", m)
+		}
+	}
+	return valid
+}
+
+// RunProjection reads all embeddings, calls the reduce plugin /fit for the given method,
+// and writes projections (2D or 3D) to DB.
+func RunProjection(
+	ctx context.Context,
+	method string,
+	store *storage.EmbeddingStore,
+	svc EmbeddingServiceForClustering,
+	callReduce ReduceFunc,
+	logger *zap.SugaredLogger,
+	params *ProjectionParams,
+) (*ProjectionResult, error) {
+	startTime := time.Now()
+
+	ids, blobs, err := store.GetAllEmbeddingVectors()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read embedding vectors for projection")
+	}
+
+	if len(ids) < 2 {
+		return nil, errors.Newf("need at least 2 embeddings to project, have %d", len(ids))
+	}
+
+	allEmbeddings := make([][]float32, 0, len(blobs))
+	for i, blob := range blobs {
+		vec, err := svc.DeserializeEmbedding(blob)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to deserialize embedding %s", ids[i])
+		}
+		allEmbeddings = append(allEmbeddings, vec)
+	}
+
+	fitBody := map[string]any{
+		"embeddings":   allEmbeddings,
+		"method":       method,
+		"n_components": 3,
+	}
+	if params != nil {
+		if params.NComponents != nil {
+			fitBody["n_components"] = *params.NComponents
+		}
+		if params.NNeighbors != nil {
+			fitBody["n_neighbors"] = *params.NNeighbors
+		}
+		if params.MinDist != nil {
+			fitBody["min_dist"] = *params.MinDist
+		}
+		if params.Perplexity != nil {
+			fitBody["perplexity"] = *params.Perplexity
+		}
+	}
+	fitReq, err := json.Marshal(fitBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal fit request")
+	}
+
+	fitResp, err := callReduce(ctx, "POST", "/fit", fitReq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reduce plugin /fit failed for method %s (%d points)", method, len(ids))
+	}
+
+	var fitResult struct {
+		Projections [][]float64 `json:"projections"`
+		NComponents int         `json:"n_components"`
+		NPoints     int         `json:"n_points"`
+		FitMS       int64       `json:"fit_ms"`
+	}
+	if err := json.Unmarshal(fitResp, &fitResult); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse reduce plugin response for method %s", method)
+	}
+
+	if len(fitResult.Projections) != len(ids) {
+		return nil, errors.Newf("projection count mismatch for %s: got %d, expected %d",
+			method, len(fitResult.Projections), len(ids))
+	}
+
+	assignments := make([]storage.ProjectionAssignment, len(ids))
+	for i, id := range ids {
+		p := fitResult.Projections[i]
+		a := storage.ProjectionAssignment{
+			ID: id,
+			X:  p[0],
+			Y:  p[1],
+		}
+		if len(p) >= 3 {
+			z := p[2]
+			a.Z = &z
+		}
+		assignments[i] = a
+	}
+
+	if err := store.UpdateProjections(method, assignments); err != nil {
+		return nil, errors.Wrapf(err, "failed to save %s projections for %d points", method, len(assignments))
+	}
+
+	totalMS := float64(time.Since(startTime).Milliseconds())
+
+	logger.Infow("Projection complete",
+		"method", method,
+		"n_points", len(ids),
+		"fit_ms", fitResult.FitMS,
+		"total_ms", totalMS)
+
+	return &ProjectionResult{
+		Method:  method,
+		NPoints: len(ids),
+		FitMS:   fitResult.FitMS,
+		TimeMS:  totalMS,
+	}, nil
+}
+
+// RunAllProjections runs projection sequentially for each configured method.
+func RunAllProjections(
+	ctx context.Context,
+	methods []string,
+	store *storage.EmbeddingStore,
+	svc EmbeddingServiceForClustering,
+	callReduce ReduceFunc,
+	logger *zap.SugaredLogger,
+	params *ProjectionParams,
+) ([]ProjectionResult, error) {
+	var results []ProjectionResult
+	validated := validProjectionMethods(methods, logger)
+	for _, method := range validated {
+		result, err := RunProjection(ctx, method, store, svc, callReduce, logger, params)
+		if err != nil {
+			return results, errors.Wrapf(err, "projection failed for method %s", method)
+		}
+		results = append(results, *result)
+	}
+	return results, nil
+}

--- a/server/embeddings/pulse.go
+++ b/server/embeddings/pulse.go
@@ -1,0 +1,210 @@
+//go:build cgo && rustembeddings
+
+package embeddings
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/teranos/QNTX/ats"
+	"github.com/teranos/QNTX/ats/identity"
+	"github.com/teranos/QNTX/ats/storage"
+	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/pulse/async"
+	"go.uber.org/zap"
+)
+
+const ReclusterHandlerName = "embeddings.recluster"
+
+// ReclusterHandler runs HDBSCAN re-clustering as a Pulse scheduled job.
+type ReclusterHandler struct {
+	DB                    *sql.DB
+	ProjectCtx            string // e.g. "project:tmp3/QNTX"
+	Store                 *storage.EmbeddingStore
+	Svc                   EmbeddingServiceForClustering
+	ATSStore              ats.AttestationStore
+	Invalidator           func()
+	MinClusterSize        int
+	ClusterMatchThreshold float64
+	GroundDBPath          string
+	GroundWrite           GroundWriteFunc
+	Logger                *zap.SugaredLogger
+}
+
+func (h *ReclusterHandler) Name() string { return ReclusterHandlerName }
+
+func (h *ReclusterHandler) Execute(ctx context.Context, job *async.Job) error {
+	h.writeLog(job.ID, "clustering", "info", "Starting HDBSCAN re-clustering", fmt.Sprintf(`{"min_cluster_size":%d}`, h.MinClusterSize))
+
+	result, err := RunHDBSCANClustering(h.Store, h.Svc, h.Invalidator, h.MinClusterSize, h.ClusterMatchThreshold, h.ATSStore, h.ProjectCtx, h.GroundDBPath, h.GroundWrite, h.Logger)
+	if err != nil {
+		h.writeLog(job.ID, "clustering", "error", fmt.Sprintf("Clustering failed: %s", err), "")
+		EmitPulseDeferredNews(h.DB, h.ATSStore, h.ProjectCtx, h.GroundDBPath, h.GroundWrite, h.Logger)
+		return err
+	}
+
+	h.writeLog(job.ID, "clustering", "info",
+		fmt.Sprintf("Clustering complete: %d points, %d clusters, %d noise, %.0fms",
+			result.Summary.NTotal, result.Summary.NClusters, result.Summary.NNoise, result.TimeMS),
+		fmt.Sprintf(`{"n_points":%d,"n_clusters":%d,"n_noise":%d,"time_ms":%.0f}`,
+			result.Summary.NTotal, result.Summary.NClusters, result.Summary.NNoise, result.TimeMS))
+
+	EmitPulseDeferredNews(h.DB, h.ATSStore, h.ProjectCtx, h.GroundDBPath, h.GroundWrite, h.Logger)
+	return nil
+}
+
+func (h *ReclusterHandler) writeLog(jobID, stage, level, message, metadata string) {
+	var metaPtr *string
+	if metadata != "" {
+		metaPtr = &metadata
+	}
+	_, err := h.DB.Exec(`INSERT INTO task_logs (job_id, stage, timestamp, level, message, metadata) VALUES (?, ?, ?, ?, ?, ?)`,
+		jobID, stage, time.Now().Format(time.RFC3339), level, message, metaPtr)
+	if err != nil {
+		h.Logger.Warnw("Failed to write task log", "job_id", jobID, "error", err)
+	}
+}
+
+const ReprojectHandlerName = "embeddings.reproject"
+
+// ReprojectHandler runs re-projection as a Pulse scheduled job for all configured methods.
+type ReprojectHandler struct {
+	DB         *sql.DB
+	Store      *storage.EmbeddingStore
+	Svc        EmbeddingServiceForClustering
+	CallReduce ReduceFunc
+	Methods    []string
+	Logger     *zap.SugaredLogger
+}
+
+func (h *ReprojectHandler) Name() string { return ReprojectHandlerName }
+
+func (h *ReprojectHandler) Execute(ctx context.Context, job *async.Job) error {
+	h.writeLog(job.ID, "projection", "info",
+		fmt.Sprintf("Starting re-projection for methods: %v", h.Methods), "")
+
+	results, err := RunAllProjections(ctx, h.Methods, h.Store, h.Svc, h.CallReduce, h.Logger, nil)
+	if err != nil {
+		h.writeLog(job.ID, "projection", "error", fmt.Sprintf("Projection failed: %s", err), "")
+		return err
+	}
+
+	for _, r := range results {
+		h.writeLog(job.ID, "projection", "info",
+			fmt.Sprintf("%s complete: %d points, fit %dms, total %.0fms",
+				r.Method, r.NPoints, r.FitMS, r.TimeMS),
+			fmt.Sprintf(`{"method":"%s","n_points":%d,"fit_ms":%d,"time_ms":%.0f}`,
+				r.Method, r.NPoints, r.FitMS, r.TimeMS))
+	}
+	return nil
+}
+
+func (h *ReprojectHandler) writeLog(jobID, stage, level, message, metadata string) {
+	var metaPtr *string
+	if metadata != "" {
+		metaPtr = &metadata
+	}
+	_, err := h.DB.Exec(`INSERT INTO task_logs (job_id, stage, timestamp, level, message, metadata) VALUES (?, ?, ?, ?, ?, ?)`,
+		jobID, stage, time.Now().Format(time.RFC3339), level, message, metaPtr)
+	if err != nil {
+		h.Logger.Warnw("Failed to write task log", "job_id", jobID, "error", err)
+	}
+}
+
+// EmitPulseDeferredNews queries recent Pulse execution stats and writes a deferred
+// news attestation for Ground. Emitted after every recluster run (success or failure)
+// as the recluster heartbeat is the natural place for periodic Pulse health reporting.
+func EmitPulseDeferredNews(db *sql.DB, atsStore ats.AttestationStore, projectCtx string, groundDBPath string, groundWrite GroundWriteFunc, logger *zap.SugaredLogger) {
+	if atsStore == nil {
+		return
+	}
+
+	// Query execution stats from the last 24 hours
+	var completed, failed int
+	var avgDurationMS sql.NullFloat64
+	row := db.QueryRow(`SELECT
+		COUNT(CASE WHEN status = 'completed' THEN 1 END),
+		COUNT(CASE WHEN status = 'failed' THEN 1 END),
+		AVG(CASE WHEN status = 'completed' THEN duration_ms END)
+		FROM pulse_executions
+		WHERE started_at > datetime('now', '-24 hours')`)
+	if err := row.Scan(&completed, &failed, &avgDurationMS); err != nil {
+		logger.Warnw("Failed to query Pulse execution stats", "error", err)
+		return
+	}
+
+	// Query recent failures with handler names
+	var failedHandlers []string
+	rows, err := db.Query(`SELECT DISTINCT s.handler_name
+		FROM pulse_executions e
+		JOIN scheduled_pulse_jobs s ON e.scheduled_job_id = s.id
+		WHERE e.status = 'failed'
+		AND e.started_at > datetime('now', '-24 hours')
+		ORDER BY e.started_at DESC LIMIT 5`)
+	if err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var name string
+			if rows.Scan(&name) == nil {
+				failedHandlers = append(failedHandlers, name)
+			}
+		}
+	}
+
+	total := completed + failed
+	if total == 0 {
+		return // nothing to report
+	}
+
+	// Build summary
+	var detail string
+	if failed == 0 {
+		detail = fmt.Sprintf("Pulse: %d jobs completed (avg %.0fms) in last 24h, no failures",
+			completed, avgDurationMS.Float64)
+	} else {
+		detail = fmt.Sprintf("Pulse: %d/%d jobs failed in last 24h", failed, total)
+		if len(failedHandlers) > 0 {
+			detail += fmt.Sprintf(" — failing: %s", failedHandlers[0])
+			for _, h := range failedHandlers[1:] {
+				detail += ", " + h
+			}
+		}
+	}
+
+	asid, err := identity.GenerateASUID("AS", "pulse", "deferred:pulse-summary", projectCtx)
+	if err != nil {
+		logger.Warnw("Failed to generate ASID for Pulse deferred news", "error", err)
+		return
+	}
+
+	now := time.Now()
+	as := &types.As{
+		ID:         asid,
+		Subjects:   []string{"pulse"},
+		Predicates: []string{"deferred:pulse-summary"},
+		Contexts:   []string{projectCtx},
+		Actors:     []string{"qntx@pulse"},
+		Timestamp:  now,
+		Source:     "pulse-heartbeat",
+		Attributes: map[string]any{
+			"event":  "pulse-summary",
+			"detail": detail,
+			"after":  now.Unix(),
+		},
+		CreatedAt: now,
+	}
+
+	if err := atsStore.CreateAttestation(as); err != nil {
+		logger.Warnw("Failed to create Pulse deferred news",
+			"asid", asid, "error", err)
+	} else {
+		logger.Infow("Deferred Pulse news for Ground",
+			"asid", asid, "completed", completed, "failed", failed)
+	}
+
+	if groundWrite != nil {
+		groundWrite(groundDBPath, as, logger)
+	}
+}

--- a/server/embeddings/stub.go
+++ b/server/embeddings/stub.go
@@ -62,3 +62,13 @@ func (h *Handler) HandleEmbeddingInfo(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) HandleEmbeddingProjections(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, unavailableMsg, http.StatusServiceUnavailable)
 }
+
+// HandleCluster is a no-op when embeddings are not available.
+func (h *Handler) HandleCluster(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, unavailableMsg, http.StatusServiceUnavailable)
+}
+
+// HandleProject is a no-op when embeddings are not available.
+func (h *Handler) HandleProject(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, unavailableMsg, http.StatusServiceUnavailable)
+}

--- a/server/embeddings_handlers.go
+++ b/server/embeddings_handlers.go
@@ -5,24 +5,16 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"os"
-	"sort"
-	"strconv"
-	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	appcfg "github.com/teranos/QNTX/am"
 	"github.com/teranos/QNTX/ats/embeddings/embeddings"
 	"github.com/teranos/QNTX/ats/storage"
-	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
+	serverembeddings "github.com/teranos/QNTX/server/embeddings"
 	grpcplugin "github.com/teranos/QNTX/plugin/grpc"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
-	"go.uber.org/zap"
 )
 
 // SetupEmbeddingService initializes the embedding service if available
@@ -73,20 +65,20 @@ func (s *QNTXServer) SetupEmbeddingService() {
 	s.embeddingStore = embStore
 
 	// Register observer for automatic embedding of attestations with rich text
-	observer := &EmbeddingObserver{
-		embeddingService: embService,
-		embeddingStore:   embStore,
-		richStore:        storage.NewBoundedStore(s.db, nil, s.logger.Named("auto-embed")),
-		logger:           s.logger.Named("auto-embed"),
-		clusterThreshold: float32(appcfg.GetFloat64("embeddings.cluster_threshold")),
-		projectFunc:      s.projectToCanvas,
-	}
+	observer := serverembeddings.NewEmbeddingObserver(
+		embService,
+		embStore,
+		storage.NewBoundedStore(s.db, nil, s.logger.Named("auto-embed")),
+		s.logger.Named("auto-embed"),
+		float32(appcfg.GetFloat64("embeddings.cluster_threshold")),
+		s.projectToCanvas,
+	)
 
 	// Wire semantic watcher matching through the embedding observer.
 	// After embedding, the observer passes the attestation + vector to the watcher
 	// engine — eliminates redundant GenerateEmbedding FFI calls per semantic watcher.
 	if s.watcherEngine != nil {
-		observer.onEmbedded = s.watcherEngine.OnAttestationEmbedded
+		observer.SetOnEmbedded(s.watcherEngine.OnAttestationEmbedded)
 	}
 
 	storage.RegisterObserver(observer)
@@ -102,288 +94,6 @@ func (s *QNTXServer) SetupEmbeddingService() {
 func hasRustEmbeddings() bool {
 	// This function will be overridden by the build tag
 	return true
-}
-
-// EmbeddingObserver automatically embeds attestations that contain rich text.
-// Implements storage.AttestationObserver — called asynchronously in a goroutine
-// by notifyObservers, so errors are logged but don't block attestation creation.
-// Only attestations with non-empty rich string fields (message, description, etc.)
-// trigger embedding; structural-only attestations are silently skipped.
-type EmbeddingObserver struct {
-	embeddingService interface {
-		GenerateEmbedding(text string) (*embeddings.EmbeddingResult, error)
-		SerializeEmbedding(embedding []float32) ([]byte, error)
-		DeserializeEmbedding(data []byte) ([]float32, error)
-		ComputeSimilarity(a, b []float32) (float32, error)
-		GetModelInfo() (*embeddings.ModelInfo, error)
-	}
-	embeddingStore   *storage.EmbeddingStore
-	richStore        *storage.BoundedStore // Reused across calls for 5-min rich field cache
-	logger           *zap.SugaredLogger
-	clusterMu        sync.RWMutex
-	clusterCache     []storage.ClusterCentroid // loaded once, refreshed on re-cluster
-	clusterThreshold float32                   // minimum similarity for cluster assignment
-	projectFunc      func(embeddingID string, embedding []float32)
-
-	// onEmbedded is called after an attestation is successfully embedded and stored.
-	// The watcher engine uses this to run semantic matching with the pre-computed
-	// embedding, eliminating redundant GenerateEmbedding FFI calls.
-	onEmbedded func(as *types.As, embedding []float32)
-
-	// Periodic summary counters (drained by ticker)
-	embedded      atomic.Int64
-	clusterHits   sync.Map // cluster display name (string) → *atomic.Int64
-	clusterNoise  atomic.Int64
-	clusterLabels sync.Map // cluster_id (int) → label (string), refreshed with centroid cache
-}
-
-// InvalidateClusterCache clears cached centroids so the next prediction reloads from DB.
-func (o *EmbeddingObserver) InvalidateClusterCache() {
-	o.clusterMu.Lock()
-	o.clusterCache = nil
-	o.clusterMu.Unlock()
-}
-
-// OnAttestationCreated selectively embeds attestations with rich text content.
-func (o *EmbeddingObserver) OnAttestationCreated(as *types.As) {
-	text := o.extractRichText(as)
-	if text == "" {
-		return
-	}
-
-	// Check if already embedded
-	existing, err := o.embeddingStore.GetBySource("attestation", as.ID)
-	if err != nil {
-		o.logger.Warnw("Failed to check existing embedding",
-			"error", errors.Wrapf(err, "attestation %s", as.ID))
-		return
-	}
-	if existing != nil {
-		return
-	}
-
-	// Generate embedding via Rust FFI (~80ms)
-	result, err := o.embeddingService.GenerateEmbedding(text)
-	if err != nil {
-		o.logger.Warnw("Failed to generate embedding",
-			"error", errors.Wrapf(err, "attestation %s (%d chars)", as.ID, len(text)))
-		return
-	}
-
-	blob, err := o.embeddingService.SerializeEmbedding(result.Embedding)
-	if err != nil {
-		o.logger.Warnw("Failed to serialize embedding",
-			"error", errors.Wrapf(err, "attestation %s (%d dimensions)", as.ID, len(result.Embedding)))
-		return
-	}
-
-	modelInfo, err := o.embeddingService.GetModelInfo()
-	if err != nil {
-		o.logger.Warnw("Failed to get model info",
-			"error", errors.Wrapf(err, "attestation %s", as.ID))
-		return
-	}
-
-	model := &storage.EmbeddingModel{
-		SourceType: "attestation",
-		SourceID:   as.ID,
-		Text:       text,
-		Embedding:  blob,
-		Model:      modelInfo.Name,
-		Dimensions: modelInfo.Dimensions,
-	}
-	if err := o.embeddingStore.Save(model); err != nil {
-		o.logger.Warnw("Failed to save embedding",
-			"error", errors.Wrapf(err, "attestation %s", as.ID))
-		return
-	}
-
-	o.embedded.Add(1)
-
-	o.logger.Debugw("Auto-embedded attestation",
-		"attestation_id", as.ID,
-		"text_length", len(text),
-		"inference_ms", result.InferenceMS)
-
-	// Notify watcher engine with the pre-computed embedding for semantic matching
-	if o.onEmbedded != nil {
-		o.onEmbedded(as, result.Embedding)
-	}
-
-	// Predict cluster assignment for the new embedding
-	o.predictCluster(model.ID, as.ID, result.Embedding)
-
-	// Project to 2D canvas if reduce plugin is available
-	if o.projectFunc != nil {
-		o.projectFunc(model.ID, result.Embedding)
-	}
-}
-
-// predictCluster assigns the embedding to the nearest cluster centroid.
-func (o *EmbeddingObserver) predictCluster(embeddingID, attestationID string, embedding []float32) {
-	// Lazy-load centroids from DB
-	o.clusterMu.RLock()
-	centroids := o.clusterCache
-	o.clusterMu.RUnlock()
-
-	if centroids == nil {
-		loaded, err := o.embeddingStore.GetAllClusterCentroids()
-		if err != nil {
-			o.logger.Warnw("Failed to load cluster centroids",
-				"error", errors.Wrapf(err, "attestation %s", attestationID))
-			return
-		}
-		if len(loaded) == 0 {
-			return // no clusters yet
-		}
-		o.clusterMu.Lock()
-		o.clusterCache = loaded
-		o.clusterMu.Unlock()
-		centroids = loaded
-
-		// Refresh cluster label cache
-		o.refreshClusterLabels()
-	}
-
-	clusterID, prob, err := o.embeddingStore.PredictCluster(
-		embedding,
-		centroids,
-		o.embeddingService.DeserializeEmbedding,
-		o.embeddingService.ComputeSimilarity,
-		o.clusterThreshold,
-	)
-	if err != nil {
-		o.logger.Warnw("Failed to predict cluster",
-			"error", errors.Wrapf(err, "attestation %s", attestationID))
-		return
-	}
-
-	if clusterID == storage.ClusterNoise {
-		o.clusterNoise.Add(1)
-		return // below threshold, stays as noise
-	}
-
-	err = o.embeddingStore.UpdateClusterAssignments([]storage.ClusterAssignment{{
-		ID:          embeddingID,
-		ClusterID:   clusterID,
-		Probability: prob,
-	}})
-	if err != nil {
-		o.logger.Warnw("Failed to save predicted cluster assignment",
-			"error", errors.Wrapf(err, "attestation %s embedding %s cluster %d", attestationID, embeddingID, clusterID))
-		return
-	}
-
-	// Track cluster hit for periodic summary
-	name := o.clusterDisplayName(clusterID)
-	val, _ := o.clusterHits.LoadOrStore(name, &atomic.Int64{})
-	val.(*atomic.Int64).Add(1)
-
-	o.logger.Debugw("Predicted cluster for new embedding",
-		"attestation_id", attestationID,
-		"embedding_id", embeddingID,
-		"cluster_id", clusterID,
-		"similarity", prob)
-}
-
-// extractRichText returns the concatenated rich text fields from an attestation's
-// attributes. Returns empty string if no rich text is found — this is the
-// selective gate that prevents embedding structural-only attestations.
-func (o *EmbeddingObserver) extractRichText(as *types.As) string {
-	if as.Attributes == nil || len(as.Attributes) == 0 {
-		return ""
-	}
-
-	richFields := o.richStore.GetDiscoveredRichFields()
-	if len(richFields) == 0 {
-		return ""
-	}
-
-	return extractRichTextFromAttributes(as.Attributes, richFields)
-}
-
-// clusterDisplayName returns a human-readable name for a cluster ID.
-// Uses the cached label if available, falls back to "cluster:<id>".
-func (o *EmbeddingObserver) clusterDisplayName(clusterID int) string {
-	if label, ok := o.clusterLabels.Load(clusterID); ok {
-		return label.(string)
-	}
-	return "cluster:" + strconv.Itoa(clusterID)
-}
-
-// refreshClusterLabels loads cluster labels from the DB into the label cache.
-func (o *EmbeddingObserver) refreshClusterLabels() {
-	clusters, err := o.embeddingStore.GetActiveClusterIdentities()
-	if err != nil {
-		o.logger.Debugw("Failed to refresh cluster labels", "error", err)
-		return
-	}
-	for _, c := range clusters {
-		if c.Label != nil && *c.Label != "" {
-			o.clusterLabels.Store(c.ID, *c.Label)
-		}
-	}
-}
-
-// DrainEmbeddingCounts atomically reads and resets embedding activity counters.
-// Returns total embedded, cluster assignment breakdown, and noise count.
-func (o *EmbeddingObserver) DrainEmbeddingCounts() (embedded int, clusterCounts []string, noise int) {
-	embedded = int(o.embedded.Swap(0))
-	noise = int(o.clusterNoise.Swap(0))
-
-	var pairs []pairCount
-	o.clusterHits.Range(func(key, value any) bool {
-		count := value.(*atomic.Int64).Swap(0)
-		if count > 0 {
-			pairs = append(pairs, pairCount{Key: key.(string), Count: count})
-		}
-		if count == 0 {
-			o.clusterHits.Delete(key)
-		}
-		return true
-	})
-
-	sort.Slice(pairs, func(i, j int) bool {
-		return pairs[i].Count > pairs[j].Count
-	})
-
-	// Show top 5 clusters
-	limit := 5
-	if len(pairs) < limit {
-		limit = len(pairs)
-	}
-	clusterCounts = make([]string, limit)
-	for i := 0; i < limit; i++ {
-		clusterCounts[i] = formatPairCount(pairs[i])
-	}
-
-	return embedded, clusterCounts, noise
-}
-
-// extractRichTextFromAttributes extracts text from the named rich fields in an
-// attestation's attribute map. Shared by EmbeddingObserver and batch handler.
-func extractRichTextFromAttributes(attrs map[string]interface{}, richFields []string) string {
-	var parts []string
-	for _, field := range richFields {
-		value, exists := attrs[field]
-		if !exists {
-			continue
-		}
-		switch v := value.(type) {
-		case string:
-			if v != "" {
-				parts = append(parts, v)
-			}
-		case []interface{}:
-			for _, item := range v {
-				if str, ok := item.(string); ok && str != "" {
-					parts = append(parts, str)
-				}
-			}
-		}
-	}
-
-	return strings.Join(parts, " ")
 }
 
 // callReducePlugin sends an HTTP request to the reduce plugin via gRPC.
@@ -414,51 +124,6 @@ func (s *QNTXServer) callReducePlugin(ctx context.Context, method, path string, 
 			method, path, resp.StatusCode, string(resp.Body))
 	}
 	return resp.Body, nil
-}
-
-// HandleEmbeddingProject runs configured projection methods on all embeddings.
-// POST /api/embeddings/project
-func (s *QNTXServer) HandleEmbeddingProject(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	if s.embeddingService == nil || s.embeddingStore == nil {
-		http.Error(w, "Embedding service not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	methods := appcfg.GetStringSlice("embeddings.projection_methods")
-	if len(methods) == 0 {
-		methods = []string{"umap"}
-	}
-
-	var params *ProjectionParams
-	if r.Body != nil {
-		var req ProjectionParams
-		if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
-			if req.NNeighbors != nil || req.MinDist != nil || req.Perplexity != nil {
-				params = &req
-			}
-		}
-	}
-
-	startTime := time.Now()
-	results, err := RunAllProjections(r.Context(), methods, s.embeddingStore, s.embeddingService, s.callReducePlugin, s.logger, params)
-	if err != nil {
-		s.logger.Errorw("Projection failed", "methods", methods, "error", err)
-		http.Error(w, fmt.Sprintf("Projection failed: %s", err), http.StatusInternalServerError)
-		return
-	}
-
-	totalMS := float64(time.Since(startTime).Milliseconds())
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"results":  results,
-		"total_ms": totalMS,
-	})
 }
 
 // projectToCanvas projects a single embedding to 2D via the reduce plugin's /transform

--- a/server/embeddings_handlers_stub.go
+++ b/server/embeddings_handlers_stub.go
@@ -3,21 +3,17 @@
 package server
 
 import (
-	"net/http"
+	"context"
 
 	am "github.com/teranos/QNTX/am"
+	"github.com/teranos/QNTX/errors"
 )
 
 // Stub handlers when rustembeddings build tag is not present
 
-// HandleEmbeddingCluster runs HDBSCAN clustering (POST /api/embeddings/cluster)
-func (s *QNTXServer) HandleEmbeddingCluster(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Embeddings feature not available (compile with -tags=rustembeddings)", http.StatusServiceUnavailable)
-}
-
-// HandleEmbeddingProject runs UMAP projection (POST /api/embeddings/project)
-func (s *QNTXServer) HandleEmbeddingProject(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "Embeddings feature not available (compile with -tags=rustembeddings)", http.StatusServiceUnavailable)
+// callReducePlugin is a no-op when embeddings are not available.
+func (s *QNTXServer) callReducePlugin(_ context.Context, _, _ string, _ []byte) ([]byte, error) {
+	return nil, errors.New("reduce plugin not available (build without rustembeddings tag)")
 }
 
 // SetupEmbeddingService is a no-op when embeddings are not available

--- a/server/embeddings_pulse.go
+++ b/server/embeddings_pulse.go
@@ -3,756 +3,15 @@
 package server
 
 import (
-	"context"
-	"database/sql"
-	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"time"
 
 	appcfg "github.com/teranos/QNTX/am"
-	"github.com/teranos/QNTX/ats"
-	"github.com/teranos/QNTX/ats/attrs"
-	"github.com/teranos/QNTX/ats/embeddings/embeddings"
-	"github.com/teranos/QNTX/ats/identity"
-	"github.com/teranos/QNTX/ats/storage"
-	"github.com/teranos/QNTX/ats/types"
-	"github.com/teranos/QNTX/errors"
-	"github.com/teranos/QNTX/pulse/async"
+	serverembeddings "github.com/teranos/QNTX/server/embeddings"
 	"github.com/teranos/QNTX/pulse/schedule"
-	vanity "github.com/teranos/vanity-id"
-	"go.uber.org/zap"
 )
-
-// EmbeddingServiceForClustering is the subset of the embedding service needed for clustering and projection.
-type EmbeddingServiceForClustering interface {
-	DeserializeEmbedding(data []byte) ([]float32, error)
-	SerializeEmbedding(embedding []float32) ([]byte, error)
-}
-
-// --- HDBSCAN clustering ---
-
-// EmbeddingClusterResult holds the outcome of a clustering run.
-type EmbeddingClusterResult struct {
-	Summary *storage.ClusterSummary
-	TimeMS  float64
-}
-
-// clusterMatchResult holds the output of stable cluster matching.
-type clusterMatchResult struct {
-	mapping map[int]int // hdbscan_label → stable_id
-	events  []storage.ClusterEvent
-}
-
-// cosineSimilarityF32 computes cosine similarity between two float32 slices.
-func cosineSimilarityF32(a, b []float32) float64 {
-	if len(a) != len(b) || len(a) == 0 {
-		return 0
-	}
-	var dot, normA, normB float64
-	for i := range a {
-		fa, fb := float64(a[i]), float64(b[i])
-		dot += fa * fb
-		normA += fa * fa
-		normB += fb * fb
-	}
-	denom := math.Sqrt(normA) * math.Sqrt(normB)
-	if denom == 0 {
-		return 0
-	}
-	return dot / denom
-}
-
-// matchClusters matches new HDBSCAN centroids against previous centroids by cosine similarity.
-// Returns a mapping from raw HDBSCAN label to stable cluster ID, plus lifecycle events.
-// The cluster_runs row for runID must already exist (FK constraint).
-func matchClusters(
-	runID string,
-	oldCentroids []storage.ClusterCentroid,
-	newCentroids [][]float32,
-	threshold float64,
-	store *storage.EmbeddingStore,
-	svc EmbeddingServiceForClustering,
-	logger *zap.SugaredLogger,
-) (*clusterMatchResult, error) {
-	result := &clusterMatchResult{
-		mapping: make(map[int]int, len(newCentroids)),
-	}
-
-	// First run or no old centroids: all births
-	if len(oldCentroids) == 0 {
-		for i := range newCentroids {
-			stableID, err := store.CreateCluster(runID)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to create cluster for HDBSCAN label %d", i)
-			}
-			result.mapping[i] = stableID
-			result.events = append(result.events, storage.ClusterEvent{
-				RunID:     runID,
-				EventType: "birth",
-				ClusterID: stableID,
-			})
-		}
-		logger.Infow("First clustering run: all births",
-			"run_id", runID,
-			"n_births", len(newCentroids))
-		return result, nil
-	}
-
-	// Deserialize old centroids
-	oldVecs := make([][]float32, len(oldCentroids))
-	for i, oc := range oldCentroids {
-		vec, err := svc.DeserializeEmbedding(oc.Centroid)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to deserialize old centroid for cluster %d", oc.ClusterID)
-		}
-		oldVecs[i] = vec
-	}
-
-	// Build similarity pairs
-	type simPair struct {
-		newIdx int
-		oldIdx int
-		sim    float64
-	}
-	var pairs []simPair
-	for ni, nv := range newCentroids {
-		for oi, ov := range oldVecs {
-			sim := cosineSimilarityF32(nv, ov)
-			if sim >= threshold {
-				pairs = append(pairs, simPair{ni, oi, sim})
-			}
-		}
-	}
-
-	// Greedy best-first matching
-	sort.Slice(pairs, func(i, j int) bool { return pairs[i].sim > pairs[j].sim })
-
-	usedNew := make(map[int]bool)
-	usedOld := make(map[int]bool)
-
-	for _, p := range pairs {
-		if usedNew[p.newIdx] || usedOld[p.oldIdx] {
-			continue
-		}
-		usedNew[p.newIdx] = true
-		usedOld[p.oldIdx] = true
-
-		stableID := oldCentroids[p.oldIdx].ClusterID
-		result.mapping[p.newIdx] = stableID
-
-		sim := p.sim
-		result.events = append(result.events, storage.ClusterEvent{
-			RunID:      runID,
-			EventType:  "stable",
-			ClusterID:  stableID,
-			Similarity: &sim,
-		})
-
-		if err := store.UpdateClusterLastSeen(stableID, runID); err != nil {
-			return nil, errors.Wrapf(err, "failed to update last_seen for cluster %d", stableID)
-		}
-	}
-
-	// Unmatched new → birth
-	for i := range newCentroids {
-		if usedNew[i] {
-			continue
-		}
-		stableID, err := store.CreateCluster(runID)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create cluster for unmatched HDBSCAN label %d", i)
-		}
-		result.mapping[i] = stableID
-		result.events = append(result.events, storage.ClusterEvent{
-			RunID:     runID,
-			EventType: "birth",
-			ClusterID: stableID,
-		})
-	}
-
-	// Unmatched old → death
-	for i, oc := range oldCentroids {
-		if usedOld[i] {
-			continue
-		}
-		if err := store.DissolveCluster(oc.ClusterID, runID); err != nil {
-			return nil, errors.Wrapf(err, "failed to dissolve cluster %d", oc.ClusterID)
-		}
-		result.events = append(result.events, storage.ClusterEvent{
-			RunID:     runID,
-			EventType: "death",
-			ClusterID: oc.ClusterID,
-		})
-	}
-
-	var nStable, nBirth, nDeath int
-	for _, ev := range result.events {
-		switch ev.EventType {
-		case "stable":
-			nStable++
-		case "birth":
-			nBirth++
-		case "death":
-			nDeath++
-		}
-	}
-	logger.Infow("Cluster matching complete",
-		"run_id", runID,
-		"stable", nStable,
-		"births", nBirth,
-		"deaths", nDeath)
-
-	return result, nil
-}
-
-// RunHDBSCANClustering executes HDBSCAN on all stored embeddings, matches new clusters
-// against previous centroids for stable identity, and writes results to DB.
-// Shared by the HTTP handler and the Pulse recluster handler.
-func RunHDBSCANClustering(
-	store *storage.EmbeddingStore,
-	svc EmbeddingServiceForClustering,
-	invalidator func(),
-	minClusterSize int,
-	clusterMatchThreshold float64,
-	atsStore ats.AttestationStore,
-	projectCtx string,
-	groundDBPath string,
-	logger *zap.SugaredLogger,
-) (*EmbeddingClusterResult, error) {
-	startTime := time.Now()
-
-	// Sweep stale embeddings before clustering so HDBSCAN operates on clean data
-	swept, err := store.SweepStaleEmbeddings()
-	if err != nil {
-		logger.Warnw("Stale embedding sweep failed, continuing with clustering", "error", err)
-	} else if swept > 0 {
-		logger.Infow("Swept stale embeddings before clustering", "count", swept)
-	}
-
-	// Read all embedding vectors
-	ids, blobs, err := store.GetAllEmbeddingVectors()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read embedding vectors for clustering")
-	}
-
-	if len(ids) < 2 {
-		return nil, errors.Newf("need at least 2 embeddings to cluster, have %d", len(ids))
-	}
-
-	// Deserialize blobs into flat float32 array
-	var dims int
-	flat := make([]float32, 0, len(blobs)*384) // pre-allocate assuming 384d
-	for i, blob := range blobs {
-		vec, err := svc.DeserializeEmbedding(blob)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to deserialize embedding %s (blob_len=%d)", ids[i], len(blob))
-		}
-		if i == 0 {
-			dims = len(vec)
-		}
-		flat = append(flat, vec...)
-	}
-
-	// Run HDBSCAN
-	result, err := embeddings.ClusterHDBSCAN(flat, len(ids), dims, minClusterSize)
-	if err != nil {
-		return nil, errors.Wrapf(err, "HDBSCAN failed (n_points=%d, dims=%d, min_cluster_size=%d)", len(ids), dims, minClusterSize)
-	}
-
-	// Create run record first — clusters and events reference it via FK
-	runID, _ := vanity.GenerateRandomID(12)
-	runID = "CR_" + runID
-	clusterRun := &storage.ClusterRun{
-		ID:             runID,
-		NPoints:        len(ids),
-		NClusters:      result.NClusters,
-		NNoise:         result.NNoise,
-		MinClusterSize: minClusterSize,
-		DurationMS:     0, // updated at end
-		CreatedAt:      time.Now().UTC(),
-	}
-	if err := store.CreateClusterRun(clusterRun); err != nil {
-		return nil, errors.Wrapf(err, "failed to create cluster run %s", runID)
-	}
-
-	// Load previous centroids for stable matching
-	oldCentroids, err := store.GetAllClusterCentroids()
-	if err != nil {
-		logger.Warnw("Failed to load old centroids for matching, treating as first run", "error", err)
-		oldCentroids = nil
-	}
-
-	// Match new centroids against old for stable identity
-	matchResult, err := matchClusters(runID, oldCentroids, result.Centroids, clusterMatchThreshold, store, svc, logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "cluster matching failed")
-	}
-
-	// Build assignments using stable IDs (mapping[rawLabel] instead of raw labels)
-	assignments := make([]storage.ClusterAssignment, len(ids))
-	memberCounts := make(map[int]int) // stable_id → count
-	for i, id := range ids {
-		rawLabel := int(result.Labels[i])
-		stableID := rawLabel // default: keep raw (-1 stays -1)
-		if rawLabel >= 0 {
-			if mapped, ok := matchResult.mapping[rawLabel]; ok {
-				stableID = mapped
-			}
-			memberCounts[stableID]++
-		}
-		assignments[i] = storage.ClusterAssignment{
-			ID:          id,
-			ClusterID:   stableID,
-			Probability: float64(result.Probabilities[i]),
-		}
-	}
-
-	if err := store.UpdateClusterAssignments(assignments); err != nil {
-		return nil, errors.Wrapf(err, "failed to save %d cluster assignments", len(assignments))
-	}
-
-	// Save cluster centroids with stable IDs (PredictCluster keeps working)
-	if len(result.Centroids) > 0 {
-		centroidModels := make([]storage.ClusterCentroid, 0, len(result.Centroids))
-		snapshots := make([]storage.ClusterSnapshot, 0, len(result.Centroids))
-
-		for rawLabel, centroid := range result.Centroids {
-			blob, err := svc.SerializeEmbedding(centroid)
-			if err != nil {
-				logger.Errorw("Failed to serialize centroid",
-					"raw_label", rawLabel,
-					"error", err)
-				continue
-			}
-
-			stableID := matchResult.mapping[rawLabel]
-			centroidModels = append(centroidModels, storage.ClusterCentroid{
-				ClusterID: stableID,
-				Centroid:  blob,
-				NMembers:  memberCounts[stableID],
-			})
-			snapshots = append(snapshots, storage.ClusterSnapshot{
-				ClusterID: stableID,
-				RunID:     runID,
-				Centroid:  blob,
-				NMembers:  memberCounts[stableID],
-			})
-		}
-
-		if err := store.SaveClusterCentroids(centroidModels); err != nil {
-			logger.Errorw("Failed to save cluster centroids",
-				"count", len(centroidModels),
-				"error", err)
-		}
-
-		// Add zero-member snapshots for dissolved clusters so timeline shows deaths
-		for _, ev := range matchResult.events {
-			if ev.EventType == "death" {
-				snapshots = append(snapshots, storage.ClusterSnapshot{
-					ClusterID: ev.ClusterID,
-					RunID:     runID,
-					Centroid:  []byte{},
-					NMembers:  0,
-				})
-			}
-		}
-
-		if err := store.SaveClusterSnapshots(snapshots); err != nil {
-			logger.Errorw("Failed to save cluster snapshots",
-				"count", len(snapshots),
-				"error", err)
-		}
-
-		if invalidator != nil {
-			invalidator()
-		}
-	}
-
-	// Record events and update run duration
-	timeMS := float64(time.Since(startTime).Milliseconds())
-
-	if err := store.UpdateClusterRunDuration(runID, int(timeMS)); err != nil {
-		logger.Errorw("Failed to update cluster run duration", "run_id", runID, "error", err)
-	}
-
-	if err := store.RecordClusterEvents(matchResult.events); err != nil {
-		logger.Errorw("Failed to record cluster events", "run_id", runID, "error", err)
-	}
-
-	if atsStore != nil {
-		for _, ev := range matchResult.events {
-			if ev.EventType == "stable" {
-				continue
-			}
-			emitClusterLifecycleAttestation(atsStore, ev, memberCounts[ev.ClusterID], runID, projectCtx, logger)
-		}
-		emitClusterDeferredNews(store, atsStore, matchResult.events, memberCounts, swept, runID, projectCtx, groundDBPath, logger)
-	}
-
-	summary, err := store.GetClusterSummary()
-	if err != nil {
-		return nil, errors.Wrap(err, "clustering succeeded but failed to read summary")
-	}
-
-	logger.Infow("HDBSCAN clustering complete",
-		"run_id", runID,
-		"n_points", len(ids),
-		"n_clusters", result.NClusters,
-		"n_noise", result.NNoise,
-		"min_cluster_size", minClusterSize,
-		"time_ms", timeMS)
-
-	return &EmbeddingClusterResult{
-		Summary: summary,
-		TimeMS:  timeMS,
-	}, nil
-}
-
-const ReclusterHandlerName = "embeddings.recluster"
-
-// ReclusterHandler runs HDBSCAN re-clustering as a Pulse scheduled job
-type ReclusterHandler struct {
-	db                    *sql.DB
-	projectCtx            string // e.g. "project:tmp3/QNTX"
-	store                 *storage.EmbeddingStore
-	svc                   EmbeddingServiceForClustering
-	atsStore              ats.AttestationStore
-	invalidator           func()
-	minClusterSize        int
-	clusterMatchThreshold float64
-	groundDBPath          string
-	logger                *zap.SugaredLogger
-}
-
-func (h *ReclusterHandler) Name() string { return ReclusterHandlerName }
-
-func (h *ReclusterHandler) Execute(ctx context.Context, job *async.Job) error {
-	h.writeLog(job.ID, "clustering", "info", "Starting HDBSCAN re-clustering", fmt.Sprintf(`{"min_cluster_size":%d}`, h.minClusterSize))
-
-	result, err := RunHDBSCANClustering(h.store, h.svc, h.invalidator, h.minClusterSize, h.clusterMatchThreshold, h.atsStore, h.projectCtx, h.groundDBPath, h.logger)
-	if err != nil {
-		h.writeLog(job.ID, "clustering", "error", fmt.Sprintf("Clustering failed: %s", err), "")
-		emitPulseDeferredNews(h.db, h.atsStore, h.projectCtx, h.groundDBPath, h.logger)
-		return err
-	}
-
-	h.writeLog(job.ID, "clustering", "info",
-		fmt.Sprintf("Clustering complete: %d points, %d clusters, %d noise, %.0fms",
-			result.Summary.NTotal, result.Summary.NClusters, result.Summary.NNoise, result.TimeMS),
-		fmt.Sprintf(`{"n_points":%d,"n_clusters":%d,"n_noise":%d,"time_ms":%.0f}`,
-			result.Summary.NTotal, result.Summary.NClusters, result.Summary.NNoise, result.TimeMS))
-
-	emitPulseDeferredNews(h.db, h.atsStore, h.projectCtx, h.groundDBPath, h.logger)
-	return nil
-}
-
-func (h *ReclusterHandler) writeLog(jobID, stage, level, message, metadata string) {
-	var metaPtr *string
-	if metadata != "" {
-		metaPtr = &metadata
-	}
-	_, err := h.db.Exec(`INSERT INTO task_logs (job_id, stage, timestamp, level, message, metadata) VALUES (?, ?, ?, ?, ?, ?)`,
-		jobID, stage, time.Now().Format(time.RFC3339), level, message, metaPtr)
-	if err != nil {
-		h.logger.Warnw("Failed to write task log", "job_id", jobID, "error", err)
-	}
-}
-
-type clusterLifecycleAttrs struct {
-	RunID    string `attr:"run_id"`
-	NMembers int    `attr:"n_members,omitempty"`
-}
-
-func emitClusterLifecycleAttestation(atsStore ats.AttestationStore, ev storage.ClusterEvent, nMembers int, runID string, projectCtx string, logger *zap.SugaredLogger) {
-	predicate := ev.EventType
-	if ev.EventType == "birth" {
-		predicate = "born"
-	} else if ev.EventType == "death" {
-		predicate = "died"
-	}
-
-	subject := fmt.Sprintf("cluster:%d", ev.ClusterID)
-	asid, err := identity.GenerateASUID("AS", subject, predicate, projectCtx)
-	if err != nil {
-		logger.Warnw("Failed to generate ASID for cluster lifecycle attestation",
-			"cluster_id", ev.ClusterID, "event", ev.EventType, "error", err)
-		return
-	}
-
-	now := time.Now()
-	as := &types.As{
-		ID:         asid,
-		Subjects:   []string{subject},
-		Predicates: []string{predicate},
-		Contexts:   []string{projectCtx},
-		Actors:     []string{"qntx@embeddings"},
-		Timestamp:  now,
-		Source:     "cluster-lifecycle",
-		Attributes: attrs.From(clusterLifecycleAttrs{
-			RunID:    runID,
-			NMembers: nMembers,
-		}),
-		CreatedAt: now,
-	}
-
-	if err := atsStore.CreateAttestation(as); err != nil {
-		logger.Warnw("Failed to create cluster lifecycle attestation",
-			"cluster_id", ev.ClusterID, "event", predicate, "asid", asid, "error", err)
-	} else {
-		logger.Infow("Created cluster lifecycle attestation",
-			"asid", asid, "cluster_id", ev.ClusterID, "event", predicate)
-	}
-}
-
-// getUndeliveredDetail returns the detail text from the most recent undelivered
-// deferred:cluster-update attestation. Returns empty string if all news has been
-// delivered or no prior news exists.
-//
-// Delivery acks are written by Ground into Ground's DB, so we check there.
-func getUndeliveredDetail(atsStore ats.AttestationStore, projectCtx string, groundDBPath string) string {
-	// Find the latest deferred:cluster-update in QNTX's store
-	deferred, err := atsStore.GetAttestations(ats.AttestationFilter{
-		Predicates: []string{"deferred:cluster-update"},
-		Contexts:   []string{projectCtx},
-		Limit:      1,
-	})
-	if err != nil || len(deferred) == 0 {
-		return ""
-	}
-
-	// Check Ground's DB for delivery ack
-	if groundDBPath != "" {
-		db, err := sql.Open("sqlite3", groundDBPath+"?_journal_mode=WAL&_busy_timeout=5000&mode=ro")
-		if err == nil {
-			defer db.Close()
-			var ackTS string
-			err = db.QueryRow(`SELECT timestamp FROM attestations
-				WHERE predicates LIKE '%delivered:cluster-update%'
-				AND contexts LIKE ?
-				ORDER BY rowid DESC LIMIT 1`, "%"+projectCtx+"%").Scan(&ackTS)
-			if err == nil {
-				// Ack exists — news was delivered
-				return ""
-			}
-		}
-	}
-
-	// Extract detail from the undelivered news
-	if detail, ok := deferred[0].Attributes["detail"].(string); ok {
-		return detail
-	}
-	return ""
-}
-
-// emitClusterDeferredNews writes a deferred message attestation for Ground to pick up
-// on Stop. If there's undelivered news from a previous run, accumulates by prepending it.
-func emitClusterDeferredNews(embStore *storage.EmbeddingStore, atsStore ats.AttestationStore, events []storage.ClusterEvent, memberCounts map[int]int, staleSwept int, runID string, projectCtx string, groundDBPath string, logger *zap.SugaredLogger) {
-	type birthInfo struct {
-		clusterID int
-		nMembers  int
-	}
-	var births []birthInfo
-	var deaths []int
-
-	for _, ev := range events {
-		switch ev.EventType {
-		case "birth":
-			births = append(births, birthInfo{ev.ClusterID, memberCounts[ev.ClusterID]})
-		case "death":
-			deaths = append(deaths, ev.ClusterID)
-		}
-	}
-	if len(births) == 0 && len(deaths) == 0 && staleSwept == 0 {
-		return
-	}
-
-	// Sort births by member count descending — show the biggest first
-	sort.Slice(births, func(i, j int) bool { return births[i].nMembers > births[j].nMembers })
-
-	var detail string
-
-	// Header
-	switch {
-	case len(births) > 0 && len(deaths) > 0:
-		detail = fmt.Sprintf("Embedding topology: %d born, %d died.", len(births), len(deaths))
-	case len(births) > 0:
-		detail = fmt.Sprintf("%d new cluster(s) emerged.", len(births))
-	case len(deaths) > 0:
-		detail = fmt.Sprintf("%d cluster(s) dissolved.", len(deaths))
-	}
-
-	// Show all births with sample texts
-	for _, b := range births {
-		detail += fmt.Sprintf(" cluster:%d (%d members)", b.clusterID, b.nMembers)
-		samples, err := embStore.SampleClusterTexts(b.clusterID, 2)
-		if err == nil && len(samples) > 0 {
-			detail += " — "
-			for j, s := range samples {
-				if len(s) > 60 {
-					s = s[:60] + "..."
-				}
-				if j > 0 {
-					detail += "; "
-				}
-				detail += s
-			}
-		}
-		detail += "."
-	}
-
-	// Deaths
-	if len(deaths) > 0 {
-		detail += " Dissolved: "
-		for i, d := range deaths {
-			if i > 0 {
-				detail += ", "
-			}
-			detail += fmt.Sprintf("cluster:%d", d)
-		}
-		detail += "."
-	}
-
-	if staleSwept > 0 {
-		detail += fmt.Sprintf(" Swept %d stale embeddings (source attestations deleted).", staleSwept)
-	}
-
-	// Accumulate: if there's undelivered news from a previous run, prepend it
-	if prior := getUndeliveredDetail(atsStore, projectCtx, groundDBPath); prior != "" {
-		detail = prior + " " + detail
-		logger.Infow("Accumulating with undelivered prior news")
-	}
-
-	asid, err := identity.GenerateASUID("AS", "embeddings", "deferred:cluster-update", projectCtx)
-	if err != nil {
-		logger.Warnw("Failed to generate ASID for cluster deferred news", "error", err)
-		return
-	}
-
-	now := time.Now()
-	as := &types.As{
-		ID:         asid,
-		Subjects:   []string{"embeddings"},
-		Predicates: []string{"deferred:cluster-update"},
-		Contexts:   []string{projectCtx},
-		Actors:     []string{"qntx@embeddings"},
-		Timestamp:  now,
-		Source:     "cluster-lifecycle",
-		Attributes: map[string]any{
-			"event":  "cluster-update",
-			"detail": detail,
-			"after":  now.Unix(),
-		},
-		CreatedAt: now,
-	}
-
-	if err := atsStore.CreateAttestation(as); err != nil {
-		logger.Warnw("Failed to create cluster deferred news",
-			"asid", asid, "error", err)
-	} else {
-		logger.Infow("Deferred cluster news for Ground",
-			"asid", asid, "births", len(births), "deaths", len(deaths))
-	}
-
-	writeToGround(groundDBPath, as, logger)
-}
-
-// emitPulseDeferredNews queries recent Pulse execution stats and writes a deferred
-// news attestation for Ground. Emitted after every recluster run (success or failure)
-// as the recluster heartbeat is the natural place for periodic Pulse health reporting.
-func emitPulseDeferredNews(db *sql.DB, atsStore ats.AttestationStore, projectCtx string, groundDBPath string, logger *zap.SugaredLogger) {
-	if atsStore == nil {
-		return
-	}
-
-	// Query execution stats from the last 24 hours
-	var completed, failed int
-	var avgDurationMS sql.NullFloat64
-	row := db.QueryRow(`SELECT
-		COUNT(CASE WHEN status = 'completed' THEN 1 END),
-		COUNT(CASE WHEN status = 'failed' THEN 1 END),
-		AVG(CASE WHEN status = 'completed' THEN duration_ms END)
-		FROM pulse_executions
-		WHERE started_at > datetime('now', '-24 hours')`)
-	if err := row.Scan(&completed, &failed, &avgDurationMS); err != nil {
-		logger.Warnw("Failed to query Pulse execution stats", "error", err)
-		return
-	}
-
-	// Query recent failures with handler names
-	var failedHandlers []string
-	rows, err := db.Query(`SELECT DISTINCT s.handler_name
-		FROM pulse_executions e
-		JOIN scheduled_pulse_jobs s ON e.scheduled_job_id = s.id
-		WHERE e.status = 'failed'
-		AND e.started_at > datetime('now', '-24 hours')
-		ORDER BY e.started_at DESC LIMIT 5`)
-	if err == nil {
-		defer rows.Close()
-		for rows.Next() {
-			var name string
-			if rows.Scan(&name) == nil {
-				failedHandlers = append(failedHandlers, name)
-			}
-		}
-	}
-
-	total := completed + failed
-	if total == 0 {
-		return // nothing to report
-	}
-
-	// Build summary
-	var detail string
-	if failed == 0 {
-		detail = fmt.Sprintf("Pulse: %d jobs completed (avg %.0fms) in last 24h, no failures",
-			completed, avgDurationMS.Float64)
-	} else {
-		detail = fmt.Sprintf("Pulse: %d/%d jobs failed in last 24h", failed, total)
-		if len(failedHandlers) > 0 {
-			detail += fmt.Sprintf(" — failing: %s", failedHandlers[0])
-			for _, h := range failedHandlers[1:] {
-				detail += ", " + h
-			}
-		}
-	}
-
-	asid, err := identity.GenerateASUID("AS", "pulse", "deferred:pulse-summary", projectCtx)
-	if err != nil {
-		logger.Warnw("Failed to generate ASID for Pulse deferred news", "error", err)
-		return
-	}
-
-	now := time.Now()
-	as := &types.As{
-		ID:         asid,
-		Subjects:   []string{"pulse"},
-		Predicates: []string{"deferred:pulse-summary"},
-		Contexts:   []string{projectCtx},
-		Actors:     []string{"qntx@pulse"},
-		Timestamp:  now,
-		Source:     "pulse-heartbeat",
-		Attributes: map[string]any{
-			"event":  "pulse-summary",
-			"detail": detail,
-			"after":  now.Unix(),
-		},
-		CreatedAt: now,
-	}
-
-	if err := atsStore.CreateAttestation(as); err != nil {
-		logger.Warnw("Failed to create Pulse deferred news",
-			"asid", asid, "error", err)
-	} else {
-		logger.Infow("Deferred Pulse news for Ground",
-			"asid", asid, "completed", completed, "failed", failed)
-	}
-
-	writeToGround(groundDBPath, as, logger)
-}
 
 // setupEmbeddingReclusterSchedule registers the recluster handler and auto-creates
 // a Pulse schedule if embeddings.recluster_interval_seconds > 0.
@@ -764,20 +23,23 @@ func (s *QNTXServer) setupEmbeddingReclusterSchedule(cfg *appcfg.Config) {
 	cwd, _ := os.Getwd()
 	projectCtx := "project:" + filepath.Join(filepath.Base(filepath.Dir(cwd)), filepath.Base(cwd))
 
-	handler := &ReclusterHandler{
-		db:                    s.db,
-		projectCtx:            projectCtx,
-		store:                 s.embeddingStore,
-		svc:                   s.embeddingService,
-		atsStore:              s.atsStore,
-		invalidator:           s.embeddingClusterInvalidator,
-		minClusterSize:        cfg.Embeddings.MinClusterSize,
-		clusterMatchThreshold: cfg.Embeddings.ClusterMatchThreshold,
-		groundDBPath:          cfg.GroundDBPath,
-		logger:                s.logger.Named("recluster"),
+	minClusterSize := cfg.Embeddings.MinClusterSize
+	if minClusterSize <= 0 {
+		minClusterSize = 5
 	}
-	if handler.minClusterSize <= 0 {
-		handler.minClusterSize = 5
+
+	handler := &serverembeddings.ReclusterHandler{
+		DB:                    s.db,
+		ProjectCtx:            projectCtx,
+		Store:                 s.embeddingStore,
+		Svc:                   s.embeddingService,
+		ATSStore:              s.atsStore,
+		Invalidator:           s.embeddingClusterInvalidator,
+		MinClusterSize:        minClusterSize,
+		ClusterMatchThreshold: cfg.Embeddings.ClusterMatchThreshold,
+		GroundDBPath:          cfg.GroundDBPath,
+		GroundWrite:           writeToGround,
+		Logger:                s.logger.Named("recluster"),
 	}
 
 	registry := s.daemon.Registry()
@@ -787,7 +49,7 @@ func (s *QNTXServer) setupEmbeddingReclusterSchedule(cfg *appcfg.Config) {
 	schedStore := schedule.NewStore(s.db)
 
 	if cfg.Embeddings.ReclusterIntervalSeconds == nil {
-		s.pauseExistingSchedule(schedStore, ReclusterHandlerName)
+		s.pauseExistingSchedule(schedStore, serverembeddings.ReclusterHandlerName)
 		return
 	}
 	interval := *cfg.Embeddings.ReclusterIntervalSeconds
@@ -796,12 +58,12 @@ func (s *QNTXServer) setupEmbeddingReclusterSchedule(cfg *appcfg.Config) {
 	existing, err := schedStore.ListAllScheduledJobs()
 	if err != nil {
 		s.logger.Errorw("Failed to list scheduled jobs for recluster idempotency check",
-			"handler_name", ReclusterHandlerName,
+			"handler_name", serverembeddings.ReclusterHandlerName,
 			"error", err)
 		return
 	}
 	for _, j := range existing {
-		if j.HandlerName == ReclusterHandlerName && j.State == schedule.StateActive {
+		if j.HandlerName == serverembeddings.ReclusterHandlerName && j.State == schedule.StateActive {
 			// Update interval if it changed
 			if j.IntervalSeconds != interval {
 				if err := schedStore.UpdateJobInterval(j.ID, interval); err != nil {
@@ -821,7 +83,7 @@ func (s *QNTXServer) setupEmbeddingReclusterSchedule(cfg *appcfg.Config) {
 	now := time.Now()
 	job := &schedule.Job{
 		ID:              fmt.Sprintf("SPJ_recluster_%d", now.Unix()),
-		HandlerName:     ReclusterHandlerName,
+		HandlerName:     serverembeddings.ReclusterHandlerName,
 		IntervalSeconds: interval,
 		State:           schedule.StateActive,
 	}
@@ -844,220 +106,6 @@ func (s *QNTXServer) setupEmbeddingReclusterSchedule(cfg *appcfg.Config) {
 		"embedding_count", count)
 }
 
-// --- Dimensionality reduction projection ---
-
-// ReducePluginCaller abstracts the reduce plugin gRPC call for testability.
-type ReducePluginCaller func(ctx context.Context, method, path string, body []byte) ([]byte, error)
-
-// ProjectionResult holds the outcome of a single-method projection run.
-type ProjectionResult struct {
-	Method  string  `json:"method"`
-	NPoints int     `json:"n_points"`
-	FitMS   int64   `json:"fit_ms"`
-	TimeMS  float64 `json:"time_ms"`
-}
-
-// ProjectionParams holds per-method tuning parameters for dimensionality reduction.
-type ProjectionParams struct {
-	NComponents *int     `json:"n_components,omitempty"` // Output dimensions (default 3)
-	NNeighbors  *int     `json:"n_neighbors,omitempty"`  // UMAP: local vs global (default 15)
-	MinDist     *float64 `json:"min_dist,omitempty"`     // UMAP: cluster tightness (default 0.1)
-	Perplexity  *float64 `json:"perplexity,omitempty"`   // t-SNE: local vs global (default 30)
-}
-
-// RunProjection reads all embeddings, calls the reduce plugin /fit for the given method,
-// and writes projections (2D or 3D) to DB.
-func RunProjection(
-	ctx context.Context,
-	method string,
-	store *storage.EmbeddingStore,
-	svc EmbeddingServiceForClustering,
-	callReduce ReducePluginCaller,
-	logger *zap.SugaredLogger,
-	params *ProjectionParams,
-) (*ProjectionResult, error) {
-	startTime := time.Now()
-
-	ids, blobs, err := store.GetAllEmbeddingVectors()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read embedding vectors for projection")
-	}
-
-	if len(ids) < 2 {
-		return nil, errors.Newf("need at least 2 embeddings to project, have %d", len(ids))
-	}
-
-	allEmbeddings := make([][]float32, 0, len(blobs))
-	for i, blob := range blobs {
-		vec, err := svc.DeserializeEmbedding(blob)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to deserialize embedding %s", ids[i])
-		}
-		allEmbeddings = append(allEmbeddings, vec)
-	}
-
-	fitBody := map[string]interface{}{
-		"embeddings":   allEmbeddings,
-		"method":       method,
-		"n_components": 3,
-	}
-	if params != nil {
-		if params.NComponents != nil {
-			fitBody["n_components"] = *params.NComponents
-		}
-		if params.NNeighbors != nil {
-			fitBody["n_neighbors"] = *params.NNeighbors
-		}
-		if params.MinDist != nil {
-			fitBody["min_dist"] = *params.MinDist
-		}
-		if params.Perplexity != nil {
-			fitBody["perplexity"] = *params.Perplexity
-		}
-	}
-	fitReq, err := json.Marshal(fitBody)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal fit request")
-	}
-
-	fitResp, err := callReduce(ctx, "POST", "/fit", fitReq)
-	if err != nil {
-		return nil, errors.Wrapf(err, "reduce plugin /fit failed for method %s (%d points)", method, len(ids))
-	}
-
-	var fitResult struct {
-		Projections [][]float64 `json:"projections"`
-		NComponents int         `json:"n_components"`
-		NPoints     int         `json:"n_points"`
-		FitMS       int64       `json:"fit_ms"`
-	}
-	if err := json.Unmarshal(fitResp, &fitResult); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse reduce plugin response for method %s", method)
-	}
-
-	if len(fitResult.Projections) != len(ids) {
-		return nil, errors.Newf("projection count mismatch for %s: got %d, expected %d",
-			method, len(fitResult.Projections), len(ids))
-	}
-
-	assignments := make([]storage.ProjectionAssignment, len(ids))
-	for i, id := range ids {
-		p := fitResult.Projections[i]
-		a := storage.ProjectionAssignment{
-			ID: id,
-			X:  p[0],
-			Y:  p[1],
-		}
-		if len(p) >= 3 {
-			z := p[2]
-			a.Z = &z
-		}
-		assignments[i] = a
-	}
-
-	if err := store.UpdateProjections(method, assignments); err != nil {
-		return nil, errors.Wrapf(err, "failed to save %s projections for %d points", method, len(assignments))
-	}
-
-	totalMS := float64(time.Since(startTime).Milliseconds())
-
-	logger.Infow("Projection complete",
-		"method", method,
-		"n_points", len(ids),
-		"fit_ms", fitResult.FitMS,
-		"total_ms", totalMS)
-
-	return &ProjectionResult{
-		Method:  method,
-		NPoints: len(ids),
-		FitMS:   fitResult.FitMS,
-		TimeMS:  totalMS,
-	}, nil
-}
-
-// validProjectionMethods filters unknown methods, logging warnings for skipped ones.
-var knownMethods = map[string]bool{"umap": true, "tsne": true, "pca": true}
-
-func validProjectionMethods(methods []string, logger *zap.SugaredLogger) []string {
-	var valid []string
-	for _, m := range methods {
-		if knownMethods[m] {
-			valid = append(valid, m)
-		} else {
-			logger.Warnw("Skipping unknown projection method", "method", m)
-		}
-	}
-	return valid
-}
-
-// RunAllProjections runs projection sequentially for each configured method.
-func RunAllProjections(
-	ctx context.Context,
-	methods []string,
-	store *storage.EmbeddingStore,
-	svc EmbeddingServiceForClustering,
-	callReduce ReducePluginCaller,
-	logger *zap.SugaredLogger,
-	params *ProjectionParams,
-) ([]ProjectionResult, error) {
-	var results []ProjectionResult
-	validated := validProjectionMethods(methods, logger)
-	for _, method := range validated {
-		result, err := RunProjection(ctx, method, store, svc, callReduce, logger, params)
-		if err != nil {
-			return results, errors.Wrapf(err, "projection failed for method %s", method)
-		}
-		results = append(results, *result)
-	}
-	return results, nil
-}
-
-const ReprojectHandlerName = "embeddings.reproject"
-
-// ReprojectHandler runs re-projection as a Pulse scheduled job for all configured methods.
-type ReprojectHandler struct {
-	db         *sql.DB
-	store      *storage.EmbeddingStore
-	svc        EmbeddingServiceForClustering
-	callReduce ReducePluginCaller
-	methods    []string
-	logger     *zap.SugaredLogger
-}
-
-func (h *ReprojectHandler) Name() string { return ReprojectHandlerName }
-
-func (h *ReprojectHandler) Execute(ctx context.Context, job *async.Job) error {
-	h.writeLog(job.ID, "projection", "info",
-		fmt.Sprintf("Starting re-projection for methods: %v", h.methods), "")
-
-	results, err := RunAllProjections(ctx, h.methods, h.store, h.svc, h.callReduce, h.logger, nil)
-	if err != nil {
-		h.writeLog(job.ID, "projection", "error", fmt.Sprintf("Projection failed: %s", err), "")
-		return err
-	}
-
-	for _, r := range results {
-		h.writeLog(job.ID, "projection", "info",
-			fmt.Sprintf("%s complete: %d points, fit %dms, total %.0fms",
-				r.Method, r.NPoints, r.FitMS, r.TimeMS),
-			fmt.Sprintf(`{"method":"%s","n_points":%d,"fit_ms":%d,"time_ms":%.0f}`,
-				r.Method, r.NPoints, r.FitMS, r.TimeMS))
-	}
-	return nil
-}
-
-func (h *ReprojectHandler) writeLog(jobID, stage, level, message, metadata string) {
-	var metaPtr *string
-	if metadata != "" {
-		metaPtr = &metadata
-	}
-	_, err := h.db.Exec(`INSERT INTO task_logs (job_id, stage, timestamp, level, message, metadata) VALUES (?, ?, ?, ?, ?, ?)`,
-		jobID, stage, time.Now().Format(time.RFC3339), level, message, metaPtr)
-	if err != nil {
-		h.logger.Warnw("Failed to write task log", "job_id", jobID, "error", err)
-	}
-}
-
 // setupEmbeddingReprojectSchedule registers the reproject handler and auto-creates
 // a Pulse schedule if embeddings.reproject_interval_seconds > 0.
 func (s *QNTXServer) setupEmbeddingReprojectSchedule(cfg *appcfg.Config) {
@@ -1070,13 +118,13 @@ func (s *QNTXServer) setupEmbeddingReprojectSchedule(cfg *appcfg.Config) {
 		methods = []string{"umap"}
 	}
 
-	handler := &ReprojectHandler{
-		db:         s.db,
-		store:      s.embeddingStore,
-		svc:        s.embeddingService,
-		callReduce: s.callReducePlugin,
-		methods:    methods,
-		logger:     s.logger.Named("reproject"),
+	handler := &serverembeddings.ReprojectHandler{
+		DB:         s.db,
+		Store:      s.embeddingStore,
+		Svc:        s.embeddingService,
+		CallReduce: s.callReducePlugin,
+		Methods:    methods,
+		Logger:     s.logger.Named("reproject"),
 	}
 
 	registry := s.daemon.Registry()
@@ -1086,7 +134,7 @@ func (s *QNTXServer) setupEmbeddingReprojectSchedule(cfg *appcfg.Config) {
 	schedStore := schedule.NewStore(s.db)
 
 	if cfg.Embeddings.ReprojectIntervalSeconds == nil {
-		s.pauseExistingSchedule(schedStore, ReprojectHandlerName)
+		s.pauseExistingSchedule(schedStore, serverembeddings.ReprojectHandlerName)
 		return
 	}
 	interval := *cfg.Embeddings.ReprojectIntervalSeconds
@@ -1095,12 +143,12 @@ func (s *QNTXServer) setupEmbeddingReprojectSchedule(cfg *appcfg.Config) {
 	existing, err := schedStore.ListAllScheduledJobs()
 	if err != nil {
 		s.logger.Errorw("Failed to list scheduled jobs for reproject idempotency check",
-			"handler_name", ReprojectHandlerName,
+			"handler_name", serverembeddings.ReprojectHandlerName,
 			"error", err)
 		return
 	}
 	for _, j := range existing {
-		if j.HandlerName == ReprojectHandlerName && j.State == schedule.StateActive {
+		if j.HandlerName == serverembeddings.ReprojectHandlerName && j.State == schedule.StateActive {
 			if j.IntervalSeconds != interval {
 				if err := schedStore.UpdateJobInterval(j.ID, interval); err != nil {
 					s.logger.Errorw("Failed to update reproject schedule interval",
@@ -1119,7 +167,7 @@ func (s *QNTXServer) setupEmbeddingReprojectSchedule(cfg *appcfg.Config) {
 	now := time.Now()
 	job := &schedule.Job{
 		ID:              fmt.Sprintf("SPJ_reproject_%d", now.Unix()),
-		HandlerName:     ReprojectHandlerName,
+		HandlerName:     serverembeddings.ReprojectHandlerName,
 		IntervalSeconds: interval,
 		State:           schedule.StateActive,
 	}

--- a/server/init.go
+++ b/server/init.go
@@ -386,11 +386,15 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 	server.groundDBPath = deps.config.GroundDBPath
 	server.SetupEmbeddingService()
 	server.embeddingsHandler = &serverembeddings.Handler{
-		DB:       db,
-		Store:    server.embeddingStore,
-		Service:  server.embeddingService,
-		ATSStore: atsStore,
-		Logger:   serverLogger,
+		DB:           db,
+		Store:        server.embeddingStore,
+		Service:      server.embeddingService,
+		ATSStore:     atsStore,
+		Logger:       serverLogger,
+		CallReduce:   server.callReducePlugin,
+		Invalidator:  server.embeddingClusterInvalidator,
+		GroundDBPath: deps.config.GroundDBPath,
+		GroundWrite:  writeToGround,
 	}
 	if server.embeddingStats != nil {
 		ticker.SetEmbeddingStats(server.embeddingStats)

--- a/server/routing.go
+++ b/server/routing.go
@@ -124,10 +124,10 @@ func (s *QNTXServer) setupHTTPRoutes() {
 	http.HandleFunc("/api/embeddings/clusters/members", wrap(s.embeddingsHandler.HandleClusterMembers))   // Recent attestations in a cluster (GET)
 	http.HandleFunc("/api/embeddings/clusters/memberships", wrap(s.embeddingsHandler.HandleClusterMemberships)) // Cluster assignments for attestation IDs (GET)
 	http.HandleFunc("/api/embeddings/cluster-timeline", wrap(s.embeddingsHandler.HandleClusterTimeline))  // Cluster evolution timeline (GET)
-	http.HandleFunc("/api/embeddings/cluster", wrap(s.HandleEmbeddingCluster))                      // HDBSCAN clustering (POST)
+	http.HandleFunc("/api/embeddings/cluster", wrap(s.embeddingsHandler.HandleCluster))              // HDBSCAN clustering (POST)
 	http.HandleFunc("/api/embeddings/by-source", wrap(s.embeddingsHandler.HandleEmbeddingsBySource)) // Embeddings by attestation source IDs (POST)
 	http.HandleFunc("/api/embeddings/info", wrap(s.embeddingsHandler.HandleEmbeddingInfo))          // Embedding service status (GET)
-	http.HandleFunc("/api/embeddings/project", wrap(s.HandleEmbeddingProject))                      // UMAP projection (POST)
+	http.HandleFunc("/api/embeddings/project", wrap(s.embeddingsHandler.HandleProject))              // UMAP projection (POST)
 	http.HandleFunc("/api/embeddings/projections", wrap(s.embeddingsHandler.HandleEmbeddingProjections)) // Get 2D projections (GET)
 	http.HandleFunc("/", wrapPublic(s.HandleStatic))
 }


### PR DESCRIPTION
## Summary

- Second extraction pass: server/ root becomes thin wiring only — domain logic lives in server/embeddings/ with explicit dependency injection
- GroundWriteFunc callback pattern keeps ground_bridge.go decoupled without import cycles

## Test plan

- [x] `make test` passes
- [x] Verified cluster, project, auto-embed, semantic search endpoints on port 8773
- [x] Cluster timeline history intact