### PR TITLE
Pulse dedup: fingerprint by failing handlers only

### DIFF
--- a/server/embeddings/pulse.go
+++ b/server/embeddings/pulse.go
@@ -120,6 +120,11 @@ func (h *ReprojectHandler) writeLog(jobID, stage, level, message, metadata strin
 // EmitPulseDeferredNews queries recent Pulse execution stats and writes a deferred
 // news attestation for Ground. Emitted after every recluster run (success or failure)
 // as the recluster heartbeat is the natural place for periodic Pulse health reporting.
+//
+// Dedup: only emits when the failure picture changes — different failing handlers
+// or a different failure count. Increasing totals with the same failures is not news.
+// The fingerprint (failure count + handler names) is compared against the last
+// emitted pulse-summary attestation in the attestation store.
 func EmitPulseDeferredNews(db *sql.DB, atsStore ats.AttestationStore, projectCtx string, groundDBPath string, groundWrite GroundWriteFunc, logger *zap.SugaredLogger) {
 	if atsStore == nil {
 		return

--- a/server/embeddings/pulse.go
+++ b/server/embeddings/pulse.go
@@ -121,10 +121,9 @@ func (h *ReprojectHandler) writeLog(jobID, stage, level, message, metadata strin
 // news attestation for Ground. Emitted after every recluster run (success or failure)
 // as the recluster heartbeat is the natural place for periodic Pulse health reporting.
 //
-// Dedup: only emits when the failure picture changes — different failing handlers
-// or a different failure count. Increasing totals with the same failures is not news.
-// The fingerprint (failure count + handler names) is compared against the last
-// emitted pulse-summary attestation in the attestation store.
+// Dedup: only emits when the failure picture changes — different failing handlers.
+// Increasing totals with the same failures is not news. The fingerprint (handler
+// names only) is compared against the last emitted pulse-summary attestation.
 func EmitPulseDeferredNews(db *sql.DB, atsStore ats.AttestationStore, projectCtx string, groundDBPath string, groundWrite GroundWriteFunc, logger *zap.SugaredLogger) {
 	if atsStore == nil {
 		return
@@ -182,6 +181,24 @@ func EmitPulseDeferredNews(db *sql.DB, atsStore ats.AttestationStore, projectCtx
 		}
 	}
 
+	// Only emit when the failure picture changes — increasing totals with the
+	// same failures is not news. Fingerprint is only the failing handler names.
+	fingerprint := "ok"
+	for _, h := range failedHandlers {
+		fingerprint += ":" + h
+	}
+
+	existing, _ := atsStore.GetAttestations(ats.AttestationFilter{
+		Predicates: []string{"deferred:pulse-summary"},
+		Contexts:   []string{projectCtx},
+		Limit:      1,
+	})
+	if len(existing) > 0 {
+		if prev, ok := existing[0].Attributes["fingerprint"].(string); ok && prev == fingerprint {
+			return
+		}
+	}
+
 	asid, err := identity.GenerateASUID("AS", "pulse", "deferred:pulse-summary", projectCtx)
 	if err != nil {
 		logger.Warnw("Failed to generate ASID for Pulse deferred news", "error", err)
@@ -198,9 +215,10 @@ func EmitPulseDeferredNews(db *sql.DB, atsStore ats.AttestationStore, projectCtx
 		Timestamp:  now,
 		Source:     "pulse-heartbeat",
 		Attributes: map[string]any{
-			"event":  "pulse-summary",
-			"detail": detail,
-			"after":  now.Unix(),
+			"event":       "pulse-summary",
+			"detail":      detail,
+			"after":       now.Unix(),
+			"fingerprint": fingerprint,
 		},
 		CreatedAt: now,
 	}

--- a/server/embeddings/pulse_test.go
+++ b/server/embeddings/pulse_test.go
@@ -1,0 +1,80 @@
+package embeddings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/teranos/QNTX/ats"
+	qntxtest "github.com/teranos/QNTX/internal/testing"
+	"go.uber.org/zap"
+)
+
+func TestEmitPulseDeferredNews_DedupSameFailurePicture(t *testing.T) {
+	atsStore, db := qntxtest.CreateTestStore(t)
+	logger := zap.NewNop().Sugar()
+
+	// Insert some pulse execution data: 2 completed, 1 failed
+	_, err := db.Exec(`INSERT INTO scheduled_pulse_jobs (id, ats_code, interval_seconds, handler_name, created_at)
+		VALUES ('job1', 'recluster', 300, 'embeddings.recluster', datetime('now'))`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO pulse_executions (id, scheduled_job_id, status, started_at, completed_at, duration_ms, created_at, updated_at)
+		VALUES ('ex1', 'job1', 'completed', datetime('now'), datetime('now'), 100, datetime('now'), datetime('now'))`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO pulse_executions (id, scheduled_job_id, status, started_at, completed_at, duration_ms, created_at, updated_at)
+		VALUES ('ex2', 'job1', 'completed', datetime('now'), datetime('now'), 200, datetime('now'), datetime('now'))`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO pulse_executions (id, scheduled_job_id, status, started_at, completed_at, duration_ms, created_at, updated_at)
+		VALUES ('ex3', 'job1', 'failed', datetime('now'), datetime('now'), 50, datetime('now'), datetime('now'))`)
+	require.NoError(t, err)
+
+	projectCtx := "project:test/dedup"
+
+	// First call — should emit
+	EmitPulseDeferredNews(db, atsStore, projectCtx, "", nil, logger)
+
+	// Second call — same failure picture, should NOT emit again
+	EmitPulseDeferredNews(db, atsStore, projectCtx, "", nil, logger)
+
+	// Count pulse-summary attestations
+	results, err := atsStore.GetAttestations(ats.AttestationFilter{
+		Predicates: []string{"deferred:pulse-summary"},
+		Contexts:   []string{projectCtx},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(results), "same failure picture should emit only once")
+}
+
+func TestEmitPulseDeferredNews_EmitsOnNewFailure(t *testing.T) {
+	atsStore, db := qntxtest.CreateTestStore(t)
+	logger := zap.NewNop().Sugar()
+
+	// Insert initial data: all completed
+	_, err := db.Exec(`INSERT INTO scheduled_pulse_jobs (id, ats_code, interval_seconds, handler_name, created_at)
+		VALUES ('job1', 'recluster', 300, 'embeddings.recluster', datetime('now'))`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO pulse_executions (id, scheduled_job_id, status, started_at, completed_at, duration_ms, created_at, updated_at)
+		VALUES ('ex1', 'job1', 'completed', datetime('now'), datetime('now'), 100, datetime('now'), datetime('now'))`)
+	require.NoError(t, err)
+
+	projectCtx := "project:test/dedup"
+
+	// First call — no failures, emits success summary
+	EmitPulseDeferredNews(db, atsStore, projectCtx, "", nil, logger)
+
+	// Add a failure
+	_, err = db.Exec(`INSERT INTO pulse_executions (id, scheduled_job_id, status, started_at, completed_at, duration_ms, created_at, updated_at)
+		VALUES ('ex2', 'job1', 'failed', datetime('now'), datetime('now'), 50, datetime('now'), datetime('now'))`)
+	require.NoError(t, err)
+
+	// Second call — failure picture changed, should emit again
+	EmitPulseDeferredNews(db, atsStore, projectCtx, "", nil, logger)
+
+	results, err := atsStore.GetAttestations(ats.AttestationFilter{
+		Predicates: []string{"deferred:pulse-summary"},
+		Contexts:   []string{projectCtx},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(results), "different failure picture should emit a new attestation")
+}

--- a/server/embeddings_handlers.go
+++ b/server/embeddings_handlers.go
@@ -54,6 +54,17 @@ func (s *QNTXServer) SetupPluginEmbeddingService(client protocol.EmbeddingServic
 	s.embeddingStats = observer
 
 	s.logger.Infow("Plugin embedding service initialized")
+
+	// Register recluster/reproject handlers now that embedding service is available.
+	// Must happen here (not in init) because embeddingService is nil until plugin connects.
+	cfg, err := appcfg.Load()
+	if err == nil {
+		s.setupEmbeddingReclusterSchedule(cfg)
+		s.setupEmbeddingReprojectSchedule(cfg)
+		s.setupClusterLabelSchedule(cfg)
+	} else {
+		s.logger.Warnw("Failed to load config for embedding schedule setup", "error", err)
+	}
 }
 
 // callReducePlugin sends an HTTP request to the reduce plugin via gRPC.

--- a/server/embeddings_pulse.go
+++ b/server/embeddings_pulse.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	appcfg "github.com/teranos/QNTX/am"
-	serverembeddings "github.com/teranos/QNTX/server/embeddings"
 	"github.com/teranos/QNTX/pulse/schedule"
+	serverembeddings "github.com/teranos/QNTX/server/embeddings"
 )
 
 // setupEmbeddingReclusterSchedule registers the recluster handler and auto-creates
@@ -31,6 +31,7 @@ func (s *QNTXServer) setupEmbeddingReclusterSchedule(cfg *appcfg.Config) {
 		ProjectCtx:            projectCtx,
 		Store:                 s.embeddingStore,
 		Svc:                   s.embeddingService,
+		ClusterFunc:           s.embeddingService.(*serverembeddings.PluginEmbeddingService).ClusterHDBSCAN,
 		ATSStore:              s.atsStore,
 		Invalidator:           s.embeddingClusterInvalidator,
 		MinClusterSize:        minClusterSize,

--- a/server/init.go
+++ b/server/init.go
@@ -398,9 +398,8 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 			ticker.SetWeaveStats(llmRouter)
 		}
 	}
-	server.setupEmbeddingReclusterSchedule(deps.config)
-	server.setupEmbeddingReprojectSchedule(deps.config)
-	server.setupClusterLabelSchedule(deps.config)
+	// Embedding schedule setup (recluster, reproject, cluster-label) deferred to
+	// SetupPluginEmbeddingService — embeddingService is nil until a plugin connects.
 
 	// Wire embedding service into gRPC for plugin access
 	if server.embeddingService != nil && server.servicesManager != nil {
@@ -607,4 +606,3 @@ func setupConfigWatcher(server *QNTXServer, db *sql.DB, serverLogger *zap.Sugare
 	configWatcher.Start()
 	serverLogger.Infow("Config watcher started", "path", configPath)
 }
-


### PR DESCRIPTION
Stop spamming Ground with identical failure news.

Follows #792 — fixes handler registration race introduced when embedding service moved to plugin gRPC.