### PR TITLE
Retire teranos/vanity-id — complete migration to Rust WASM (ADR-010)

### DIFF
--- a/ats/identity/id_noqntx.go
+++ b/ats/identity/id_noqntx.go
@@ -2,15 +2,12 @@
 
 package identity
 
-import (
-	id "github.com/teranos/vanity-id"
-)
+import "github.com/teranos/QNTX/errors"
 
-// generateASUID falls back to vanity-id when WASM is not available.
-// TODO(#645): remove this file once vanity-id is retired.
 func generateASUID(prefix, subject, predicate, context string) (string, error) {
-	if prefix != "AS" {
-		return id.GenerateASIDWithPrefix(prefix, subject, predicate, context, "")
-	}
-	return id.GenerateASID(subject, predicate, context, "")
+	return "", errors.New("ASUID generation requires qntxwasm build tag")
+}
+
+func generateRandomID(length int) (string, error) {
+	return "", errors.New("random ID generation requires qntxwasm build tag")
 }

--- a/ats/identity/id_qntx.go
+++ b/ats/identity/id_qntx.go
@@ -15,3 +15,12 @@ func generateASUID(prefix, subject, predicate, context string) (string, error) {
 	}
 	return engine.GenerateASUID(prefix, subject, predicate, context)
 }
+
+// generateRandomID generates a random ID via the Rust WASM engine.
+func generateRandomID(length int) (string, error) {
+	engine, err := wasm.GetEngine()
+	if err != nil {
+		return "", errors.Wrapf(err, "WASM engine unavailable for random ID (length %d)", length)
+	}
+	return engine.GenerateRandomID(length)
+}

--- a/ats/identity/identity.go
+++ b/ats/identity/identity.go
@@ -1,7 +1,7 @@
 // Package identity provides ASUID generation for all QNTX components.
 //
 // This is the single entry point for identity generation. Implementation
-// dispatches to Rust WASM (qntxwasm build tag) or falls back to vanity-id.
+// dispatches to Rust WASM (qntxwasm build tag).
 //
 // Usage:
 //
@@ -37,6 +37,11 @@ func GenerateASUIDWithRetry(prefix, subject, predicate, context string, checkExi
 // GenerateJobID generates a Job ASUID (JB prefix).
 func GenerateJobID(jobType, source string) (string, error) {
 	return generateASUID("JB", jobType, "process", source)
+}
+
+// GenerateRandomID generates a random ID of the given length using the QNTX alphabet.
+func GenerateRandomID(length int) (string, error) {
+	return generateRandomID(length)
 }
 
 // GenerateExecutionID generates a Pulse Execution ID (PX prefix).

--- a/ats/storage/batch_test.go
+++ b/ats/storage/batch_test.go
@@ -190,7 +190,7 @@ func TestPersistItems_EmptySubject(t *testing.T) {
 
 	bp := NewBatchPersister(db, store, "test-actor", "test-source")
 
-	// Empty subject is valid - vanity-id library accepts empty strings
+	// Empty subject is valid - identity library accepts empty strings
 	items := []AttestationItem{
 		&mockItem{
 			subject:   "alice",

--- a/ats/storage/embedding_store.go
+++ b/ats/storage/embedding_store.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/teranos/QNTX/ats/identity"
 	"github.com/teranos/QNTX/errors"
-	vanity "github.com/teranos/vanity-id"
 	"go.uber.org/zap"
 )
 
@@ -51,7 +51,7 @@ func (s *EmbeddingStore) Save(embedding *EmbeddingModel) error {
 
 	if embedding.ID == "" {
 		// Generate a random 8-character ID for embeddings
-		embedding.ID, _ = vanity.GenerateRandomID(8)
+		embedding.ID, _ = identity.GenerateRandomID(8)
 	}
 
 	now := time.Now().UTC()
@@ -351,7 +351,7 @@ func (s *EmbeddingStore) BatchSaveAttestationEmbeddings(embeddings []*EmbeddingM
 	for _, embedding := range embeddings {
 		if embedding.ID == "" {
 			// Generate a random 8-character ID for embeddings
-			embedding.ID, _ = vanity.GenerateRandomID(8)
+			embedding.ID, _ = identity.GenerateRandomID(8)
 		}
 		if embedding.CreatedAt.IsZero() {
 			embedding.CreatedAt = now

--- a/ats/types/type_definitions.go
+++ b/ats/types/type_definitions.go
@@ -97,7 +97,7 @@ func AttestType(store AttestationStore, typeName, source, context string, attrib
 		return errors.New("context cannot be empty")
 	}
 
-	// Generate ASUID (WASM engine with qntxwasm tag, vanity-id fallback without)
+	// Generate ASUID via Rust WASM engine
 	asuid, err := identity.GenerateASUID("AS", typeName, "type", context)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate ASUID for type %s", typeName)
@@ -198,7 +198,7 @@ func AttestRelationshipType(store AttestationStore, predicateName, source string
 		return errors.New("source cannot be empty")
 	}
 
-	// Generate ASUID (WASM engine with qntxwasm tag, vanity-id fallback without)
+	// Generate ASUID via Rust WASM engine
 	asuid, err := identity.GenerateASUID("AS", predicateName, "relationship_type", "graph")
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate ASUID for relationship type %s", predicateName)

--- a/ats/wasm/engine.go
+++ b/ats/wasm/engine.go
@@ -488,6 +488,49 @@ func (e *Engine) GenerateASUID(prefix, subject, predicate, context string) (stri
 	return result.Full, nil
 }
 
+// GenerateRandomID generates a random ID of the given length using the QNTX alphabet.
+// Randomness comes from crypto/rand.
+func (e *Engine) GenerateRandomID(length int) (string, error) {
+	randomBytes := make([]byte, length)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", errors.Wrap(err, "crypto/rand failed for random ID generation")
+	}
+
+	byteArray := make([]int, len(randomBytes))
+	for i, b := range randomBytes {
+		byteArray[i] = int(b)
+	}
+
+	input, err := json.Marshal(struct {
+		Length      int   `json:"length"`
+		RandomBytes []int `json:"random_bytes"`
+	}{
+		Length:      length,
+		RandomBytes: byteArray,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "marshal generate_random_id input")
+	}
+
+	raw, err := e.Call("generate_random_id", string(input))
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		ID    string `json:"id"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return "", errors.Wrapf(err, "unmarshal generate_random_id result: %s", raw)
+	}
+	if result.Error != "" {
+		return "", errors.Newf("generate_random_id: %s", result.Error)
+	}
+
+	return result.ID, nil
+}
+
 // GetWASMSize returns the size of the embedded WASM module in bytes.
 func GetWASMSize() int {
 	return len(wasmBytes)

--- a/crates/qntx-core/src/classify/classifier.rs
+++ b/crates/qntx-core/src/classify/classifier.rs
@@ -284,7 +284,7 @@ impl SmartClassifier {
             .collect();
 
         // Sort by credibility descending
-        rankings.sort_by(|a, b| b.credibility.cmp(&a.credibility));
+        rankings.sort_by_key(|r| std::cmp::Reverse(r.credibility));
         rankings
     }
 }

--- a/crates/qntx-wasm/src/browser.rs
+++ b/crates/qntx-wasm/src/browser.rs
@@ -772,6 +772,14 @@ pub fn generate_asuid(input: &str) -> String {
     crate::identity::generate_asuid_impl(input)
 }
 
+/// Generate a random ID using the QNTX alphabet.
+/// Input: `{"length":8,"random_bytes":[161,178,...]}`
+/// Returns JSON: `{"id":"A3B7X9K2"}` or `{"error":"..."}`.
+#[wasm_bindgen]
+pub fn generate_random_id(input: &str) -> String {
+    crate::identity::generate_random_id_impl(input)
+}
+
 /// Clean a seed string for ID generation (normalize, uppercase, collapse repeats).
 #[wasm_bindgen]
 pub fn id_clean_seed(input: &str) -> String {

--- a/crates/qntx-wasm/src/identity.rs
+++ b/crates/qntx-wasm/src/identity.rs
@@ -37,6 +37,37 @@ pub(crate) fn generate_asuid_impl(input: &str) -> String {
     }
 }
 
+/// JSON input for random ID generation.
+#[derive(serde::Deserialize)]
+pub(crate) struct RandomIdInput {
+    pub length: usize,
+    pub random_bytes: Vec<u8>,
+}
+
+/// Generate a random ID from JSON input, returning JSON with the ID string.
+pub(crate) fn generate_random_id_impl(input: &str) -> String {
+    let parsed: RandomIdInput = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            return format!(
+                r#"{{"error":"invalid JSON: {}"}}"#,
+                e.to_string().replace('"', "\\\"")
+            )
+        }
+    };
+
+    if parsed.random_bytes.len() < parsed.length {
+        return format!(
+            r#"{{"error":"need at least {} random bytes, got {}"}}"#,
+            parsed.length,
+            parsed.random_bytes.len()
+        );
+    }
+
+    let id = qntx_id::random_id_from_bytes(parsed.length, &parsed.random_bytes);
+    format!(r#"{{"id":"{}"}}"#, id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,6 +125,31 @@ mod tests {
         let result = generate_asuid_impl(&input.to_string());
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed["error"].as_str().is_some());
+    }
+
+    #[test]
+    fn generate_random_id_basic() {
+        let input = serde_json::json!({
+            "length": 8,
+            "random_bytes": [0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0xA7, 0xB8]
+        });
+        let result = generate_random_id_impl(&input.to_string());
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["error"].is_null(), "unexpected error: {}", result);
+        let id = parsed["id"].as_str().unwrap();
+        assert_eq!(id.len(), 8);
+        assert!(id.chars().all(|c| matches!(c, '2'..='9' | 'A'..='Z')));
+    }
+
+    #[test]
+    fn generate_random_id_insufficient_bytes() {
+        let input = serde_json::json!({
+            "length": 8,
+            "random_bytes": [0x01, 0x02]
+        });
+        let result = generate_random_id_impl(&input.to_string());
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["error"].as_str().unwrap().contains("need at least"));
     }
 
     #[test]

--- a/crates/qntx-wasm/src/lib.rs
+++ b/crates/qntx-wasm/src/lib.rs
@@ -495,6 +495,15 @@ mod wazero {
         write_result(&crate::identity::generate_asuid_impl(input))
     }
 
+    /// Generate a random ID using the QNTX alphabet.
+    /// Input: `{"length":8,"random_bytes":[161,178,...]}`
+    /// Returns packed u64 pointing to `{"id":"A3B7X9K2"}` or `{"error":"..."}`.
+    #[no_mangle]
+    pub extern "C" fn generate_random_id(ptr: u32, len: u32) -> u64 {
+        let input = unsafe { read_str(ptr, len) };
+        write_result(&crate::identity::generate_random_id_impl(input))
+    }
+
     /// Clean a seed string for ID generation (normalize, uppercase, collapse repeats).
     /// Input: raw UTF-8 string
     /// Returns packed u64 pointing to the cleaned string.

--- a/docs/adr/ADR-010-identity-system.md
+++ b/docs/adr/ADR-010-identity-system.md
@@ -1,11 +1,11 @@
 # ADR-010: QNTX Identity System — Vanity Subjects and Attestation System Unique IDs
 
 Date: 2026-03-06
-Status: Accepted
+Status: Completed (steps 1-4, 6). Step 5 won't-do.
 
 ## Context
 
-QNTX uses `teranos/vanity-id` (Go, v0.3.0) for all ID generation — attestation IDs, subject names, job IDs. The library is imported in 25+ files. It works, but it's a single Go module that can't run in the browser, and it conflates two fundamentally different concerns: human-readable names and unique attestation identity.
+QNTX used `teranos/vanity-id` (Go, v0.3.0) for all ID generation — attestation IDs, subject names, job IDs. The library was imported in 25+ files. It worked, but it was a single Go module that couldn't run in the browser, and it conflated two fundamentally different concerns: human-readable names and unique attestation identity.
 
 ## Decision
 
@@ -56,7 +56,7 @@ AS-SARAH-AUTHOR-GITHUB-7K4M3B9X
 
 ### Implementation: Rust crate `qntx-id`
 
-Both layers are implemented in a new Rust crate, maintained in this repository. The Go dependency on `teranos/vanity-id` is retired.
+Both layers are implemented in the Rust crate `qntx-id`, maintained in this repository. The Go dependency on `teranos/vanity-id` has been retired (#793).
 
 **Design principles:**
 
@@ -67,12 +67,12 @@ Both layers are implemented in a new Rust crate, maintained in this repository. 
 
 **Migration order** (each phase independently shippable):
 
-1. **Core alphabet and normalization** — Custom alphabet (Crockford-inspired, no 0/1), Unicode-to-ASCII, seed cleaning. Foundation for display segments in ASUIDs.
-2. **ASUID generation** — Prefix system (`AS`, `JB`, `PX`), SPC display segments, random suffix. Replaces all `GenerateASID*` calls (~20 call sites). This is the critical path.
-3. **Random ID generation** — For non-attestation uses (embedding IDs, run IDs). Replaces `GenerateRandomID`.
-4. **WASM bridge** — Expose to both wazero and browser targets as each piece lands, not as a separate phase.
-5. **Vanity ID generation** — Subject name derivation (name→handle). Not actively used in the codebase today — build when the feature is needed, not before.
-6. **Retire `teranos/vanity-id`** — Remove from `go.mod` once all callers are migrated.
+1. **Core alphabet and normalization** — Done. Custom alphabet (Crockford-inspired, no 0/1), Unicode-to-ASCII, seed cleaning.
+2. **ASUID generation** — Done. Prefix system (`AS`, `JB`, `PX`), SPC display segments, random suffix.
+3. **Random ID generation** — Done (#793). For non-attestation uses (embedding IDs, run IDs).
+4. **WASM bridge** — Done. Both wazero and browser targets.
+5. **Vanity ID generation** — Won't do. Subject name derivation (name→handle) is not needed.
+6. **Retire `teranos/vanity-id`** — Done (#793). Removed from `go.mod`, all callers migrated.
 
 ## Consequences
 
@@ -85,12 +85,12 @@ Both layers are implemented in a new Rust crate, maintained in this repository. 
 
 ### Negative
 
-- **Migration cost.** 25+ Go files need updating, incrementally.
+- **Migration cost.** 25+ Go files were updated across multiple PRs.
 
 ### Neutral
 
 - **Performance.** ID generation is not a bottleneck. The motivation is portability and readability.
-- **vanity-id retirement.** The Go module served its purpose as prior art. The lessons carry forward; the code doesn't.
+- **vanity-id retired.** The Go module served its purpose as prior art. The lessons carried forward; the code didn't.
 
 ## References
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/teranos/vanity-id v0.3.0 // TODO(#645): retire — migrate remaining callers to qntx-id via WASM
 	github.com/tetratelabs/wazero v1.11.0
 	github.com/tliron/glsp v0.2.2
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/teranos/vanity-id v0.3.0 h1:tEoGvYcJ2TN5ssDa9IoAeAGIGltRB3icJTM0pBPfox0=
-github.com/teranos/vanity-id v0.3.0/go.mod h1:NOEPEmgP0yUJVoaQEMHo03HB7YU5L8dzrEPHta0xQpY=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
 github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/nix/vendor-hash.nix
+++ b/nix/vendor-hash.nix
@@ -1,4 +1,4 @@
 # Shared Go vendorHash for all builds from repo root
 # To update: set vendorHash = pkgs.lib.fakeHash; in flake.nix,
 # run `nix build .#qntx`, copy the hash from the error, paste it here.
-"sha256-hizZTu3or4XrFeHA+PmqTktRcbE/zKZxvDRLnkSBCLY="
+"sha256-yJdWJ922vSdgIZG7VMCd9fk84rV9M2ROaQF+15gp7wc="

--- a/plugin/grpc/schedules.go
+++ b/plugin/grpc/schedules.go
@@ -125,7 +125,7 @@ func SetupPluginSchedules(db *sql.DB, pluginName string, schedules []*protocol.S
 
 // createPluginSchedule creates a new schedule.Job for a plugin-announced schedule.
 func createPluginSchedule(db *sql.DB, pluginName string, s *protocol.ScheduleInfo, logger *zap.SugaredLogger) error {
-	// Generate schedule ID using vanity-id
+	// Generate schedule ID
 	jobID, err := identity.GenerateASUID(
 		"AS",
 		fmt.Sprintf("plugin:%s:%s", pluginName, s.HandlerName),

--- a/server/embeddings/clustering.go
+++ b/server/embeddings/clustering.go
@@ -15,7 +15,6 @@ import (
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
-	vanity "github.com/teranos/vanity-id"
 	"go.uber.org/zap"
 )
 
@@ -274,7 +273,7 @@ func RunHDBSCANClustering(
 		"output_sha256", fmt.Sprintf("%x", outputHash.Sum(nil)))
 
 	// Create run record first — clusters and events reference it via FK
-	runID, _ := vanity.GenerateRandomID(12)
+	runID, _ := identity.GenerateRandomID(12)
 	runID = "CR_" + runID
 	clusterRun := &storage.ClusterRun{
 		ID:             runID,


### PR DESCRIPTION
## Summary
- All ID generation now routes through the Rust WASM engine (`qntx-id` crate)
- Added `generate_random_id` to the WASM bridge for embedding/run IDs
- Removed Go `vanity-id` dependency and the `id_noqntx.go` fallback file
- Completes ADR-010 steps 3 and 6

## Test plan
- [x] `make test` — all Go + TypeScript tests pass
- [x] `make wasm` — WASM module builds with new export
- [x] `cargo clippy` — no warnings on touched crates
- [ ] Manual: verify embedding and clustering IDs generate correctly in UI