### PR TITLE
Route search through plugin gRPC (SearchService)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-meili"
-version = "0.4.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "meilisearch-sdk",

--- a/docs/adr/ADR-015-search-as-plugin-provided-service.md
+++ b/docs/adr/ADR-015-search-as-plugin-provided-service.md
@@ -1,7 +1,7 @@
 # ADR-015: Search as a Plugin-Provided Service
 
 ## Status
-Accepted
+Completed
 
 ## Context
 
@@ -21,52 +21,7 @@ This is the second plugin-provided service on `ServiceRegistry`, after LLMServic
 
 ## Protocol
 
-`plugin/grpc/protocol/search.proto`
-
-```protobuf
-service SearchService {
-  rpc Search(SearchRequest) returns (SearchResponse);
-  rpc IndexDocuments(IndexDocumentsRequest) returns (IndexDocumentsResponse);
-  rpc DeleteDocuments(DeleteDocumentsRequest) returns (DeleteDocumentsResponse);
-}
-
-message SearchRequest {
-  string query = 1;           // search query text
-  string index = 2;           // which index to search
-  int32 top_k = 3;            // max results to return
-  bytes filters = 4;          // filter expression as JSON — interpreted by the provider
-}
-
-message SearchResponse {
-  repeated SearchHit hits = 1;
-  int32 total = 2;            // total matches (before top_k limit)
-  int32 processing_ms = 3;
-}
-
-message SearchHit {
-  string id = 1;
-  float score = 2;
-  bytes document = 3;         // indexed content as JSON
-}
-
-message IndexDocumentsRequest {
-  string index = 1;           // index name (created implicitly if needed)
-  repeated bytes documents = 2; // documents as JSON — schema is qntx-meili's concern
-}
-
-message IndexDocumentsResponse {
-  int32 accepted = 1;         // number of documents accepted for indexing
-}
-
-message DeleteDocumentsRequest {
-  string index = 1;
-  repeated string ids = 2;    // document IDs to remove
-}
-
-message DeleteDocumentsResponse {
-  int32 deleted = 1;
-}
-```
+See `plugin/grpc/protocol/search.proto`. Four RPCs: `Search`, `IndexDocuments`, `DeleteDocuments`, `ConfigureIndex`. Documents and filters flow as JSON bytes — the proto is engine-agnostic.
 
 ## Responsibility boundary
 
@@ -88,7 +43,7 @@ Same pattern as LLMService: `SearchServer` in core holds a reference to the prov
 
 ## Startup ordering
 
-If a plugin calls `services.Search()` before `qntx-meili` has initialized, the call fails. The plugin should fail its own initialization and be restarted until SearchService is available.
+If a plugin calls `services.Search()` before `qntx-meili` has initialized, the call fails. Consumer plugins should defer configuration (e.g. `ConfigureIndex`) and retry lazily rather than failing initialization — the search provider may register seconds after the consumer starts.
 
 ## Meili Panel Glyph
 

--- a/plugin/grpc/ocaml/proto/search.ml
+++ b/plugin/grpc/ocaml/proto/search.ml
@@ -36,8 +36,15 @@ module rec Protocol : sig
 %}
       *)
 
+      facets:string list;
+      (**
+{%html:
+<p>facet fields to include in response</p>
+%}
+      *)
+
     }
-    val make: ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> unit -> t
+    val make: ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> ?facets:string list -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -56,7 +63,7 @@ module rec Protocol : sig
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> unit -> t
+    type make_t = ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> ?facets:string list -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -69,8 +76,15 @@ module rec Protocol : sig
       hits:SearchHit.t list;
       total:int;
       processing_ms:int;
+      facet_distribution:bytes;
+      (**
+{%html:
+<p>facet counts as JSON</p>
+%}
+      *)
+
     }
-    val make: ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> unit -> t
+    val make: ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> ?facet_distribution:bytes -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -89,7 +103,7 @@ module rec Protocol : sig
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> unit -> t
+    type make_t = ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> ?facet_distribution:bytes -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -108,8 +122,15 @@ module rec Protocol : sig
 %}
       *)
 
+      highlighted:bytes;
+      (**
+{%html:
+<p>highlighted fields as JSON (_formatted from provider)</p>
+%}
+      *)
+
     }
-    val make: ?id:string -> ?score:float -> ?document:bytes -> unit -> t
+    val make: ?id:string -> ?score:float -> ?document:bytes -> ?highlighted:bytes -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -128,7 +149,7 @@ module rec Protocol : sig
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?id:string -> ?score:float -> ?document:bytes -> unit -> t
+    type make_t = ?id:string -> ?score:float -> ?document:bytes -> ?highlighted:bytes -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -264,6 +285,70 @@ module rec Protocol : sig
     (**/**)
   end
 
+  and ConfigureIndexRequest : sig
+    type t = {
+      index:string;
+      primary_key:string;
+      filterable_attributes:string list;
+      sortable_attributes:string list;
+      searchable_attributes:string list;
+    }
+    val make: ?index:string -> ?primary_key:string -> ?filterable_attributes:string list -> ?sortable_attributes:string list -> ?searchable_attributes:string list -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?index:string -> ?primary_key:string -> ?filterable_attributes:string list -> ?sortable_attributes:string list -> ?searchable_attributes:string list -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end
+
+  and ConfigureIndexResponse : sig
+    type t = (bool)
+    val make: ?accepted:bool -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?accepted:bool -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end
+
   module SearchService : sig
     module Search : sig
       include Runtime'.Service.Rpc with type Request.t = SearchRequest.t and type Response.t = SearchResponse.t
@@ -298,6 +383,17 @@ module rec Protocol : sig
     end
 
     val deleteDocuments : (module Runtime'.Spec.Message with type t = DeleteDocumentsRequest.t) * (module Runtime'.Spec.Message with type t = DeleteDocumentsResponse.t)
+    module ConfigureIndex : sig
+      include Runtime'.Service.Rpc with type Request.t = ConfigureIndexRequest.t and type Response.t = ConfigureIndexResponse.t
+      module Request : Runtime'.Spec.Message with type t = ConfigureIndexRequest.t and type make_t = ConfigureIndexRequest.make_t
+      (** Module alias for the request message for this method call *)
+
+      module Response : Runtime'.Spec.Message with type t = ConfigureIndexResponse.t and type make_t = ConfigureIndexResponse.make_t
+      (** Module alias for the response message for this method call *)
+
+    end
+
+    val configureIndex : (module Runtime'.Spec.Message with type t = ConfigureIndexRequest.t) * (module Runtime'.Spec.Message with type t = ConfigureIndexResponse.t)
   end
 
 end = struct
@@ -313,8 +409,15 @@ end = struct
 %}
       *)
 
+      facets:string list;
+      (**
+{%html:
+<p>facet fields to include in response</p>
+%}
+      *)
+
     }
-    val make: ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> unit -> t
+    val make: ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> ?facets:string list -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -333,7 +436,7 @@ end = struct
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> unit -> t
+    type make_t = ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> ?facets:string list -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -347,35 +450,38 @@ end = struct
       index:string;
       top_k:int;
       filters:bytes;
+      facets:string list;
     }
-    type make_t = ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> unit -> t
-    let make ?(query = {||}) ?(index = {||}) ?(top_k = 0) ?(filters = (Bytes.of_string {||})) () = { query; index; top_k; filters }
+    type make_t = ?query:string -> ?index:string -> ?top_k:int -> ?filters:bytes -> ?facets:string list -> unit -> t
+    let make ?(query = {||}) ?(index = {||}) ?(top_k = 0) ?(filters = (Bytes.of_string {||})) ?(facets = []) () = { query; index; top_k; filters; facets }
     let merge =
     let merge_query = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "query", "query"), string, ({||})) ) in
     let merge_index = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "index", "index"), string, ({||})) ) in
     let merge_top_k = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "top_k", "topK"), int32_int, (0)) ) in
     let merge_filters = Runtime'.Merge.merge Runtime'.Spec.( basic ((4, "filters", "filters"), bytes, ((Bytes.of_string {||}))) ) in
+    let merge_facets = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "facets", "facets"), string, not_packed) ) in
     fun t1 t2 -> {
     	query = (merge_query t1.query t2.query);
     	index = (merge_index t1.index t2.index);
     	top_k = (merge_top_k t1.top_k t2.top_k);
     	filters = (merge_filters t1.filters t2.filters);
+    	facets = (merge_facets t1.facets t2.facets);
      }
-    let spec () = Runtime'.Spec.( basic ((1, "query", "query"), string, ({||})) ^:: basic ((2, "index", "index"), string, ({||})) ^:: basic ((3, "top_k", "topK"), int32_int, (0)) ^:: basic ((4, "filters", "filters"), bytes, ((Bytes.of_string {||}))) ^:: nil )
+    let spec () = Runtime'.Spec.( basic ((1, "query", "query"), string, ({||})) ^:: basic ((2, "index", "index"), string, ({||})) ^:: basic ((3, "top_k", "topK"), int32_int, (0)) ^:: basic ((4, "filters", "filters"), bytes, ((Bytes.of_string {||}))) ^:: repeated ((5, "facets", "facets"), string, not_packed) ^:: nil )
     let to_proto' =
       let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
-      fun writer { query; index; top_k; filters } -> serialize writer query index top_k filters
+      fun writer { query; index; top_k; filters; facets } -> serialize writer query index top_k filters facets
 
     let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
     let from_proto_exn =
-      let constructor query index top_k filters = { query; index; top_k; filters } in
+      let constructor query index top_k filters facets = { query; index; top_k; filters; facets } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
     let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     let to_json options =
       let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
-      fun { query; index; top_k; filters } -> serialize query index top_k filters
+      fun { query; index; top_k; filters; facets } -> serialize query index top_k filters facets
     let from_json_exn =
-      let constructor query index top_k filters = { query; index; top_k; filters } in
+      let constructor query index top_k filters facets = { query; index; top_k; filters; facets } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end
@@ -385,8 +491,15 @@ end = struct
       hits:SearchHit.t list;
       total:int;
       processing_ms:int;
+      facet_distribution:bytes;
+      (**
+{%html:
+<p>facet counts as JSON</p>
+%}
+      *)
+
     }
-    val make: ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> unit -> t
+    val make: ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> ?facet_distribution:bytes -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -405,7 +518,7 @@ end = struct
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> unit -> t
+    type make_t = ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> ?facet_distribution:bytes -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -418,33 +531,36 @@ end = struct
       hits:SearchHit.t list;
       total:int;
       processing_ms:int;
+      facet_distribution:bytes;
     }
-    type make_t = ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> unit -> t
-    let make ?(hits = []) ?(total = 0) ?(processing_ms = 0) () = { hits; total; processing_ms }
+    type make_t = ?hits:SearchHit.t list -> ?total:int -> ?processing_ms:int -> ?facet_distribution:bytes -> unit -> t
+    let make ?(hits = []) ?(total = 0) ?(processing_ms = 0) ?(facet_distribution = (Bytes.of_string {||})) () = { hits; total; processing_ms; facet_distribution }
     let merge =
     let merge_hits = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "hits", "hits"), (message (module SearchHit)), not_packed) ) in
     let merge_total = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "total", "total"), int32_int, (0)) ) in
     let merge_processing_ms = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "processing_ms", "processingMs"), int32_int, (0)) ) in
+    let merge_facet_distribution = Runtime'.Merge.merge Runtime'.Spec.( basic ((4, "facet_distribution", "facetDistribution"), bytes, ((Bytes.of_string {||}))) ) in
     fun t1 t2 -> {
     	hits = (merge_hits t1.hits t2.hits);
     	total = (merge_total t1.total t2.total);
     	processing_ms = (merge_processing_ms t1.processing_ms t2.processing_ms);
+    	facet_distribution = (merge_facet_distribution t1.facet_distribution t2.facet_distribution);
      }
-    let spec () = Runtime'.Spec.( repeated ((1, "hits", "hits"), (message (module SearchHit)), not_packed) ^:: basic ((2, "total", "total"), int32_int, (0)) ^:: basic ((3, "processing_ms", "processingMs"), int32_int, (0)) ^:: nil )
+    let spec () = Runtime'.Spec.( repeated ((1, "hits", "hits"), (message (module SearchHit)), not_packed) ^:: basic ((2, "total", "total"), int32_int, (0)) ^:: basic ((3, "processing_ms", "processingMs"), int32_int, (0)) ^:: basic ((4, "facet_distribution", "facetDistribution"), bytes, ((Bytes.of_string {||}))) ^:: nil )
     let to_proto' =
       let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
-      fun writer { hits; total; processing_ms } -> serialize writer hits total processing_ms
+      fun writer { hits; total; processing_ms; facet_distribution } -> serialize writer hits total processing_ms facet_distribution
 
     let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
     let from_proto_exn =
-      let constructor hits total processing_ms = { hits; total; processing_ms } in
+      let constructor hits total processing_ms facet_distribution = { hits; total; processing_ms; facet_distribution } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
     let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     let to_json options =
       let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
-      fun { hits; total; processing_ms } -> serialize hits total processing_ms
+      fun { hits; total; processing_ms; facet_distribution } -> serialize hits total processing_ms facet_distribution
     let from_json_exn =
-      let constructor hits total processing_ms = { hits; total; processing_ms } in
+      let constructor hits total processing_ms facet_distribution = { hits; total; processing_ms; facet_distribution } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end
@@ -460,8 +576,15 @@ end = struct
 %}
       *)
 
+      highlighted:bytes;
+      (**
+{%html:
+<p>highlighted fields as JSON (_formatted from provider)</p>
+%}
+      *)
+
     }
-    val make: ?id:string -> ?score:float -> ?document:bytes -> unit -> t
+    val make: ?id:string -> ?score:float -> ?document:bytes -> ?highlighted:bytes -> unit -> t
     (** Helper function to generate a message using default values *)
 
     val to_proto: t -> Runtime'.Writer.t
@@ -480,7 +603,7 @@ end = struct
     (** Fully qualified protobuf name of this message *)
 
     (**/**)
-    type make_t = ?id:string -> ?score:float -> ?document:bytes -> unit -> t
+    type make_t = ?id:string -> ?score:float -> ?document:bytes -> ?highlighted:bytes -> unit -> t
     val merge: t -> t -> t
     val to_proto': Runtime'.Writer.t -> t -> unit
     val from_proto_exn: Runtime'.Reader.t -> t
@@ -493,33 +616,36 @@ end = struct
       id:string;
       score:float;
       document:bytes;
+      highlighted:bytes;
     }
-    type make_t = ?id:string -> ?score:float -> ?document:bytes -> unit -> t
-    let make ?(id = {||}) ?(score = 0.) ?(document = (Bytes.of_string {||})) () = { id; score; document }
+    type make_t = ?id:string -> ?score:float -> ?document:bytes -> ?highlighted:bytes -> unit -> t
+    let make ?(id = {||}) ?(score = 0.) ?(document = (Bytes.of_string {||})) ?(highlighted = (Bytes.of_string {||})) () = { id; score; document; highlighted }
     let merge =
     let merge_id = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "id", "id"), string, ({||})) ) in
     let merge_score = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "score", "score"), float, (0.)) ) in
     let merge_document = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "document", "document"), bytes, ((Bytes.of_string {||}))) ) in
+    let merge_highlighted = Runtime'.Merge.merge Runtime'.Spec.( basic ((4, "highlighted", "highlighted"), bytes, ((Bytes.of_string {||}))) ) in
     fun t1 t2 -> {
     	id = (merge_id t1.id t2.id);
     	score = (merge_score t1.score t2.score);
     	document = (merge_document t1.document t2.document);
+    	highlighted = (merge_highlighted t1.highlighted t2.highlighted);
      }
-    let spec () = Runtime'.Spec.( basic ((1, "id", "id"), string, ({||})) ^:: basic ((2, "score", "score"), float, (0.)) ^:: basic ((3, "document", "document"), bytes, ((Bytes.of_string {||}))) ^:: nil )
+    let spec () = Runtime'.Spec.( basic ((1, "id", "id"), string, ({||})) ^:: basic ((2, "score", "score"), float, (0.)) ^:: basic ((3, "document", "document"), bytes, ((Bytes.of_string {||}))) ^:: basic ((4, "highlighted", "highlighted"), bytes, ((Bytes.of_string {||}))) ^:: nil )
     let to_proto' =
       let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
-      fun writer { id; score; document } -> serialize writer id score document
+      fun writer { id; score; document; highlighted } -> serialize writer id score document highlighted
 
     let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
     let from_proto_exn =
-      let constructor id score document = { id; score; document } in
+      let constructor id score document highlighted = { id; score; document; highlighted } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
     let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
     let to_json options =
       let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
-      fun { id; score; document } -> serialize id score document
+      fun { id; score; document; highlighted } -> serialize id score document highlighted
     let from_json_exn =
-      let constructor id score document = { id; score; document } in
+      let constructor id score document highlighted = { id; score; document; highlighted } in
       Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end
@@ -770,6 +896,138 @@ end = struct
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end
 
+  and ConfigureIndexRequest : sig
+    type t = {
+      index:string;
+      primary_key:string;
+      filterable_attributes:string list;
+      sortable_attributes:string list;
+      searchable_attributes:string list;
+    }
+    val make: ?index:string -> ?primary_key:string -> ?filterable_attributes:string list -> ?sortable_attributes:string list -> ?searchable_attributes:string list -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?index:string -> ?primary_key:string -> ?filterable_attributes:string list -> ?sortable_attributes:string list -> ?searchable_attributes:string list -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end = struct
+    module This'_ = ConfigureIndexRequest
+    let name () = ".protocol.ConfigureIndexRequest"
+    type t = {
+      index:string;
+      primary_key:string;
+      filterable_attributes:string list;
+      sortable_attributes:string list;
+      searchable_attributes:string list;
+    }
+    type make_t = ?index:string -> ?primary_key:string -> ?filterable_attributes:string list -> ?sortable_attributes:string list -> ?searchable_attributes:string list -> unit -> t
+    let make ?(index = {||}) ?(primary_key = {||}) ?(filterable_attributes = []) ?(sortable_attributes = []) ?(searchable_attributes = []) () = { index; primary_key; filterable_attributes; sortable_attributes; searchable_attributes }
+    let merge =
+    let merge_index = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "index", "index"), string, ({||})) ) in
+    let merge_primary_key = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "primary_key", "primaryKey"), string, ({||})) ) in
+    let merge_filterable_attributes = Runtime'.Merge.merge Runtime'.Spec.( repeated ((3, "filterable_attributes", "filterableAttributes"), string, not_packed) ) in
+    let merge_sortable_attributes = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "sortable_attributes", "sortableAttributes"), string, not_packed) ) in
+    let merge_searchable_attributes = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "searchable_attributes", "searchableAttributes"), string, not_packed) ) in
+    fun t1 t2 -> {
+    	index = (merge_index t1.index t2.index);
+    	primary_key = (merge_primary_key t1.primary_key t2.primary_key);
+    	filterable_attributes = (merge_filterable_attributes t1.filterable_attributes t2.filterable_attributes);
+    	sortable_attributes = (merge_sortable_attributes t1.sortable_attributes t2.sortable_attributes);
+    	searchable_attributes = (merge_searchable_attributes t1.searchable_attributes t2.searchable_attributes);
+     }
+    let spec () = Runtime'.Spec.( basic ((1, "index", "index"), string, ({||})) ^:: basic ((2, "primary_key", "primaryKey"), string, ({||})) ^:: repeated ((3, "filterable_attributes", "filterableAttributes"), string, not_packed) ^:: repeated ((4, "sortable_attributes", "sortableAttributes"), string, not_packed) ^:: repeated ((5, "searchable_attributes", "searchableAttributes"), string, not_packed) ^:: nil )
+    let to_proto' =
+      let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
+      fun writer { index; primary_key; filterable_attributes; sortable_attributes; searchable_attributes } -> serialize writer index primary_key filterable_attributes sortable_attributes searchable_attributes
+
+    let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
+    let from_proto_exn =
+      let constructor index primary_key filterable_attributes sortable_attributes searchable_attributes = { index; primary_key; filterable_attributes; sortable_attributes; searchable_attributes } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
+    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
+    let to_json options =
+      let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
+      fun { index; primary_key; filterable_attributes; sortable_attributes; searchable_attributes } -> serialize index primary_key filterable_attributes sortable_attributes searchable_attributes
+    let from_json_exn =
+      let constructor index primary_key filterable_attributes sortable_attributes searchable_attributes = { index; primary_key; filterable_attributes; sortable_attributes; searchable_attributes } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
+    let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
+  end
+
+  and ConfigureIndexResponse : sig
+    type t = (bool)
+    val make: ?accepted:bool -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?accepted:bool -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end = struct
+    module This'_ = ConfigureIndexResponse
+    let name () = ".protocol.ConfigureIndexResponse"
+    type t = (bool)
+    type make_t = ?accepted:bool -> unit -> t
+    let make ?(accepted = false) () = (accepted)
+    let merge =
+    let merge_accepted = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "accepted", "accepted"), bool, (false)) ) in
+    fun (t1_accepted) (t2_accepted) -> merge_accepted t1_accepted t2_accepted
+    let spec () = Runtime'.Spec.( basic ((1, "accepted", "accepted"), bool, (false)) ^:: nil )
+    let to_proto' =
+      let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
+      fun writer (accepted) -> serialize writer accepted
+
+    let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
+    let from_proto_exn =
+      let constructor accepted = (accepted) in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
+    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
+    let to_json options =
+      let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
+      fun (accepted) -> serialize accepted
+    let from_json_exn =
+      let constructor accepted = (accepted) in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
+    let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
+  end
+
   module SearchService = struct
     module Search = struct
       let package_name = Some "protocol"
@@ -809,6 +1067,19 @@ end = struct
     let deleteDocuments =
       (module DeleteDocumentsRequest : Runtime'.Spec.Message with type t = DeleteDocumentsRequest.t ),
       (module DeleteDocumentsResponse : Runtime'.Spec.Message with type t = DeleteDocumentsResponse.t )
+
+    module ConfigureIndex = struct
+      let package_name = Some "protocol"
+      let service_name = "SearchService"
+      let method_name = "ConfigureIndex"
+      let name = "/protocol.SearchService/ConfigureIndex"
+      module Request = ConfigureIndexRequest
+      module Response = ConfigureIndexResponse
+    end
+
+    let configureIndex =
+      (module ConfigureIndexRequest : Runtime'.Spec.Message with type t = ConfigureIndexRequest.t ),
+      (module ConfigureIndexResponse : Runtime'.Spec.Message with type t = ConfigureIndexResponse.t )
 
   end
 

--- a/plugin/grpc/protocol/search.pb.go
+++ b/plugin/grpc/protocol/search.pb.go
@@ -27,6 +27,7 @@ type SearchRequest struct {
 	Index         string                 `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
 	TopK          int32                  `protobuf:"varint,3,opt,name=top_k,json=topK,proto3" json:"top_k,omitempty"`
 	Filters       []byte                 `protobuf:"bytes,4,opt,name=filters,proto3" json:"filters,omitempty"` // filter expression as JSON — interpreted by the provider
+	Facets        []string               `protobuf:"bytes,5,rep,name=facets,proto3" json:"facets,omitempty"`   // facet fields to include in response
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -89,13 +90,21 @@ func (x *SearchRequest) GetFilters() []byte {
 	return nil
 }
 
+func (x *SearchRequest) GetFacets() []string {
+	if x != nil {
+		return x.Facets
+	}
+	return nil
+}
+
 type SearchResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hits          []*SearchHit           `protobuf:"bytes,1,rep,name=hits,proto3" json:"hits,omitempty"`
-	Total         int32                  `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty"`
-	ProcessingMs  int32                  `protobuf:"varint,3,opt,name=processing_ms,json=processingMs,proto3" json:"processing_ms,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Hits              []*SearchHit           `protobuf:"bytes,1,rep,name=hits,proto3" json:"hits,omitempty"`
+	Total             int32                  `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty"`
+	ProcessingMs      int32                  `protobuf:"varint,3,opt,name=processing_ms,json=processingMs,proto3" json:"processing_ms,omitempty"`
+	FacetDistribution []byte                 `protobuf:"bytes,4,opt,name=facet_distribution,json=facetDistribution,proto3" json:"facet_distribution,omitempty"` // facet counts as JSON
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SearchResponse) Reset() {
@@ -149,11 +158,19 @@ func (x *SearchResponse) GetProcessingMs() int32 {
 	return 0
 }
 
+func (x *SearchResponse) GetFacetDistribution() []byte {
+	if x != nil {
+		return x.FacetDistribution
+	}
+	return nil
+}
+
 type SearchHit struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Score         float32                `protobuf:"fixed32,2,opt,name=score,proto3" json:"score,omitempty"`
-	Document      []byte                 `protobuf:"bytes,3,opt,name=document,proto3" json:"document,omitempty"` // indexed content as JSON
+	Document      []byte                 `protobuf:"bytes,3,opt,name=document,proto3" json:"document,omitempty"`       // indexed content as JSON
+	Highlighted   []byte                 `protobuf:"bytes,4,opt,name=highlighted,proto3" json:"highlighted,omitempty"` // highlighted fields as JSON (_formatted from provider)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -205,6 +222,13 @@ func (x *SearchHit) GetScore() float32 {
 func (x *SearchHit) GetDocument() []byte {
 	if x != nil {
 		return x.Document
+	}
+	return nil
+}
+
+func (x *SearchHit) GetHighlighted() []byte {
+	if x != nil {
+		return x.Highlighted
 	}
 	return nil
 }
@@ -401,24 +425,147 @@ func (x *DeleteDocumentsResponse) GetDeleted() int32 {
 	return 0
 }
 
+type ConfigureIndexRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Index                string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	PrimaryKey           string                 `protobuf:"bytes,2,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	FilterableAttributes []string               `protobuf:"bytes,3,rep,name=filterable_attributes,json=filterableAttributes,proto3" json:"filterable_attributes,omitempty"`
+	SortableAttributes   []string               `protobuf:"bytes,4,rep,name=sortable_attributes,json=sortableAttributes,proto3" json:"sortable_attributes,omitempty"`
+	SearchableAttributes []string               `protobuf:"bytes,5,rep,name=searchable_attributes,json=searchableAttributes,proto3" json:"searchable_attributes,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ConfigureIndexRequest) Reset() {
+	*x = ConfigureIndexRequest{}
+	mi := &file_plugin_grpc_protocol_search_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureIndexRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureIndexRequest) ProtoMessage() {}
+
+func (x *ConfigureIndexRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_grpc_protocol_search_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureIndexRequest.ProtoReflect.Descriptor instead.
+func (*ConfigureIndexRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_grpc_protocol_search_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ConfigureIndexRequest) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *ConfigureIndexRequest) GetPrimaryKey() string {
+	if x != nil {
+		return x.PrimaryKey
+	}
+	return ""
+}
+
+func (x *ConfigureIndexRequest) GetFilterableAttributes() []string {
+	if x != nil {
+		return x.FilterableAttributes
+	}
+	return nil
+}
+
+func (x *ConfigureIndexRequest) GetSortableAttributes() []string {
+	if x != nil {
+		return x.SortableAttributes
+	}
+	return nil
+}
+
+func (x *ConfigureIndexRequest) GetSearchableAttributes() []string {
+	if x != nil {
+		return x.SearchableAttributes
+	}
+	return nil
+}
+
+type ConfigureIndexResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Accepted      bool                   `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigureIndexResponse) Reset() {
+	*x = ConfigureIndexResponse{}
+	mi := &file_plugin_grpc_protocol_search_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureIndexResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureIndexResponse) ProtoMessage() {}
+
+func (x *ConfigureIndexResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_grpc_protocol_search_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureIndexResponse.ProtoReflect.Descriptor instead.
+func (*ConfigureIndexResponse) Descriptor() ([]byte, []int) {
+	return file_plugin_grpc_protocol_search_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ConfigureIndexResponse) GetAccepted() bool {
+	if x != nil {
+		return x.Accepted
+	}
+	return false
+}
+
 var File_plugin_grpc_protocol_search_proto protoreflect.FileDescriptor
 
 const file_plugin_grpc_protocol_search_proto_rawDesc = "" +
 	"\n" +
-	"!plugin/grpc/protocol/search.proto\x12\bprotocol\"j\n" +
+	"!plugin/grpc/protocol/search.proto\x12\bprotocol\"\x82\x01\n" +
 	"\rSearchRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x14\n" +
 	"\x05index\x18\x02 \x01(\tR\x05index\x12\x13\n" +
 	"\x05top_k\x18\x03 \x01(\x05R\x04topK\x12\x18\n" +
-	"\afilters\x18\x04 \x01(\fR\afilters\"t\n" +
+	"\afilters\x18\x04 \x01(\fR\afilters\x12\x16\n" +
+	"\x06facets\x18\x05 \x03(\tR\x06facets\"\xa3\x01\n" +
 	"\x0eSearchResponse\x12'\n" +
 	"\x04hits\x18\x01 \x03(\v2\x13.protocol.SearchHitR\x04hits\x12\x14\n" +
 	"\x05total\x18\x02 \x01(\x05R\x05total\x12#\n" +
-	"\rprocessing_ms\x18\x03 \x01(\x05R\fprocessingMs\"M\n" +
+	"\rprocessing_ms\x18\x03 \x01(\x05R\fprocessingMs\x12-\n" +
+	"\x12facet_distribution\x18\x04 \x01(\fR\x11facetDistribution\"o\n" +
 	"\tSearchHit\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05score\x18\x02 \x01(\x02R\x05score\x12\x1a\n" +
-	"\bdocument\x18\x03 \x01(\fR\bdocument\"K\n" +
+	"\bdocument\x18\x03 \x01(\fR\bdocument\x12 \n" +
+	"\vhighlighted\x18\x04 \x01(\fR\vhighlighted\"K\n" +
 	"\x15IndexDocumentsRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x1c\n" +
 	"\tdocuments\x18\x02 \x03(\fR\tdocuments\"4\n" +
@@ -428,11 +575,21 @@ const file_plugin_grpc_protocol_search_proto_rawDesc = "" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x10\n" +
 	"\x03ids\x18\x02 \x03(\tR\x03ids\"3\n" +
 	"\x17DeleteDocumentsResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\x05R\adeleted2\xf9\x01\n" +
+	"\adeleted\x18\x01 \x01(\x05R\adeleted\"\xe9\x01\n" +
+	"\x15ConfigureIndexRequest\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x12\x1f\n" +
+	"\vprimary_key\x18\x02 \x01(\tR\n" +
+	"primaryKey\x123\n" +
+	"\x15filterable_attributes\x18\x03 \x03(\tR\x14filterableAttributes\x12/\n" +
+	"\x13sortable_attributes\x18\x04 \x03(\tR\x12sortableAttributes\x123\n" +
+	"\x15searchable_attributes\x18\x05 \x03(\tR\x14searchableAttributes\"4\n" +
+	"\x16ConfigureIndexResponse\x12\x1a\n" +
+	"\baccepted\x18\x01 \x01(\bR\baccepted2\xce\x02\n" +
 	"\rSearchService\x12;\n" +
 	"\x06Search\x12\x17.protocol.SearchRequest\x1a\x18.protocol.SearchResponse\x12S\n" +
 	"\x0eIndexDocuments\x12\x1f.protocol.IndexDocumentsRequest\x1a .protocol.IndexDocumentsResponse\x12V\n" +
-	"\x0fDeleteDocuments\x12 .protocol.DeleteDocumentsRequest\x1a!.protocol.DeleteDocumentsResponseB.Z,github.com/teranos/QNTX/plugin/grpc/protocolb\x06proto3"
+	"\x0fDeleteDocuments\x12 .protocol.DeleteDocumentsRequest\x1a!.protocol.DeleteDocumentsResponse\x12S\n" +
+	"\x0eConfigureIndex\x12\x1f.protocol.ConfigureIndexRequest\x1a .protocol.ConfigureIndexResponseB.Z,github.com/teranos/QNTX/plugin/grpc/protocolb\x06proto3"
 
 var (
 	file_plugin_grpc_protocol_search_proto_rawDescOnce sync.Once
@@ -446,7 +603,7 @@ func file_plugin_grpc_protocol_search_proto_rawDescGZIP() []byte {
 	return file_plugin_grpc_protocol_search_proto_rawDescData
 }
 
-var file_plugin_grpc_protocol_search_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_plugin_grpc_protocol_search_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_plugin_grpc_protocol_search_proto_goTypes = []any{
 	(*SearchRequest)(nil),           // 0: protocol.SearchRequest
 	(*SearchResponse)(nil),          // 1: protocol.SearchResponse
@@ -455,17 +612,21 @@ var file_plugin_grpc_protocol_search_proto_goTypes = []any{
 	(*IndexDocumentsResponse)(nil),  // 4: protocol.IndexDocumentsResponse
 	(*DeleteDocumentsRequest)(nil),  // 5: protocol.DeleteDocumentsRequest
 	(*DeleteDocumentsResponse)(nil), // 6: protocol.DeleteDocumentsResponse
+	(*ConfigureIndexRequest)(nil),   // 7: protocol.ConfigureIndexRequest
+	(*ConfigureIndexResponse)(nil),  // 8: protocol.ConfigureIndexResponse
 }
 var file_plugin_grpc_protocol_search_proto_depIdxs = []int32{
 	2, // 0: protocol.SearchResponse.hits:type_name -> protocol.SearchHit
 	0, // 1: protocol.SearchService.Search:input_type -> protocol.SearchRequest
 	3, // 2: protocol.SearchService.IndexDocuments:input_type -> protocol.IndexDocumentsRequest
 	5, // 3: protocol.SearchService.DeleteDocuments:input_type -> protocol.DeleteDocumentsRequest
-	1, // 4: protocol.SearchService.Search:output_type -> protocol.SearchResponse
-	4, // 5: protocol.SearchService.IndexDocuments:output_type -> protocol.IndexDocumentsResponse
-	6, // 6: protocol.SearchService.DeleteDocuments:output_type -> protocol.DeleteDocumentsResponse
-	4, // [4:7] is the sub-list for method output_type
-	1, // [1:4] is the sub-list for method input_type
+	7, // 4: protocol.SearchService.ConfigureIndex:input_type -> protocol.ConfigureIndexRequest
+	1, // 5: protocol.SearchService.Search:output_type -> protocol.SearchResponse
+	4, // 6: protocol.SearchService.IndexDocuments:output_type -> protocol.IndexDocumentsResponse
+	6, // 7: protocol.SearchService.DeleteDocuments:output_type -> protocol.DeleteDocumentsResponse
+	8, // 8: protocol.SearchService.ConfigureIndex:output_type -> protocol.ConfigureIndexResponse
+	5, // [5:9] is the sub-list for method output_type
+	1, // [1:5] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
 	1, // [1:1] is the sub-list for extension extendee
 	0, // [0:1] is the sub-list for field type_name
@@ -482,7 +643,7 @@ func file_plugin_grpc_protocol_search_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_grpc_protocol_search_proto_rawDesc), len(file_plugin_grpc_protocol_search_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/plugin/grpc/protocol/search.proto
+++ b/plugin/grpc/protocol/search.proto
@@ -11,6 +11,7 @@ service SearchService {
   rpc Search(SearchRequest) returns (SearchResponse);
   rpc IndexDocuments(IndexDocumentsRequest) returns (IndexDocumentsResponse);
   rpc DeleteDocuments(DeleteDocumentsRequest) returns (DeleteDocumentsResponse);
+  rpc ConfigureIndex(ConfigureIndexRequest) returns (ConfigureIndexResponse);
 }
 
 message SearchRequest {
@@ -18,18 +19,21 @@ message SearchRequest {
   string index = 2;
   int32 top_k = 3;
   bytes filters = 4;          // filter expression as JSON — interpreted by the provider
+  repeated string facets = 5; // facet fields to include in response
 }
 
 message SearchResponse {
   repeated SearchHit hits = 1;
   int32 total = 2;
   int32 processing_ms = 3;
+  bytes facet_distribution = 4; // facet counts as JSON
 }
 
 message SearchHit {
   string id = 1;
   float score = 2;
   bytes document = 3;         // indexed content as JSON
+  bytes highlighted = 4;      // highlighted fields as JSON (_formatted from provider)
 }
 
 message IndexDocumentsRequest {
@@ -48,4 +52,16 @@ message DeleteDocumentsRequest {
 
 message DeleteDocumentsResponse {
   int32 deleted = 1;
+}
+
+message ConfigureIndexRequest {
+  string index = 1;
+  string primary_key = 2;
+  repeated string filterable_attributes = 3;
+  repeated string sortable_attributes = 4;
+  repeated string searchable_attributes = 5;
+}
+
+message ConfigureIndexResponse {
+  bool accepted = 1;
 }

--- a/plugin/grpc/protocol/search_grpc.pb.go
+++ b/plugin/grpc/protocol/search_grpc.pb.go
@@ -22,6 +22,7 @@ const (
 	SearchService_Search_FullMethodName          = "/protocol.SearchService/Search"
 	SearchService_IndexDocuments_FullMethodName  = "/protocol.SearchService/IndexDocuments"
 	SearchService_DeleteDocuments_FullMethodName = "/protocol.SearchService/DeleteDocuments"
+	SearchService_ConfigureIndex_FullMethodName  = "/protocol.SearchService/ConfigureIndex"
 )
 
 // SearchServiceClient is the client API for SearchService service.
@@ -35,6 +36,7 @@ type SearchServiceClient interface {
 	Search(ctx context.Context, in *SearchRequest, opts ...grpc.CallOption) (*SearchResponse, error)
 	IndexDocuments(ctx context.Context, in *IndexDocumentsRequest, opts ...grpc.CallOption) (*IndexDocumentsResponse, error)
 	DeleteDocuments(ctx context.Context, in *DeleteDocumentsRequest, opts ...grpc.CallOption) (*DeleteDocumentsResponse, error)
+	ConfigureIndex(ctx context.Context, in *ConfigureIndexRequest, opts ...grpc.CallOption) (*ConfigureIndexResponse, error)
 }
 
 type searchServiceClient struct {
@@ -75,6 +77,16 @@ func (c *searchServiceClient) DeleteDocuments(ctx context.Context, in *DeleteDoc
 	return out, nil
 }
 
+func (c *searchServiceClient) ConfigureIndex(ctx context.Context, in *ConfigureIndexRequest, opts ...grpc.CallOption) (*ConfigureIndexResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ConfigureIndexResponse)
+	err := c.cc.Invoke(ctx, SearchService_ConfigureIndex_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SearchServiceServer is the server API for SearchService service.
 // All implementations must embed UnimplementedSearchServiceServer
 // for forward compatibility.
@@ -86,6 +98,7 @@ type SearchServiceServer interface {
 	Search(context.Context, *SearchRequest) (*SearchResponse, error)
 	IndexDocuments(context.Context, *IndexDocumentsRequest) (*IndexDocumentsResponse, error)
 	DeleteDocuments(context.Context, *DeleteDocumentsRequest) (*DeleteDocumentsResponse, error)
+	ConfigureIndex(context.Context, *ConfigureIndexRequest) (*ConfigureIndexResponse, error)
 	mustEmbedUnimplementedSearchServiceServer()
 }
 
@@ -104,6 +117,9 @@ func (UnimplementedSearchServiceServer) IndexDocuments(context.Context, *IndexDo
 }
 func (UnimplementedSearchServiceServer) DeleteDocuments(context.Context, *DeleteDocumentsRequest) (*DeleteDocumentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteDocuments not implemented")
+}
+func (UnimplementedSearchServiceServer) ConfigureIndex(context.Context, *ConfigureIndexRequest) (*ConfigureIndexResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ConfigureIndex not implemented")
 }
 func (UnimplementedSearchServiceServer) mustEmbedUnimplementedSearchServiceServer() {}
 func (UnimplementedSearchServiceServer) testEmbeddedByValue()                       {}
@@ -180,6 +196,24 @@ func _SearchService_DeleteDocuments_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SearchService_ConfigureIndex_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ConfigureIndexRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SearchServiceServer).ConfigureIndex(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SearchService_ConfigureIndex_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SearchServiceServer).ConfigureIndex(ctx, req.(*ConfigureIndexRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SearchService_ServiceDesc is the grpc.ServiceDesc for SearchService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -198,6 +232,10 @@ var SearchService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteDocuments",
 			Handler:    _SearchService_DeleteDocuments_Handler,
+		},
+		{
+			MethodName: "ConfigureIndex",
+			Handler:    _SearchService_ConfigureIndex_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/plugin/grpc/remote_search.go
+++ b/plugin/grpc/remote_search.go
@@ -49,6 +49,7 @@ func (r *RemoteSearch) Search(ctx context.Context, req plugin.SearchRequest) (*p
 		Index:   req.Index,
 		TopK:    int32(req.TopK),
 		Filters: req.Filters,
+		Facets:  req.Facets,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "search service gRPC call failed")
@@ -57,16 +58,18 @@ func (r *RemoteSearch) Search(ctx context.Context, req plugin.SearchRequest) (*p
 	hits := make([]plugin.SearchHit, len(resp.Hits))
 	for i, h := range resp.Hits {
 		hits[i] = plugin.SearchHit{
-			ID:       h.Id,
-			Score:    h.Score,
-			Document: h.Document,
+			ID:          h.Id,
+			Score:       h.Score,
+			Document:    h.Document,
+			Highlighted: h.Highlighted,
 		}
 	}
 
 	return &plugin.SearchResponse{
-		Hits:         hits,
-		Total:        int(resp.Total),
-		ProcessingMs: int(resp.ProcessingMs),
+		Hits:              hits,
+		Total:             int(resp.Total),
+		ProcessingMs:      int(resp.ProcessingMs),
+		FacetDistribution: resp.FacetDistribution,
 	}, nil
 }
 
@@ -97,5 +100,23 @@ func (r *RemoteSearch) DeleteDocuments(ctx context.Context, req plugin.DeleteDoc
 
 	return &plugin.DeleteDocumentsResponse{
 		Deleted: int(resp.Deleted),
+	}, nil
+}
+
+// ConfigureIndex sends an index configuration request via gRPC.
+func (r *RemoteSearch) ConfigureIndex(ctx context.Context, req plugin.ConfigureIndexRequest) (*plugin.ConfigureIndexResponse, error) {
+	resp, err := r.client.ConfigureIndex(ctx, &protocol.ConfigureIndexRequest{
+		Index:                req.Index,
+		PrimaryKey:           req.PrimaryKey,
+		FilterableAttributes: req.FilterableAttributes,
+		SortableAttributes:   req.SortableAttributes,
+		SearchableAttributes: req.SearchableAttributes,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "configure index gRPC call failed")
+	}
+
+	return &plugin.ConfigureIndexResponse{
+		Accepted: resp.Accepted,
 	}, nil
 }

--- a/plugin/grpc/search_server.go
+++ b/plugin/grpc/search_server.go
@@ -94,6 +94,21 @@ func (s *SearchServer) DeleteDocuments(ctx context.Context, req *protocol.Delete
 	return resp, nil
 }
 
+// ConfigureIndex routes an index configuration request to the provider plugin.
+func (s *SearchServer) ConfigureIndex(ctx context.Context, req *protocol.ConfigureIndexRequest) (*protocol.ConfigureIndexResponse, error) {
+	client, name, err := s.getProvider()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ConfigureIndex(ctx, req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "configure index via provider %s failed", name)
+	}
+
+	return resp, nil
+}
+
 // getProvider returns the search client or an error if none is registered.
 func (s *SearchServer) getProvider() (protocol.SearchServiceClient, string, error) {
 	s.mu.RLock()

--- a/plugin/grpc/server.go
+++ b/plugin/grpc/server.go
@@ -568,6 +568,7 @@ func (s *searchPluginServer) Search(ctx context.Context, req *protocol.SearchReq
 		Index:   req.Index,
 		TopK:    int(req.TopK),
 		Filters: req.Filters,
+		Facets:  req.Facets,
 	})
 	if err != nil {
 		return nil, err
@@ -576,16 +577,18 @@ func (s *searchPluginServer) Search(ctx context.Context, req *protocol.SearchReq
 	hits := make([]*protocol.SearchHit, len(resp.Hits))
 	for i, h := range resp.Hits {
 		hits[i] = &protocol.SearchHit{
-			Id:       h.ID,
-			Score:    h.Score,
-			Document: h.Document,
+			Id:          h.ID,
+			Score:       h.Score,
+			Document:    h.Document,
+			Highlighted: h.Highlighted,
 		}
 	}
 
 	return &protocol.SearchResponse{
-		Hits:         hits,
-		Total:        int32(resp.Total),
-		ProcessingMs: int32(resp.ProcessingMs),
+		Hits:              hits,
+		Total:             int32(resp.Total),
+		ProcessingMs:      int32(resp.ProcessingMs),
+		FacetDistribution: resp.FacetDistribution,
 	}, nil
 }
 
@@ -614,5 +617,22 @@ func (s *searchPluginServer) DeleteDocuments(ctx context.Context, req *protocol.
 
 	return &protocol.DeleteDocumentsResponse{
 		Deleted: int32(resp.Deleted),
+	}, nil
+}
+
+func (s *searchPluginServer) ConfigureIndex(ctx context.Context, req *protocol.ConfigureIndexRequest) (*protocol.ConfigureIndexResponse, error) {
+	resp, err := s.provider.ConfigureIndex(ctx, plugin.ConfigureIndexRequest{
+		Index:                req.Index,
+		PrimaryKey:           req.PrimaryKey,
+		FilterableAttributes: req.FilterableAttributes,
+		SortableAttributes:   req.SortableAttributes,
+		SearchableAttributes: req.SearchableAttributes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &protocol.ConfigureIndexResponse{
+		Accepted: resp.Accepted,
 	}, nil
 }

--- a/plugin/interface.go
+++ b/plugin/interface.go
@@ -177,6 +177,9 @@ type SearchProvider interface {
 
 	// DeleteDocuments removes documents from an index by ID.
 	DeleteDocuments(ctx context.Context, req DeleteDocumentsRequest) (*DeleteDocumentsResponse, error)
+
+	// ConfigureIndex creates/configures an index with filterable, sortable, and searchable attributes.
+	ConfigureIndex(ctx context.Context, req ConfigureIndexRequest) (*ConfigureIndexResponse, error)
 }
 
 // EmbeddingProvider is an optional interface marker for plugins that provide

--- a/plugin/services.go
+++ b/plugin/services.go
@@ -156,6 +156,9 @@ type SearchService interface {
 
 	// DeleteDocuments removes documents from an index by ID.
 	DeleteDocuments(ctx context.Context, req DeleteDocumentsRequest) (*DeleteDocumentsResponse, error)
+
+	// ConfigureIndex creates/configures an index with filterable, sortable, and searchable attributes.
+	ConfigureIndex(ctx context.Context, req ConfigureIndexRequest) (*ConfigureIndexResponse, error)
 }
 
 // SearchRequest is a search query against an index.
@@ -163,21 +166,24 @@ type SearchRequest struct {
 	Query   string
 	Index   string
 	TopK    int
-	Filters []byte // filter expression as JSON — interpreted by the provider
+	Filters []byte   // filter expression as JSON — interpreted by the provider
+	Facets  []string // facet fields to include in response
 }
 
 // SearchResponse contains ranked search results.
 type SearchResponse struct {
-	Hits         []SearchHit
-	Total        int
-	ProcessingMs int
+	Hits              []SearchHit
+	Total             int
+	ProcessingMs      int
+	FacetDistribution []byte // facet counts as JSON
 }
 
 // SearchHit is a single search result.
 type SearchHit struct {
-	ID       string
-	Score    float32
-	Document []byte // indexed content as JSON
+	ID          string
+	Score       float32
+	Document    []byte // indexed content as JSON
+	Highlighted []byte // highlighted fields as JSON
 }
 
 // IndexDocumentsRequest pushes documents into an index.
@@ -200,6 +206,20 @@ type DeleteDocumentsRequest struct {
 // DeleteDocumentsResponse reports how many documents were deleted.
 type DeleteDocumentsResponse struct {
 	Deleted int
+}
+
+// ConfigureIndexRequest creates/configures an index with its settings.
+type ConfigureIndexRequest struct {
+	Index                string
+	PrimaryKey           string
+	FilterableAttributes []string
+	SortableAttributes   []string
+	SearchableAttributes []string
+}
+
+// ConfigureIndexResponse reports whether the configuration was accepted.
+type ConfigureIndexResponse struct {
+	Accepted bool
 }
 
 // ServiceRegistry provides access to QNTX core services for domain plugins.

--- a/qntx-plugins/gaze/README.md
+++ b/qntx-plugins/gaze/README.md
@@ -48,3 +48,7 @@ Scry instruments every token with signal data and renders a 3D nebula. Gaze is t
 - **IBP** — Image-based PDFs return empty text. OCR not supported.
 - **UIG** — UI still references scry. The LLM provider glyph (`llm-provider-glyph.ts`) hardcodes scry as the local provider option. Needs a gaze option or a generic "local" toggle that discovers whichever local LLM plugin is running.
 - **SDR** — Shutdown race between gRPC teardown and llama.cpp destructor. Cosmetic log noise.
+
+## Feature Requests
+
+- **NMOD** — Gaze should refuse to start (or report unhealthy) when no models are configured. Currently it starts successfully with "no models loaded", which masks configuration errors and causes silent downstream failures for any plugin relying on the LLM service.

--- a/qntx-plugins/qntx-meili/Cargo.toml
+++ b/qntx-plugins/qntx-meili/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qntx-meili"
-version = "0.4.0"
+version = "0.7.1"
 edition.workspace = true
 description = "QNTX search provider plugin — routes SearchService RPCs to MeiliSearch"
 license.workspace = true

--- a/qntx-plugins/qntx-meili/Makefile
+++ b/qntx-plugins/qntx-meili/Makefile
@@ -18,6 +18,7 @@ install: ## Build, install, and restart qntx-meili plugin
 	@mkdir -p $(PREFIX)/plugins
 	@cp $(WORKSPACE_ROOT)/target/release/qntx-meili $(PREFIX)/plugins/qntx-meili
 	@chmod +x $(PREFIX)/plugins/qntx-meili
+	@codesign -s - --force $(PREFIX)/plugins/qntx-meili
 	@echo "✓ BUILD OK — binary installed to $(PREFIX)/plugins/qntx-meili"
 	$(call restart-plugin)
 

--- a/qntx-plugins/qntx-meili/src/main.rs
+++ b/qntx-plugins/qntx-meili/src/main.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_thread_ids(false)
         .with_file(false)
         .with_line_number(false)
+        .with_writer(std::io::stderr)
         .init();
 
     info!("Initializing QNTX MeiliSearch Plugin");
@@ -79,6 +80,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = listener.local_addr()?;
     info!("gRPC server listening on {}", addr);
     println!("QNTX_PLUGIN_PORT={}", addr.port());
+    use std::io::Write;
+    std::io::stdout().flush().ok();
 
     let search_service = Arc::new(MeiliSearchService::new());
     let plugin_service =

--- a/qntx-plugins/qntx-meili/src/search.rs
+++ b/qntx-plugins/qntx-meili/src/search.rs
@@ -2,8 +2,8 @@ use meilisearch_sdk::client::Client;
 use parking_lot::RwLock;
 use qntx_grpc::plugin::proto::search_service_server::SearchService;
 use qntx_grpc::plugin::proto::{
-    DeleteDocumentsRequest, DeleteDocumentsResponse, IndexDocumentsRequest, IndexDocumentsResponse,
-    SearchHit, SearchRequest, SearchResponse,
+    ConfigureIndexRequest, ConfigureIndexResponse, DeleteDocumentsRequest, DeleteDocumentsResponse,
+    IndexDocumentsRequest, IndexDocumentsResponse, SearchHit, SearchRequest, SearchResponse,
 };
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
@@ -96,7 +96,35 @@ impl SearchService for MeiliSearchService {
             query.with_limit(req.top_k as usize);
         }
 
-        // TODO: apply filters from req.filters (JSON bytes)
+        // Apply filters from req.filters (JSON bytes — expect a string filter expression)
+        let filter_str = if !req.filters.is_empty() {
+            match serde_json::from_slice::<String>(&req.filters) {
+                Ok(f) if !f.is_empty() => Some(f),
+                _ => {
+                    // Try raw UTF-8 string (non-JSON-quoted filter)
+                    match std::str::from_utf8(&req.filters) {
+                        Ok(s) if !s.is_empty() => Some(s.to_string()),
+                        _ => None,
+                    }
+                }
+            }
+        } else {
+            None
+        };
+        if let Some(ref f) = filter_str {
+            query.with_filter(f);
+        }
+
+        // Apply facets
+        let facet_refs: Vec<&str> = req.facets.iter().map(|s| s.as_str()).collect();
+        if !facet_refs.is_empty() {
+            query.with_facets(meilisearch_sdk::search::Selectors::Some(&facet_refs));
+        }
+
+        // Request highlights on all attributes
+        query.with_attributes_to_highlight(meilisearch_sdk::search::Selectors::All);
+        query.with_highlight_pre_tag("<em>");
+        query.with_highlight_post_tag("</em>");
 
         let start = std::time::Instant::now();
         let results = query
@@ -111,6 +139,11 @@ impl SearchService for MeiliSearchService {
             .into_iter()
             .map(|hit| {
                 let doc_bytes = serde_json::to_vec(&hit.result).unwrap_or_default();
+                let highlighted = hit
+                    .formatted_result
+                    .as_ref()
+                    .and_then(|v| serde_json::to_vec(v).ok())
+                    .unwrap_or_default();
                 SearchHit {
                     id: hit
                         .result
@@ -120,16 +153,24 @@ impl SearchService for MeiliSearchService {
                         .to_string(),
                     score: 0.0, // MeiliSearch doesn't expose relevance scores by default
                     document: doc_bytes,
+                    highlighted,
                 }
             })
             .collect();
 
         let total = results.estimated_total_hits.unwrap_or(hits.len());
 
+        let facet_distribution = results
+            .facet_distribution
+            .as_ref()
+            .and_then(|fd| serde_json::to_vec(fd).ok())
+            .unwrap_or_default();
+
         Ok(Response::new(SearchResponse {
             hits,
             total: total as i32,
             processing_ms,
+            facet_distribution,
         }))
     }
 
@@ -174,5 +215,79 @@ impl SearchService for MeiliSearchService {
             .map_err(|e| Status::internal(format!("MeiliSearch delete failed: {}", e)))?;
 
         Ok(Response::new(DeleteDocumentsResponse { deleted: count }))
+    }
+
+    async fn configure_index(
+        &self,
+        request: Request<ConfigureIndexRequest>,
+    ) -> Result<Response<ConfigureIndexResponse>, Status> {
+        let req = request.into_inner();
+        let client = self.get_client()?;
+
+        // Create the index with the specified primary key
+        let pk = if req.primary_key.is_empty() {
+            None
+        } else {
+            Some(req.primary_key.as_str())
+        };
+        // create_index is idempotent — returns TaskInfo even if index exists
+        let _ = client
+            .create_index(&req.index, pk)
+            .await
+            .map_err(|e| Status::internal(format!("create index '{}' failed: {}", req.index, e)))?;
+
+        let index = client.index(&req.index);
+
+        // Set filterable attributes
+        if !req.filterable_attributes.is_empty() {
+            let attrs: Vec<&str> = req
+                .filterable_attributes
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            index.set_filterable_attributes(&attrs).await.map_err(|e| {
+                Status::internal(format!(
+                    "set filterable attributes on '{}' failed: {}",
+                    req.index, e
+                ))
+            })?;
+        }
+
+        // Set sortable attributes
+        if !req.sortable_attributes.is_empty() {
+            let attrs: Vec<&str> = req.sortable_attributes.iter().map(|s| s.as_str()).collect();
+            index.set_sortable_attributes(&attrs).await.map_err(|e| {
+                Status::internal(format!(
+                    "set sortable attributes on '{}' failed: {}",
+                    req.index, e
+                ))
+            })?;
+        }
+
+        // Set searchable attributes
+        if !req.searchable_attributes.is_empty() {
+            let attrs: Vec<&str> = req
+                .searchable_attributes
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            index.set_searchable_attributes(&attrs).await.map_err(|e| {
+                Status::internal(format!(
+                    "set searchable attributes on '{}' failed: {}",
+                    req.index, e
+                ))
+            })?;
+        }
+
+        info!(
+            "Configured index '{}' (pk={}, filterable={}, sortable={}, searchable={})",
+            req.index,
+            pk.unwrap_or("auto"),
+            req.filterable_attributes.len(),
+            req.sortable_attributes.len(),
+            req.searchable_attributes.len(),
+        );
+
+        Ok(Response::new(ConfigureIndexResponse { accepted: true }))
     }
 }


### PR DESCRIPTION
## Summary

- Extend SearchService proto with `ConfigureIndex` RPC, facet requests, facet distribution responses, and highlighted fields
- Implement in qntx-meili: index creation with primary key, filterable/sortable/searchable attributes, filter passthrough, facet/highlight returns
- Fix release binary loading: tracing to stderr, stdout flush, codesign after copy

Removes the last direct-HTTP path between CTP plugins and backend services. Search now routes exclusively through QNTX plugin infrastructure.

## Lineage

- #792 — Route embedding calls through plugin gRPC (Cyrnel)
- #795 — Remove FFI remnants (cleanup after #792)
- **This PR** — Route search calls through plugin gRPC (meili)

## Verified

- `make test` passes (663/663)
- meili 0.7.1 loads on first try after codesign fix
- End-to-end: CV upload → LLM parse → candidate indexed via gRPC → search returns result with facets and highlights