### PR TITLE
Runtime plugin enable/disable without server restart

### DIFF
--- a/plugin/grpc/banner.go
+++ b/plugin/grpc/banner.go
@@ -19,6 +19,7 @@ const (
 	BannerRestart      BannerReason = "restart"
 	BannerRecovered    BannerReason = "recovered"
 	BannerReconfigured BannerReason = "reconfigured"
+	BannerDisabled     BannerReason = "disabled"
 )
 
 // BannerInfo holds accumulated lifecycle data for a single plugin banner.

--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -879,6 +879,85 @@ func (m *PluginManager) registerRestarted(ctx context.Context, name string, regi
 	}
 }
 
+// EnablePlugin discovers, loads, registers, and initializes a plugin at runtime.
+// The plugin must not already be loaded. Search paths are used to find the binary.
+func (m *PluginManager) EnablePlugin(ctx context.Context, name string, searchPaths []string, registry *plugin.Registry, services plugin.ServiceRegistry) error {
+	// Check if already loaded
+	m.mu.RLock()
+	_, exists := m.plugins[name]
+	m.mu.RUnlock()
+	if exists {
+		return errors.Newf("plugin '%s' is already loaded", name)
+	}
+
+	// Discover binary
+	config, err := discoverPlugin(name, searchPaths, m.logger)
+	if err != nil {
+		return errors.Wrapf(err, "failed to discover plugin '%s'", name)
+	}
+
+	// Load (launch process + connect gRPC)
+	if err := m.loadPlugin(ctx, config); err != nil {
+		return errors.Wrapf(err, "failed to load plugin '%s'", name)
+	}
+
+	// Register + initialize + setup handlers/watchers/schedules/providers
+	m.registerRestarted(ctx, name, registry, services)
+
+	return nil
+}
+
+// DisablePlugin shuts down a running plugin, unregisters it, and kills its process.
+// Prunes the plugin's watchers from the DB and removes async handlers.
+func (m *PluginManager) DisablePlugin(ctx context.Context, name string, registry *plugin.Registry) error {
+	m.mu.Lock()
+	p, exists := m.plugins[name]
+	if !exists {
+		m.mu.Unlock()
+		return errors.Newf("plugin '%s' is not loaded", name)
+	}
+	process := p.process
+	client := p.client
+	delete(m.plugins, name)
+	delete(m.failedPlugins, name)
+	m.mu.Unlock()
+
+	// Shutdown via gRPC (best-effort)
+	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	if err := client.Shutdown(shutdownCtx); err != nil {
+		m.logger.Warnw("Plugin shutdown RPC failed (will kill process)", "plugin", name, "error", err)
+	}
+	cancel()
+
+	// Kill process
+	if process != nil {
+		process.Kill()
+	}
+
+	// Unregister from plugin registry and mark stopped (not restarting)
+	registry.Unregister(name)
+	registry.MarkStopped(name)
+
+	// Prune watchers: pass empty list so all watchers with this plugin's prefix are deleted
+	if m.db != nil {
+		if err := SetupPluginWatchers(m.db, name, nil, m.logger); err != nil {
+			m.logger.Warnw("Failed to prune watchers for disabled plugin", "plugin", name, "error", err)
+		}
+		if m.onWatchersSetup != nil {
+			m.onWatchersSetup()
+		}
+	}
+
+	// Unregister async handlers
+	if m.handlerRegistry != nil {
+		for _, handlerName := range client.GetHandlerNames() {
+			m.handlerRegistry.Remove(handlerName)
+		}
+	}
+
+	return nil
+}
+
 // Shutdown stops all managed plugins and retry goroutines.
 func (m *PluginManager) Shutdown(ctx context.Context) error {
 	// Stop retry goroutines first

--- a/plugin/grpc/watchers.go
+++ b/plugin/grpc/watchers.go
@@ -19,10 +19,12 @@ import (
 // Uses CreateOrReplace for idempotency — safe across plugin restarts.
 // Prunes stale watchers that the plugin no longer declares.
 func SetupPluginWatchers(db *sql.DB, pluginName string, registrations []*protocol.WatcherRegistration, logger *zap.SugaredLogger) error {
-	logger.Infow("Setting up plugin watchers",
-		"plugin", pluginName,
-		"count", len(registrations),
-	)
+	if len(registrations) > 0 {
+		logger.Infow("Setting up plugin watchers",
+			"plugin", pluginName,
+			"count", len(registrations),
+		)
+	}
 
 	ws := storage.NewWatcherStore(db)
 	ctx := context.Background()

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -72,6 +72,13 @@ func (r *Registry) Unregister(name string) {
 	r.logger.Debugf("Unregistered plugin '%s' for restart", name)
 }
 
+// MarkStopped sets a plugin's state to stopped (used when disabling at runtime).
+func (r *Registry) MarkStopped(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states[name] = StateStopped
+}
+
 // Get retrieves a domain plugin by name
 func (r *Registry) Get(name string) (DomainPlugin, bool) {
 	r.mu.RLock()

--- a/plugin/registry_test.go
+++ b/plugin/registry_test.go
@@ -972,6 +972,51 @@ func TestRegistry_AsyncLoadingReadiness(t *testing.T) {
 		assert.Equal(t, []string{"registered"}, list)
 	})
 
+	t.Run("MarkStopped transitions to stopped state", func(t *testing.T) {
+		registry := NewRegistry("1.0.0", testLogger(t))
+		plugin := newMockPlugin("test")
+		require.NoError(t, registry.Register(plugin))
+
+		ctx := context.Background()
+		services := newMockServiceRegistry()
+		require.NoError(t, registry.InitializeAll(ctx, services))
+
+		// Running after init
+		state, _ := registry.GetState("test")
+		assert.Equal(t, StateRunning, state)
+
+		// Unregister sets restarting
+		registry.Unregister("test")
+		state, _ = registry.GetState("test")
+		assert.Equal(t, StateRestarting, state)
+
+		// MarkStopped overrides to stopped
+		registry.MarkStopped("test")
+		state, _ = registry.GetState("test")
+		assert.Equal(t, StateStopped, state)
+
+		// Plugin is no longer retrievable
+		_, ok := registry.Get("test")
+		assert.False(t, ok)
+	})
+
+	t.Run("Unregister then re-register", func(t *testing.T) {
+		registry := NewRegistry("1.0.0", testLogger(t))
+		plugin1 := newMockPlugin("test")
+		require.NoError(t, registry.Register(plugin1))
+
+		registry.Unregister("test")
+
+		// Can re-register after unregister
+		plugin2 := newMockPlugin("test")
+		err := registry.Register(plugin2)
+		require.NoError(t, err)
+
+		retrieved, ok := registry.Get("test")
+		assert.True(t, ok)
+		assert.Equal(t, plugin2, retrieved)
+	})
+
 	t.Run("async loading state transitions", func(t *testing.T) {
 		registry := NewRegistry("1.0.0", testLogger(t))
 

--- a/pulse/async/handler.go
+++ b/pulse/async/handler.go
@@ -80,6 +80,13 @@ func (r *HandlerRegistry) Replace(handler JobHandler) {
 	r.handlers[handler.Name()] = handler
 }
 
+// Remove deletes a handler by name. No-op if the handler doesn't exist.
+func (r *HandlerRegistry) Remove(handlerName string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.handlers, handlerName)
+}
+
 // Get retrieves the handler for a handler name.
 // Returns nil if no handler is registered.
 func (r *HandlerRegistry) Get(handlerName string) JobHandler {

--- a/pulse/async/handler_registry_test.go
+++ b/pulse/async/handler_registry_test.go
@@ -159,6 +159,65 @@ func TestHandlerRegistry_PhoneBook(t *testing.T) {
 		phoneBook.Register(techSupport2) // Should panic
 	})
 
+	t.Run("phone company removes department from phone book", func(t *testing.T) {
+		phoneBook := NewHandlerRegistry()
+
+		techSupport := &phoneBookTestHandler{name: "tech-support"}
+		billing := &phoneBookTestHandler{name: "billing"}
+		phoneBook.Register(techSupport)
+		phoneBook.Register(billing)
+
+		// Remove tech support
+		phoneBook.Remove("tech-support")
+
+		// tech-support should be gone
+		if phoneBook.Has("tech-support") {
+			t.Error("Expected tech-support to be removed")
+		}
+		if phoneBook.Get("tech-support") != nil {
+			t.Error("Expected nil for removed department")
+		}
+
+		// billing should still be there
+		if !phoneBook.Has("billing") {
+			t.Error("Expected billing to still exist")
+		}
+
+		// Names should only have billing
+		names := phoneBook.Names()
+		if len(names) != 1 {
+			t.Errorf("Expected 1 department, got %d", len(names))
+		}
+	})
+
+	t.Run("phone company removes non-existent department (no-op)", func(t *testing.T) {
+		phoneBook := NewHandlerRegistry()
+
+		// Should not panic
+		phoneBook.Remove("nonexistent")
+
+		if len(phoneBook.Names()) != 0 {
+			t.Errorf("Expected empty phone book after removing nonexistent entry")
+		}
+	})
+
+	t.Run("phone company re-registers after removal", func(t *testing.T) {
+		phoneBook := NewHandlerRegistry()
+
+		original := &phoneBookTestHandler{name: "tech-support"}
+		phoneBook.Register(original)
+		phoneBook.Remove("tech-support")
+
+		// Should be able to re-register without panic
+		replacement := &phoneBookTestHandler{name: "tech-support"}
+		phoneBook.Register(replacement)
+
+		handler := phoneBook.Get("tech-support")
+		if handler != replacement {
+			t.Error("Expected replacement handler after re-registration")
+		}
+	})
+
 	t.Run("phone company handles unknown departments", func(t *testing.T) {
 		phoneBook := NewHandlerRegistry()
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -898,8 +898,71 @@ func (s *QNTXServer) HandlePluginAction(w http.ResponseWriter, r *http.Request) 
 		s.logger.Debugw("Plugin restarted", "plugin", name)
 		s.BroadcastPluginHealth(name, true, string(plugin.StateRunning), "Plugin restarted")
 
+	case "enable":
+		pm := s.getPluginManager()
+		if pm == nil {
+			writeError(w, http.StatusServiceUnavailable, "Plugin manager not available")
+			return
+		}
+		// Re-read config to get current search paths
+		appcfg.Reset()
+		cfg, cfgErr := appcfg.Load()
+		if cfgErr != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to load config: %v", cfgErr))
+			return
+		}
+		err = pm.EnablePlugin(ctx, name, cfg.Plugin.Paths, s.pluginRegistry, s.services)
+		if err != nil {
+			s.logger.Warnw("Failed to enable plugin", "plugin", name, "error", err)
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		// Invalidate HTTP mux cache for the newly enabled plugin
+		s.pluginMuxes.Delete(name)
+		s.pluginMuxInit.Delete(name)
+		// Emit banner
+		if acc := pm.Accumulator(); acc != nil {
+			acc.Emit(name, plugingrpc.BannerBoot)
+		}
+		s.BroadcastPluginHealth(name, true, string(plugin.StateRunning), "Plugin enabled")
+
+	case "disable":
+		pm := s.getPluginManager()
+		if pm == nil {
+			writeError(w, http.StatusServiceUnavailable, "Plugin manager not available")
+			return
+		}
+		// Capture metadata before disabling (plugin will be gone after)
+		var disabledVersion string
+		var handlerCount, watcherCount int
+		if p, ok := s.pluginRegistry.Get(name); ok {
+			disabledVersion = p.Metadata().Version
+			if proxy, ok := p.(*plugingrpc.ExternalDomainProxy); ok {
+				handlerCount = len(proxy.GetHandlerNames())
+				watcherCount = len(proxy.GetWatchers())
+			}
+		}
+		err = pm.DisablePlugin(ctx, name, s.pluginRegistry)
+		if err != nil {
+			s.logger.Warnw("Failed to disable plugin", "plugin", name, "error", err)
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		// Clear cached HTTP mux
+		s.pluginMuxes.Delete(name)
+		s.pluginMuxInit.Delete(name)
+		// Emit disabled banner with cleanup summary
+		if acc := pm.Accumulator(); acc != nil {
+			acc.SetLoading(name, disabledVersion)
+			acc.SetHandlers(name, nil, 0, watcherCount)
+			status := fmt.Sprintf("stopped, %d handlers, %d watchers removed", handlerCount, watcherCount)
+			acc.SetHealth(name, true, status, nil)
+			acc.Emit(name, plugingrpc.BannerDisabled)
+		}
+		s.BroadcastPluginHealth(name, false, string(plugin.StateStopped), "Plugin disabled")
+
 	default:
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("Unknown action: %s (expected 'pause', 'resume', or 'restart')", action))
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("Unknown action: %s (expected 'pause', 'resume', 'restart', 'enable', or 'disable')", action))
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Plugins can be enabled/disabled via API (`POST /api/plugins/{name}/{enable,disable}`) while the server is running — no more restarting `make dev` for plugin lifecycle changes
- Disable: gRPC shutdown → kill process → unregister → prune watchers → remove async handlers
- Enable: discover binary → launch → gRPC connect → register → initialize → setup watchers/handlers
- Banners report both transitions; log noise reduced by suppressing empty-watcher setup messages

## Builds on

- #770 — Plugin watcher registration via InitializeResponse
- #776 — Single plugin init path with inline provider registration

## Follow-up

- #791 — Plugin panel UI: enable/disable buttons

## Test plan

- [x] `make test` — 663 pass, 0 fail
- [x] Rapid disable/enable cycles (5x) validated manually
- [x] Edge cases: double-disable, double-enable, all-off then selective re-enable
- [x] State correctly shows `stopped` (not `restarting`) after disable
- [x] Re-enable after disable fully restores plugin (watchers, handlers, HTTP routes)