### PR TITLE
Build WASM in TS CI — gitignore all wasm-pack generated files

### DIFF
--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -21,6 +21,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build WASM module
+        run: make wasm
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ internal/server/dist/
 tmp/
 *.log
 web/wasm/qntx_wasm.js
+web/wasm/qntx_wasm.d.ts
+web/wasm/qntx_wasm_bg.wasm.d.ts
 
 # Test coverage
 web/coverage/


### PR DESCRIPTION
TS workflow now builds WASM before typechecking, so all three wasm-pack generated files (.js, .d.ts) can be gitignored. No more dirty tree after make dev.

Follow-up to #787 — gitignoring wasm bindings broke TS CI because tsc needed the .d.ts files. This adds make wasm to ts.yml so nothing generated lives in git.