### PR TITLE
Fix ATS backup deadlock under load

### DIFF
--- a/am/load.go
+++ b/am/load.go
@@ -81,6 +81,39 @@ func LoadFromFile(configPath string) (*Config, error) {
 	return &config, nil
 }
 
+// ReloadPluginSection re-reads am.toml from disk and updates Viper's keys
+// for the given plugin section. This allows plugin re-initialization to pick
+// up config changes without restarting the entire server.
+func ReloadPluginSection(pluginName string) error {
+	v, err := initViper()
+	if err != nil {
+		return errors.Wrap(err, "viper not initialized")
+	}
+
+	configPath := findProjectConfig()
+	if configPath == "" {
+		return nil // no project config, nothing to reload
+	}
+
+	// Read am.toml with a fresh viper to get current disk state
+	fresh := viper.New()
+	fresh.SetConfigFile(configPath)
+	fresh.SetConfigType("toml")
+	if err := fresh.ReadInConfig(); err != nil {
+		return errors.Wrapf(err, "failed to re-read config from %s", configPath)
+	}
+
+	// Copy all keys under [pluginName] into the global viper
+	prefix := pluginName + "."
+	for _, key := range fresh.AllKeys() {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			v.Set(key, fresh.Get(key))
+		}
+	}
+
+	return nil
+}
+
 // Reset clears the cached configuration (useful for testing)
 func Reset() {
 	globalConfig = nil

--- a/ats/storage/embedding_store.go
+++ b/ats/storage/embedding_store.go
@@ -50,8 +50,11 @@ func (s *EmbeddingStore) Save(embedding *EmbeddingModel) error {
 	}
 
 	if embedding.ID == "" {
-		// Generate a random 8-character ID for embeddings
-		embedding.ID, _ = identity.GenerateRandomID(8)
+		id, err := identity.GenerateRandomID(8)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate embedding ID")
+		}
+		embedding.ID = id
 	}
 
 	now := time.Now().UTC()
@@ -350,8 +353,12 @@ func (s *EmbeddingStore) BatchSaveAttestationEmbeddings(embeddings []*EmbeddingM
 	now := time.Now().UTC()
 	for _, embedding := range embeddings {
 		if embedding.ID == "" {
-			// Generate a random 8-character ID for embeddings
-			embedding.ID, _ = identity.GenerateRandomID(8)
+			id, idErr := identity.GenerateRandomID(8)
+			if idErr != nil {
+				err = errors.Wrap(idErr, "failed to generate embedding ID in batch save")
+				return err
+			}
+			embedding.ID = id
 		}
 		if embedding.CreatedAt.IsZero() {
 			embedding.CreatedAt = now

--- a/ats/storage/embedding_store_test.go
+++ b/ats/storage/embedding_store_test.go
@@ -31,6 +31,18 @@ func generateTestID() string {
 	return fmt.Sprintf("test-id-%d", testIDCounter)
 }
 
+func testEmbedding(text string) *EmbeddingModel {
+	return &EmbeddingModel{
+		ID:         generateTestID(),
+		SourceType: "attestation",
+		SourceID:   generateTestID(),
+		Text:       text,
+		Embedding:  createTestEmbedding(384),
+		Model:      "all-MiniLM-L6-v2",
+		Dimensions: 384,
+	}
+}
+
 // Helper function to create a test FLOAT32_BLOB embedding
 func createTestEmbedding(dimensions int) []byte {
 	embedding := make([]float32, dimensions)
@@ -57,6 +69,7 @@ func TestEmbeddingStore_Save(t *testing.T) {
 	store := NewEmbeddingStore(db, logger)
 
 	embedding := &EmbeddingModel{
+		ID:         generateTestID(),
 		SourceType: "attestation",
 		SourceID:   generateTestID(),
 		Text:       "test attestation content",
@@ -99,6 +112,7 @@ func TestEmbeddingStore_SemanticSearch(t *testing.T) {
 	// Create test embeddings with different similarities
 	embeddings := []*EmbeddingModel{
 		{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       "cat kitten feline",
@@ -107,6 +121,7 @@ func TestEmbeddingStore_SemanticSearch(t *testing.T) {
 			Dimensions: 384,
 		},
 		{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       "dog puppy canine",
@@ -115,6 +130,7 @@ func TestEmbeddingStore_SemanticSearch(t *testing.T) {
 			Dimensions: 384,
 		},
 		{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       "car vehicle automobile",
@@ -154,14 +170,7 @@ func TestEmbeddingStore_DeleteBySource(t *testing.T) {
 	logger := zap.NewNop()
 	store := NewEmbeddingStore(db, logger)
 
-	embedding := &EmbeddingModel{
-		SourceType: "attestation",
-		SourceID:   generateTestID(),
-		Text:       "test content to delete",
-		Embedding:  createTestEmbedding(384),
-		Model:      "all-MiniLM-L6-v2",
-		Dimensions: 384,
-	}
+	embedding := testEmbedding("test content to delete")
 
 	// Save the embedding
 	err := store.Save(embedding)
@@ -193,6 +202,7 @@ func TestEmbeddingStore_BatchSaveAttestationEmbeddings(t *testing.T) {
 
 	embeddings := []*EmbeddingModel{
 		{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       "batch test 1",
@@ -201,6 +211,7 @@ func TestEmbeddingStore_BatchSaveAttestationEmbeddings(t *testing.T) {
 			Dimensions: 384,
 		},
 		{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       "batch test 2",
@@ -209,6 +220,7 @@ func TestEmbeddingStore_BatchSaveAttestationEmbeddings(t *testing.T) {
 			Dimensions: 384,
 		},
 		{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       "batch test 3",
@@ -251,14 +263,7 @@ func TestEmbeddingStore_UpdateExisting(t *testing.T) {
 	logger := zap.NewNop()
 	store := NewEmbeddingStore(db, logger)
 
-	embedding := &EmbeddingModel{
-		SourceType: "attestation",
-		SourceID:   generateTestID(),
-		Text:       "original text",
-		Embedding:  createTestEmbedding(384),
-		Model:      "all-MiniLM-L6-v2",
-		Dimensions: 384,
-	}
+	embedding := testEmbedding("original text")
 
 	// Save initial
 	err := store.Save(embedding)
@@ -292,6 +297,7 @@ func TestEmbeddingStore_UpdateProjections(t *testing.T) {
 	embeddings := make([]*EmbeddingModel, 3)
 	for i := range embeddings {
 		embeddings[i] = &EmbeddingModel{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       fmt.Sprintf("projection test %d", i),
@@ -340,6 +346,7 @@ func TestEmbeddingStore_MultiMethodProjections(t *testing.T) {
 	embeddings := make([]*EmbeddingModel, 2)
 	for i := range embeddings {
 		embeddings[i] = &EmbeddingModel{
+			ID:         generateTestID(),
 			SourceType: "attestation",
 			SourceID:   generateTestID(),
 			Text:       fmt.Sprintf("multi-method test %d", i),
@@ -395,14 +402,7 @@ func TestEmbeddingStore_GetProjectionsByMethod_ExcludesUnprojected(t *testing.T)
 	// Save 3 embeddings
 	embeddings := make([]*EmbeddingModel, 3)
 	for i := range embeddings {
-		embeddings[i] = &EmbeddingModel{
-			SourceType: "attestation",
-			SourceID:   generateTestID(),
-			Text:       fmt.Sprintf("exclude test %d", i),
-			Embedding:  createTestEmbedding(384),
-			Model:      "all-MiniLM-L6-v2",
-			Dimensions: 384,
-		}
+		embeddings[i] = testEmbedding(fmt.Sprintf("exclude test %d", i))
 		require.NoError(t, store.Save(embeddings[i]))
 	}
 
@@ -442,14 +442,7 @@ func TestEmbeddingStore_ProjectionRoundTrip(t *testing.T) {
 	logger := zap.NewNop()
 	store := NewEmbeddingStore(db, logger)
 
-	embedding := &EmbeddingModel{
-		SourceType: "attestation",
-		SourceID:   generateTestID(),
-		Text:       "round trip test",
-		Embedding:  createTestEmbedding(384),
-		Model:      "all-MiniLM-L6-v2",
-		Dimensions: 384,
-	}
+	embedding := testEmbedding("round trip test")
 	require.NoError(t, store.Save(embedding))
 
 	// Project it
@@ -607,29 +600,17 @@ func TestEmbeddingStore_GetLabelEligibleClusters(t *testing.T) {
 
 	// Assign embeddings: c1=5, c2=10, c3=2
 	for i := 0; i < 5; i++ {
-		emb := &EmbeddingModel{
-			SourceType: "attestation", SourceID: generateTestID(),
-			Text: fmt.Sprintf("c1 text %d", i), Embedding: createTestEmbedding(384),
-			Model: "test", Dimensions: 384,
-		}
+		emb := testEmbedding(fmt.Sprintf("c1 text %d", i))
 		require.NoError(t, store.Save(emb))
 		require.NoError(t, store.UpdateClusterAssignments([]ClusterAssignment{{ID: emb.ID, ClusterID: c1, Probability: 0.9}}))
 	}
 	for i := 0; i < 10; i++ {
-		emb := &EmbeddingModel{
-			SourceType: "attestation", SourceID: generateTestID(),
-			Text: fmt.Sprintf("c2 text %d", i), Embedding: createTestEmbedding(384),
-			Model: "test", Dimensions: 384,
-		}
+		emb := testEmbedding(fmt.Sprintf("c2 text %d", i))
 		require.NoError(t, store.Save(emb))
 		require.NoError(t, store.UpdateClusterAssignments([]ClusterAssignment{{ID: emb.ID, ClusterID: c2, Probability: 0.9}}))
 	}
 	for i := 0; i < 2; i++ {
-		emb := &EmbeddingModel{
-			SourceType: "attestation", SourceID: generateTestID(),
-			Text: fmt.Sprintf("c3 text %d", i), Embedding: createTestEmbedding(384),
-			Model: "test", Dimensions: 384,
-		}
+		emb := testEmbedding(fmt.Sprintf("c3 text %d", i))
 		require.NoError(t, store.Save(emb))
 		require.NoError(t, store.UpdateClusterAssignments([]ClusterAssignment{{ID: emb.ID, ClusterID: c3, Probability: 0.9}}))
 	}
@@ -685,11 +666,7 @@ func TestEmbeddingStore_SampleClusterTexts(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		text := fmt.Sprintf("sample text %d", i)
 		expectedTexts[text] = true
-		emb := &EmbeddingModel{
-			SourceType: "attestation", SourceID: generateTestID(),
-			Text: text, Embedding: createTestEmbedding(384),
-			Model: "test", Dimensions: 384,
-		}
+		emb := testEmbedding(text)
 		require.NoError(t, store.Save(emb))
 		require.NoError(t, store.UpdateClusterAssignments([]ClusterAssignment{{ID: emb.ID, ClusterID: cid, Probability: 0.9}}))
 	}
@@ -830,14 +807,7 @@ func TestEmbeddingStore_GetClusterDetails(t *testing.T) {
 
 	// Save some embeddings and assign them to the cluster
 	for i := 0; i < 3; i++ {
-		emb := &EmbeddingModel{
-			SourceType: "attestation",
-			SourceID:   generateTestID(),
-			Text:       fmt.Sprintf("detail test %d", i),
-			Embedding:  createTestEmbedding(384),
-			Model:      "all-MiniLM-L6-v2",
-			Dimensions: 384,
-		}
+		emb := testEmbedding(fmt.Sprintf("detail test %d", i))
 		require.NoError(t, store.Save(emb))
 		require.NoError(t, store.UpdateClusterAssignments([]ClusterAssignment{
 			{ID: emb.ID, ClusterID: cid, Probability: 0.9},

--- a/ats/storage/sqlitecgo/storage_cgo.go
+++ b/ats/storage/sqlitecgo/storage_cgo.go
@@ -609,11 +609,11 @@ func (rs *RustStore) IntegrityCheck() ([]string, error) {
 }
 
 // Backup creates a hot backup of the database to destPath.
-// Safe to call while the database is in use.
+// Safe to call while the database is in use — SQLite's backup API handles
+// concurrency internally. Must NOT hold rs.mu: the backup reads the database
+// while other operations write, and holding the Go mutex deadlocks the system.
 func (rs *RustStore) Backup(destPath string) error {
-	rs.mu.Lock()
 	if rs.store == nil {
-		rs.mu.Unlock()
 		return errors.New("store is closed")
 	}
 
@@ -627,7 +627,6 @@ func (rs *RustStore) Backup(destPath string) error {
 		errMsg = C.GoString(result.error_msg)
 	}
 	C.storage_result_free(result)
-	rs.mu.Unlock()
 
 	if !success {
 		return errors.Newf("backup failed for %s: %s", destPath, errMsg)

--- a/ats/storage/sqlitecgo/watchdog.go
+++ b/ats/storage/sqlitecgo/watchdog.go
@@ -1,0 +1,59 @@
+package sqlitecgo
+
+import (
+	"sync"
+	"time"
+)
+
+// WatchdogConfig configures the mutex watchdog.
+type WatchdogConfig struct {
+	Interval time.Duration               // how often to probe
+	Timeout  time.Duration               // how long to wait for mutex acquisition
+	OnAlert  func(blocked time.Duration) // called when acquisition exceeds Timeout
+}
+
+// StartMutexWatchdog spawns a goroutine that periodically probes the given mutex.
+// If acquisition takes longer than Timeout, OnAlert is called.
+// Returns a stop function. Safe to call stop multiple times.
+func StartMutexWatchdog(mu *sync.Mutex, cfg WatchdogConfig) func() {
+	done := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		ticker := time.NewTicker(cfg.Interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				probe(mu, cfg.Timeout, cfg.OnAlert)
+			}
+		}
+	}()
+
+	return func() {
+		once.Do(func() { close(done) })
+	}
+}
+
+func probe(mu *sync.Mutex, timeout time.Duration, onAlert func(time.Duration)) {
+	acquired := make(chan struct{})
+	start := time.Now()
+
+	go func() {
+		mu.Lock()
+		mu.Unlock() //nolint:SA2001 // probe — we only measure acquisition time
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		// healthy
+	case <-time.After(timeout):
+		onAlert(time.Since(start))
+		// wait for the probe goroutine to finish so we don't leak
+		<-acquired
+	}
+}

--- a/ats/storage/sqlitecgo/watchdog_test.go
+++ b/ats/storage/sqlitecgo/watchdog_test.go
@@ -1,0 +1,63 @@
+package sqlitecgo
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWatchdog_DetectsStuckMutex(t *testing.T) {
+	var mu sync.Mutex
+	var alerts atomic.Int32
+
+	mu.Lock() // simulate stuck holder
+
+	stop := StartMutexWatchdog(&mu, WatchdogConfig{
+		Interval: 50 * time.Millisecond,
+		Timeout:  10 * time.Millisecond,
+		OnAlert: func(d time.Duration) {
+			alerts.Add(1)
+		},
+	})
+
+	// Wait for at least one alert
+	time.Sleep(150 * time.Millisecond)
+	mu.Unlock()
+	stop()
+
+	if alerts.Load() == 0 {
+		t.Fatal("watchdog did not fire an alert for stuck mutex")
+	}
+}
+
+func TestWatchdog_NoAlertWhenHealthy(t *testing.T) {
+	var mu sync.Mutex
+	var alerts atomic.Int32
+
+	stop := StartMutexWatchdog(&mu, WatchdogConfig{
+		Interval: 50 * time.Millisecond,
+		Timeout:  100 * time.Millisecond,
+		OnAlert: func(d time.Duration) {
+			alerts.Add(1)
+		},
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	stop()
+
+	if alerts.Load() != 0 {
+		t.Fatalf("watchdog fired %d alerts on healthy mutex", alerts.Load())
+	}
+}
+
+func TestWatchdog_StopIsIdempotent(t *testing.T) {
+	var mu sync.Mutex
+	stop := StartMutexWatchdog(&mu, WatchdogConfig{
+		Interval: 50 * time.Millisecond,
+		Timeout:  10 * time.Millisecond,
+		OnAlert:  func(d time.Duration) {},
+	})
+	stop()
+	stop() // second call should not panic
+}

--- a/cmd/qntx/commands/database.go
+++ b/cmd/qntx/commands/database.go
@@ -5,7 +5,9 @@ package commands
 import (
 	"database/sql"
 	"fmt"
+	"runtime"
 	"sync"
+	"time"
 
 	"github.com/teranos/QNTX/am"
 	"github.com/teranos/QNTX/ats"
@@ -60,6 +62,17 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) 
 		rustStore.Close()
 		return nil, nil, "", fmt.Errorf("failed to create attestation store: %w", err)
 	}
+
+	// Start mutex watchdog — alerts when RustStore mutex is held too long
+	sqlitecgo.StartMutexWatchdog(rustStore.Mu(), sqlitecgo.WatchdogConfig{
+		Interval: 30 * time.Second,
+		Timeout:  5 * time.Second,
+		OnAlert: func(blocked time.Duration) {
+			buf := make([]byte, 64*1024)
+			n := runtime.Stack(buf, true)
+			logger.Logger.Warnf("RustStore mutex held for %s — possible deadlock\n%s", blocked, buf[:n])
+		},
+	})
 
 	return database, atsStore, dbPath, nil
 }

--- a/crates/qntx-sqlite/src/store.rs
+++ b/crates/qntx-sqlite/src/store.rs
@@ -33,6 +33,8 @@ type StoreResult<T> = Result<T, StoreError>;
 /// SQLite-backed attestation store
 pub struct SqliteStore {
     pub(crate) conn: Connection,
+    /// Database file path, if file-backed. Used by backup to open a separate read connection.
+    pub(crate) db_path: Option<String>,
 }
 
 impl SqliteStore {
@@ -41,7 +43,10 @@ impl SqliteStore {
     /// The connection should already have migrations applied.
     /// Use [`crate::migrate::migrate`] to initialize a fresh database.
     pub fn new(conn: Connection) -> Self {
-        Self { conn }
+        Self {
+            conn,
+            db_path: None,
+        }
     }
 
     /// Create a new in-memory SQLite store (for testing)
@@ -59,13 +64,17 @@ impl SqliteStore {
         // Initialize sqlite-vec extension BEFORE creating connection
         crate::vec::init_vec_extension();
 
+        let path_str = path.as_ref().to_string_lossy().to_string();
         let conn = Connection::open(path)?;
 
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.pragma_update(None, "busy_timeout", "5000")?;
         crate::migrate::migrate(&conn)?;
-        Ok(Self::new(conn))
+        Ok(Self {
+            conn,
+            db_path: Some(path_str),
+        })
     }
 
     /// Run PRAGMA integrity_check and return the result lines.
@@ -86,12 +95,34 @@ impl SqliteStore {
     }
 
     /// Create a hot backup of the database to the given path.
-    /// Uses SQLite's online backup API — safe to call while the database is in use.
+    /// Opens a separate read-only source connection so the backup does not need
+    /// exclusive access to `self.conn` — callers do NOT need to hold the mutex.
     pub fn backup(&self, dest_path: &str) -> StoreResult<()> {
+        let src_path = self
+            .db_path
+            .as_deref()
+            .ok_or_else(|| StoreError::Backend("backup requires a file-backed database".into()))?;
+        let src = Connection::open_with_flags(
+            src_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(SqliteError::from)?;
         let mut dest = Connection::open(dest_path).map_err(SqliteError::from)?;
-        let b = backup::Backup::new(&self.conn, &mut dest).map_err(SqliteError::from)?;
-        b.run_to_completion(100, std::time::Duration::from_millis(10), None)
-            .map_err(SqliteError::from)?;
+        let b = backup::Backup::new(&src, &mut dest).map_err(SqliteError::from)?;
+
+        loop {
+            match b.step(5_000).map_err(SqliteError::from)? {
+                backup::StepResult::Done => break,
+                backup::StepResult::More => {
+                    // Yield briefly so writers aren't starved
+                    std::thread::yield_now();
+                }
+                backup::StepResult::Busy | backup::StepResult::Locked | _ => {
+                    // Short backoff — long waits let writers invalidate more pages
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+            }
+        }
         Ok(())
     }
 

--- a/docs/architecture/database-backup.md
+++ b/docs/architecture/database-backup.md
@@ -1,0 +1,45 @@
+# Database Hot Backup
+
+Periodic hot backup of the ATS SQLite database while the system is running.
+
+## Architecture
+
+Backup runs on the Pulse ticker (every `backup_interval_seconds`, default 3600). It rotates two files: `.bak1` (newest) and `.bak2` (previous).
+
+The backup opens its own **read-only SQLite connection** to the source database. It does not use the shared `RustStore` connection and does not hold the Go mutex. This means ATS operations (reads, writes, enforce_limits) continue uninterrupted during backup.
+
+The backup runs in a **goroutine** so the Pulse ticker loop is never blocked. An `atomic.Bool` guard prevents overlapping backups.
+
+## SQLite Backup API Under Write Load
+
+SQLite's `sqlite3_backup_step()` copies pages from source to destination. Under concurrent writes:
+
+- **`StepResult::More`** — pages copied successfully. The backup yields briefly (`thread::yield_now()`) to let writers proceed.
+- **`StepResult::Busy` / `Locked`** — the source is being written to. The backup backs off 5ms and retries.
+
+The backup uses a manual `step()` loop instead of rusqlite's `run_to_completion()`. Under sustained write load, `run_to_completion` stalls because its fixed sleep between steps (originally 250ms) gives writers enough time to re-acquire the lock before the next step can read. The manual loop uses minimal delays: `yield_now()` on success, 5ms on Busy.
+
+### Performance (measured under rw_flood at 100ms write interval, 273MB database)
+
+| Approach | Duration | Notes |
+|----------|----------|-------|
+| Old: mutex held during `C.storage_backup()` | 4-12s | **All ATS blocked for the entire duration** |
+| `run_to_completion(10k, 250ms)` | never finishes | 250ms sleep lets writers starve the backup |
+| `run_to_completion(1k, 10ms)` | 42s | Better but still too much yielding |
+| Manual `step(5k)`, yield/5ms backoff | 4-10s | No ATS blocking, completes reliably |
+
+## Configuration
+
+In `am.toml`:
+
+```toml
+[Database]
+backup_interval_seconds = 3600  # 0 disables backup
+```
+
+## Key Files
+
+- `crates/qntx-sqlite/src/store.rs` — `SqliteStore::backup()`: opens read-only source, manual step loop
+- `crates/qntx-sqlite/src/ffi.rs` — `storage_backup()`: FFI entry point
+- `ats/storage/sqlitecgo/storage_cgo.go` — `RustStore.Backup()`: Go wrapper, no mutex
+- `pulse/schedule/ticker.go` — `checkBackup()`: scheduling, goroutine, rotation

--- a/docs/development/grace.md
+++ b/docs/development/grace.md
@@ -292,11 +292,15 @@ config := async.WorkerPoolConfig{
 | `SIGTERM` | `kill <pid>` | Same as SIGINT |
 | `SIGQUIT` | Ctrl+\ or `kill -QUIT` | Go default: goroutine stacks to stderr, exit 2. Fallback when HTTP is unreachable |
 
-### Mutex watchdog (planned)
+### Mutex watchdog
 
 The RustStore shared mutex (`ats/storage/sqlitecgo/storage_cgo.go`) serializes all SQLite access. A leaked transaction or slow CGO call can hold this mutex indefinitely, deadlocking all attestation operations.
 
 A background goroutine periodically attempts to acquire the mutex with a timeout. If acquisition takes longer than the threshold, it logs a warning with the current goroutine stacks. This provides early warning before a full deadlock develops.
+
+### Database backup
+
+Hot backup runs on the Pulse ticker without holding the Go mutex. See [database-backup.md](../architecture/database-backup.md) for architecture, write-load behavior, and why `run_to_completion` stalls under sustained writes.
 
 ---
 **Status**: Implemented and tested

--- a/docs/development/grace.md
+++ b/docs/development/grace.md
@@ -269,5 +269,34 @@ config := async.WorkerPoolConfig{
 }
 ```
 
+## Diagnostics
+
+### pprof (always on)
+
+`net/http/pprof` is registered on the main HTTP server. Available whenever QNTX is running:
+
+| Endpoint | Use |
+|----------|-----|
+| `/debug/pprof/goroutine?debug=2` | Full goroutine stacks with mutex wait times — primary deadlock diagnostic |
+| `/debug/pprof/mutex` | Mutex contention profile |
+| `/debug/pprof/heap` | Memory allocation profile |
+| `/debug/pprof/profile?seconds=30` | CPU profile (30s sample) |
+
+**Example**: to diagnose a hanging ATS store, hit `http://localhost:{port}/debug/pprof/goroutine?debug=2` and look for goroutines blocked on mutex acquisition.
+
+### Signal behavior
+
+| Signal | Trigger | Behavior |
+|--------|---------|----------|
+| `SIGINT` | Ctrl+C | Graceful shutdown: stop workers (20s timeout), checkpoint jobs, stop plugins, exit 0 |
+| `SIGTERM` | `kill <pid>` | Same as SIGINT |
+| `SIGQUIT` | Ctrl+\ or `kill -QUIT` | Go default: goroutine stacks to stderr, exit 2. Fallback when HTTP is unreachable |
+
+### Mutex watchdog (planned)
+
+The RustStore shared mutex (`ats/storage/sqlitecgo/storage_cgo.go`) serializes all SQLite access. A leaked transaction or slow CGO call can hold this mutex indefinitely, deadlocking all attestation operations.
+
+A background goroutine periodically attempts to acquire the mutex with a timeout. If acquisition takes longer than the threshold, it logs a warning with the current goroutine stacks. This provides early warning before a full deadlock develops.
+
 ---
 **Status**: Implemented and tested

--- a/plugin/grpc/atsstore_server.go
+++ b/plugin/grpc/atsstore_server.go
@@ -137,7 +137,7 @@ func (s *ATSStoreServer) GetAttestations(ctx context.Context, req *protocol.GetA
 		}, nil
 	}
 
-	s.logger.Infow("GetAttestations",
+	s.logger.Debugw("GetAttestations",
 		"results", len(attestations),
 		"predicates", filter.Predicates,
 		"subjects", filter.Subjects,
@@ -158,7 +158,7 @@ func (s *ATSStoreServer) GetAttestations(ctx context.Context, req *protocol.GetA
 		protoAttestations[i] = protoAtt
 	}
 
-	s.logger.Infow("GetAttestations returning", "count", len(protoAttestations))
+	s.logger.Debugw("GetAttestations returning", "count", len(protoAttestations))
 
 	return &protocol.GetAttestationsResponse{
 		Success:      true,

--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/teranos/QNTX/am"
 	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
@@ -88,25 +89,25 @@ type PluginConfig struct {
 
 // PluginManager manages plugin processes and connections.
 type PluginManager struct {
-	mu                sync.RWMutex
-	plugins           map[string]*managedPlugin
-	failedPlugins     map[string]string // plugin name → error message for plugins that failed to load
-	logger            *zap.SugaredLogger
-	rootLogger        *zap.SugaredLogger // un-named root logger for creating per-plugin named loggers
-	basePort          int
-	nextPort          int             // Track the next port to allocate
-	portMu            sync.Mutex      // Separate mutex for port allocation
-	typescriptRuntime string          // Path to TypeScript runtime (main.ts)
-	shutdownCtx       context.Context // cancelled on Shutdown to stop retry goroutines
-	shutdownCancel    context.CancelFunc
-	servicesManager   *ServicesManager // for re-registering LLM providers after restart
-	accumulator       *PluginAccumulator
-	onWatchersSetup   func()            // called after plugin watchers are written to DB
-	onPluginRestarted        func(name string)                              // called after auto-restart succeeds (clear HTTP mux state)
+	mu                       sync.RWMutex
+	plugins                  map[string]*managedPlugin
+	failedPlugins            map[string]string // plugin name → error message for plugins that failed to load
+	logger                   *zap.SugaredLogger
+	rootLogger               *zap.SugaredLogger // un-named root logger for creating per-plugin named loggers
+	basePort                 int
+	nextPort                 int             // Track the next port to allocate
+	portMu                   sync.Mutex      // Separate mutex for port allocation
+	typescriptRuntime        string          // Path to TypeScript runtime (main.ts)
+	shutdownCtx              context.Context // cancelled on Shutdown to stop retry goroutines
+	shutdownCancel           context.CancelFunc
+	servicesManager          *ServicesManager // for re-registering LLM providers after restart
+	accumulator              *PluginAccumulator
+	onWatchersSetup          func()                                                    // called after plugin watchers are written to DB
+	onPluginRestarted        func(name string)                                         // called after auto-restart succeeds (clear HTTP mux state)
 	onEmbeddingProviderReady func(name string, client protocol.EmbeddingServiceClient) // called when embedding provider is ready (init or restart)
 	pidFile                  *pidFile
-	db                *sql.DB                // for schedule setup on restart
-	handlerRegistry   *async.HandlerRegistry // for handler re-registration on restart
+	db                       *sql.DB                // for schedule setup on restart
+	handlerRegistry          *async.HandlerRegistry // for handler re-registration on restart
 }
 
 // managedPlugin tracks a running plugin.
@@ -812,6 +813,10 @@ func (m *PluginManager) registerRestarted(ctx context.Context, name string, regi
 	registry.MarkReady(name)
 
 	if services != nil {
+		// Re-read am.toml from disk so plugin gets fresh config without server restart
+		if err := am.ReloadPluginSection(name); err != nil {
+			m.logger.Warnf("Failed to reload config for plugin '%s' from am.toml: %v", name, err)
+		}
 		if err := m.ReinitializePlugin(ctx, name, services); err != nil {
 			m.logger.Errorf("Failed to reinitialize plugin '%s' after restart: %v", name, err)
 		}

--- a/pulse/schedule/ticker.go
+++ b/pulse/schedule/ticker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -86,6 +87,7 @@ type Ticker struct {
 	backupDBPath    string        // source db path, used to derive backup destination
 	backupInterval  time.Duration // how often to backup (0 = disabled)
 	lastBackupAt    time.Time
+	backupRunning   atomic.Bool
 }
 
 // TickerConfig contains configuration for the Pulse ticker
@@ -337,6 +339,7 @@ func (t *Ticker) logActivitySummary() {
 
 // checkBackup runs a hot backup if the backup interval has elapsed.
 // Rotates .bak1 → .bak2, keeping 2 backups. .bak1 is always the newest.
+// Runs the backup in a goroutine so the ticker loop is never blocked.
 func (t *Ticker) checkBackup(now time.Time) {
 	if t.backupProvider == nil || t.backupInterval == 0 {
 		return
@@ -344,22 +347,31 @@ func (t *Ticker) checkBackup(now time.Time) {
 	if !t.lastBackupAt.IsZero() && now.Sub(t.lastBackupAt) < t.backupInterval {
 		return
 	}
+	if t.backupRunning.Load() {
+		return
+	}
+
+	// Mark backup started and update lastBackupAt so we don't re-trigger
+	t.backupRunning.Store(true)
+	t.lastBackupAt = now
 
 	bak1 := t.backupDBPath + ".bak1"
 	bak2 := t.backupDBPath + ".bak2"
 
-	// Rotate: .bak1 → .bak2
-	os.Rename(bak1, bak2)
+	go func() {
+		defer t.backupRunning.Store(false)
 
-	start := time.Now()
-	if err := t.backupProvider.Backup(bak1); err != nil {
-		t.pulseLog.Errorw("Database backup failed", "dest", bak1, "error", err)
-		return
-	}
-	duration := time.Since(start)
+		// Rotate: .bak1 → .bak2
+		os.Rename(bak1, bak2)
 
-	t.lastBackupAt = now
-	t.pulseLog.Infow("Database backup complete", "dest", bak1, "duration", duration.Round(time.Millisecond))
+		start := time.Now()
+		if err := t.backupProvider.Backup(bak1); err != nil {
+			t.pulseLog.Errorw("Database backup failed", "dest", bak1, "error", err)
+			return
+		}
+		duration := time.Since(start)
+		t.pulseLog.Infow("Database backup complete", "dest", bak1, "duration", duration.Round(time.Millisecond))
+	}()
 }
 
 // checkScheduledJobs finds scheduled jobs ready to run and enqueues them

--- a/qntx-plugins/faal/source/faal/grpc.d
+++ b/qntx-plugins/faal/source/faal/grpc.d
@@ -361,7 +361,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
         } catch (Exception) {}
     }
 
-    logInfo("[faal] grpc_client: connecting to %s:%d for %s", host, port, method);
 
     Socket sock;
     try {
@@ -375,7 +374,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
     }
     scope(exit) sock.close();
 
-    logInfo("[faal] grpc_client: connected, sending H2 preface");
 
     // Send HTTP/2 client preface
     auto sent = sock.send(cast(const(ubyte)[])H2_PREFACE);
@@ -396,7 +394,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
         logError("[faal] grpc_client: no server SETTINGS received");
         return null;
     }
-    logInfo("[faal] grpc_client: got server SETTINGS (type=%d)", serverSettings.type);
 
     // ACK server SETTINGS
     sendSettingsAck(sock);
@@ -410,7 +407,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
         auto f = readFrame(sock);
         if (f is null) break;
         if (f.type == FrameType.SETTINGS && (f.flags & FrameFlags.ACK) != 0) {
-            logInfo("[faal] grpc_client: got SETTINGS ACK");
             break;
         }
         if (f.type == FrameType.WINDOW_UPDATE) continue;
@@ -426,7 +422,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
     headers ~= encodeLiteralHeader("content-type", "application/grpc");
     headers ~= encodeLiteralHeader("te", "trailers");
 
-    logInfo("[faal] grpc_client: sending HEADERS + DATA on stream %d", streamId);
 
     writeFrame(sock, FrameType.HEADERS, FrameFlags.END_HEADERS, streamId, headers);
 
@@ -434,7 +429,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
     auto grpcData = grpcFrame(requestProto);
     writeFrame(sock, FrameType.DATA, FrameFlags.END_STREAM, streamId, grpcData);
 
-    logInfo("[faal] grpc_client: request sent, waiting for response...");
 
     // Read response frames
     ubyte[] responseData;
@@ -459,7 +453,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
                 break;
             case FrameType.HEADERS:
                 if ((f.flags & FrameFlags.END_STREAM) != 0) {
-                    logInfo("[faal] grpc_client: got trailers (END_STREAM)");
                     gotResponse = true;
                 }
                 break;
@@ -483,7 +476,6 @@ ubyte[] grpcCall(string address, string method, const ubyte[] requestProto, int 
 
     if (responseData.length > 0) {
         auto proto = grpcUnframe(responseData);
-        logInfo("[faal] grpc_client: got %d bytes response proto", proto.length);
         return proto;
     }
 

--- a/qntx-plugins/faal/source/faal/plugin.d
+++ b/qntx-plugins/faal/source/faal/plugin.d
@@ -27,6 +27,9 @@ enum FailureMode {
     bad_metadata,        // return corrupt Metadata
     random,              // pick a random misbehavior per RPC
     test_ats,            // test ATS gRPC endpoint during Initialize
+    ats_flood,           // continuously create attestations on a timer
+    read_flood,          // continuously query attestations on a timer
+    rw_flood,            // interspersed reads and writes on a timer
 }
 
 // ---------------------------------------------------------------------------
@@ -58,6 +61,9 @@ private FailureMode parseMode(string s) {
     if (s == "bad_metadata")        return FailureMode.bad_metadata;
     if (s == "random")              return FailureMode.random;
     if (s == "test_ats")            return FailureMode.test_ats;
+    if (s == "ats_flood")           return FailureMode.ats_flood;
+    if (s == "read_flood")          return FailureMode.read_flood;
+    if (s == "rw_flood")            return FailureMode.rw_flood;
     return FailureMode.none;
 }
 
@@ -137,6 +143,15 @@ private bool applyFailure(string rpcName) {
 
         case FailureMode.test_ats:
             return false; // handled in initialize()
+
+        case FailureMode.ats_flood:
+            return false; // handled in initialize()
+
+        case FailureMode.read_flood:
+            return false; // handled in initialize()
+
+        case FailureMode.rw_flood:
+            return false; // handled in initialize()
     }
 }
 
@@ -151,6 +166,9 @@ private string modeStr(FailureMode m) {
         case FailureMode.bad_metadata:        return "bad_metadata";
         case FailureMode.random:              return "random";
         case FailureMode.test_ats:            return "test_ats";
+        case FailureMode.ats_flood:           return "ats_flood";
+        case FailureMode.read_flood:          return "read_flood";
+        case FailureMode.rw_flood:            return "rw_flood";
     }
 }
 
@@ -254,6 +272,226 @@ InitializeResponse initialize(ref const InitializeRequest req) {
                     logError("[faal] test_ats: FAILED — %s", resp.error);
                 }
             }
+        }
+    }
+
+    // ats_flood: spawn background thread that continuously creates attestations
+    if (state.mode == FailureMode.ats_flood) {
+        auto endpoint = req.atsStoreEndpoint;
+        auto token = req.authToken;
+        int intervalMs = state.delayMs; // reuse delay_ms config, default 3000
+
+        if ("flood_interval_ms" in state.config) {
+            import std.conv : to;
+            try {
+                intervalMs = state.config["flood_interval_ms"].to!int;
+            } catch (Exception) {
+                intervalMs = 100;
+            }
+        }
+
+        if (endpoint.length > 0 && token.length > 0) {
+            logInfo("[faal] ats_flood: starting — interval=%dms endpoint=%s", intervalMs, endpoint);
+
+            auto floodThread = new Thread({
+                int count = 0;
+                while (true) {
+                    count++;
+                    auto cmd = AttestationCommand();
+                    cmd.subjects = ["faal-flood"];
+                    cmd.predicates = ["ats-flood"];
+                    cmd.contexts = ["chaos-test"];
+                    cmd.actors = ["faal"];
+                    cmd.source = "faal";
+                    cmd.sourceVersion = PLUGIN_VERSION;
+
+                    auto request = GenerateAttestationRequest();
+                    request.authToken = token;
+                    request.command = cmd;
+
+                    auto requestBytes = encode(request);
+
+                    import faal.grpc : grpcCall;
+                    auto responseBytes = grpcCall(
+                        endpoint,
+                        "/protocol.ATSStoreService/GenerateAndCreateAttestation",
+                        requestBytes,
+                        5_000
+                    );
+
+                    if (responseBytes is null) {
+                        logError("[faal] ats_flood #%d: RPC timeout", count);
+                    } else {
+                        auto resp = decode!GenerateAttestationResponse(responseBytes);
+                        if (resp.success) {
+                            if (count % 100 == 0)
+                                logInfo("[faal] ats_flood: %d attestations created", count);
+                        } else {
+                            logError("[faal] ats_flood #%d: %s", count, resp.error);
+                        }
+                    }
+
+                    Thread.sleep(dur!"msecs"(intervalMs));
+                }
+            });
+            floodThread.isDaemon = true;
+            floodThread.start();
+        } else {
+            logError("[faal] ats_flood: no endpoint or token — skipping");
+        }
+    }
+
+    // read_flood: spawn background thread that continuously queries attestations
+    if (state.mode == FailureMode.read_flood) {
+        auto endpoint = req.atsStoreEndpoint;
+        auto token = req.authToken;
+        int intervalMs = 10;
+
+        if ("flood_interval_ms" in state.config) {
+            import std.conv : to;
+            try {
+                intervalMs = state.config["flood_interval_ms"].to!int;
+            } catch (Exception) {
+                intervalMs = 100;
+            }
+        }
+
+        if (endpoint.length > 0 && token.length > 0) {
+            logInfo("[faal] read_flood: starting — interval=%dms endpoint=%s", intervalMs, endpoint);
+
+            auto readThread = new Thread({
+                int count = 0;
+                while (true) {
+                    count++;
+
+                    auto filter = AttestationFilter();
+                    filter.predicates = ["ats-flood"];
+                    filter.contexts = ["chaos-test"];
+
+                    auto request = GetAttestationsRequest();
+                    request.authToken = token;
+                    request.filter = filter;
+
+                    auto requestBytes = encode(request);
+
+                    import faal.grpc : grpcCall;
+                    auto responseBytes = grpcCall(
+                        endpoint,
+                        "/protocol.ATSStoreService/GetAttestations",
+                        requestBytes,
+                        5_000
+                    );
+
+                    if (responseBytes is null) {
+                        logError("[faal] read_flood #%d: RPC timeout", count);
+                    } else {
+                        auto resp = decode!GetAttestationsResponse(responseBytes);
+                        if (resp.success) {
+                            if (count % 100 == 0)
+                                logInfo("[faal] read_flood: %d queries completed", count);
+                        } else {
+                            logError("[faal] read_flood #%d: %s", count, resp.error);
+                        }
+                    }
+
+                    Thread.sleep(dur!"msecs"(intervalMs));
+                }
+            });
+            readThread.isDaemon = true;
+            readThread.start();
+        } else {
+            logError("[faal] read_flood: no endpoint or token — skipping");
+        }
+    }
+
+    // rw_flood: interspersed reads and writes
+    if (state.mode == FailureMode.rw_flood) {
+        auto endpoint = req.atsStoreEndpoint;
+        auto token = req.authToken;
+        int intervalMs = 10;
+
+        if ("flood_interval_ms" in state.config) {
+            import std.conv : to;
+            try {
+                intervalMs = state.config["flood_interval_ms"].to!int;
+            } catch (Exception) {
+                intervalMs = 10;
+            }
+        }
+
+        if (endpoint.length > 0 && token.length > 0) {
+            logInfo("[faal] rw_flood: starting — interval=%dms endpoint=%s", intervalMs, endpoint);
+
+            auto rwThread = new Thread({
+                int count = 0;
+                while (true) {
+                    count++;
+                    import faal.grpc : grpcCall;
+
+                    if (count % 2 == 1) {
+                        // Odd: write
+                        auto cmd = AttestationCommand();
+                        cmd.subjects = ["faal-flood"];
+                        cmd.predicates = ["ats-flood"];
+                        cmd.contexts = ["chaos-test"];
+                        cmd.actors = ["faal"];
+                        cmd.source = "faal";
+                        cmd.sourceVersion = PLUGIN_VERSION;
+
+                        auto request = GenerateAttestationRequest();
+                        request.authToken = token;
+                        request.command = cmd;
+
+                        auto responseBytes = grpcCall(
+                            endpoint,
+                            "/protocol.ATSStoreService/GenerateAndCreateAttestation",
+                            encode(request),
+                            5_000
+                        );
+
+                        if (responseBytes is null) {
+                            logError("[faal] rw_flood W#%d: RPC timeout", count);
+                        } else {
+                            auto resp = decode!GenerateAttestationResponse(responseBytes);
+                            if (!resp.success)
+                                logError("[faal] rw_flood W#%d: %s", count, resp.error);
+                        }
+                    } else {
+                        // Even: read
+                        auto filter = AttestationFilter();
+                        filter.predicates = ["ats-flood"];
+                        filter.contexts = ["chaos-test"];
+
+                        auto request = GetAttestationsRequest();
+                        request.authToken = token;
+                        request.filter = filter;
+
+                        auto responseBytes = grpcCall(
+                            endpoint,
+                            "/protocol.ATSStoreService/GetAttestations",
+                            encode(request),
+                            5_000
+                        );
+
+                        if (responseBytes is null) {
+                            logError("[faal] rw_flood R#%d: RPC timeout", count);
+                        } else {
+                            auto resp = decode!GetAttestationsResponse(responseBytes);
+                            if (!resp.success)
+                                logError("[faal] rw_flood R#%d: %s", count, resp.error);
+                        }
+                    }
+
+                    if (count % 200 == 0)
+                        logInfo("[faal] rw_flood: %d ops completed", count);
+
+                    Thread.sleep(dur!"msecs"(intervalMs));
+                }
+            });
+            rwThread.isDaemon = true;
+            rwThread.start();
+        } else {
+            logError("[faal] rw_flood: no endpoint or token — skipping");
         }
     }
 
@@ -367,8 +605,9 @@ void registerHandlers(ref GrpcServer server) {
 
     server.registerHandler("/protocol.DomainPluginService/ConfigSchema", (const ubyte[] _) {
         ConfigSchemaResponse resp;
-        resp.fields["failure_mode"] = "none|crash_once|crash_before_health|crash_after_health|hang_on_initialize|slow_responses|bad_metadata|random|test_ats";
-        resp.fields["delay_ms"]     = "Delay in milliseconds for slow_responses mode (default: 3000)";
+        resp.fields["failure_mode"]     = "none|crash_once|crash_before_health|crash_after_health|hang_on_initialize|slow_responses|bad_metadata|random|test_ats|ats_flood|read_flood|rw_flood";
+        resp.fields["delay_ms"]         = "Delay in milliseconds for slow_responses mode (default: 3000)";
+        resp.fields["flood_interval_ms"] = "Interval between attestations in ats_flood mode (default: 100)";
         return encode(resp);
     });
 

--- a/qntx-plugins/faal/source/faal/proto.d
+++ b/qntx-plugins/faal/source/faal/proto.d
@@ -469,3 +469,20 @@ struct GenerateAttestationResponse {
     @Proto(1) bool success;
     @Proto(2) string error;
 }
+
+struct AttestationFilter {
+    @Proto(1) @Repeated string[] subjects;
+    @Proto(2) @Repeated string[] predicates;
+    @Proto(3) @Repeated string[] contexts;
+    @Proto(4) @Repeated string[] actors;
+}
+
+struct GetAttestationsRequest {
+    @Proto(1) string authToken;
+    @Proto(2) AttestationFilter filter;
+}
+
+struct GetAttestationsResponse {
+    @Proto(1) bool success;
+    @Proto(2) string error;
+}

--- a/qntx-plugins/faal/source/faal/version_.d
+++ b/qntx-plugins/faal/source/faal/version_.d
@@ -2,4 +2,4 @@
 module faal.version_;
 
 enum PLUGIN_NAME    = "faal";
-enum PLUGIN_VERSION = "0.3.0";
+enum PLUGIN_VERSION = "0.4.3";

--- a/server/lifecycle.go
+++ b/server/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/teranos/QNTX/errors"

--- a/server/lifecycle.go
+++ b/server/lifecycle.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"runtime"
 	"time"
 
 	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/logger"
 )
+
+func init() {
+	runtime.SetMutexProfileFraction(5)
+	runtime.SetBlockProfileRate(1000)
+}
 
 // Opening/Closing Phase 4: Server state management
 


### PR DESCRIPTION
Follows #795 and #792 which removed the embedding FFI path. The remaining Rust FFI surface — SQLite storage — had a deadlock hiding in backup: `Backup()` held the Go mutex for 12+ seconds during `C.storage_backup()`, blocking all ATS operations. Levi's 3s timeout fired, plugins got connection errors, the system appeared hung.

Finding it required building the tools to find it:

- **pprof mutex/block profiling** — goroutine dumps showed 30+ goroutines stuck on `sync.Mutex.Lock` while `storage_backup` held the lock in a syscall
- **Faal rw_flood mode** — interspersed read/write chaos testing at 100ms interval to reproduce the contention
- **Plugin config hot-reload** — `am.toml` changes picked up on plugin restart without killing the server, for faster iteration

Fixing it took five attempts because the Rust/Go/SQLite boundary punishes assumptions:

1. Remove mutex, keep `self.conn` → segfault (rusqlite not thread-safe)
2. Separate connection, `run_to_completion(-1)` → panic (must be positive)
3. Separate connection, `run_to_completion(10k, 250ms)` → stalled forever under write load
4. Separate connection, `run_to_completion(1k, 10ms)` → 42s backup
5. **Manual `step(5k)` loop, `yield_now()`/5ms backoff → 4-10s under load**

The backup now opens its own read-only SQLite connection, runs in a goroutine (Pulse ticker never blocked), and uses a manual step loop that handles `Busy`/`Locked` without stalling.