### PR TITLE
Batch writes, sigma convergence, distillation refinements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-app"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "log",
  "qntx-grpc",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-core"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -3824,11 +3824,11 @@ dependencies = [
 
 [[package]]
 name = "qntx-ffi-common"
-version = "0.2.36"
+version = "0.2.41"
 
 [[package]]
 name = "qntx-grpc"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "http",
  "lazy_static",
@@ -3847,14 +3847,14 @@ dependencies = [
 
 [[package]]
 name = "qntx-id"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "qntx-indexeddb"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "js-sys",
  "qntx-core",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-proto"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "base64 0.22.1",
  "prost",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-sqlite"
-version = "0.2.36"
+version = "0.2.41"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-app"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "log",
  "qntx-grpc",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-core"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -3824,11 +3824,11 @@ dependencies = [
 
 [[package]]
 name = "qntx-ffi-common"
-version = "0.2.28"
+version = "0.2.36"
 
 [[package]]
 name = "qntx-grpc"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "http",
  "lazy_static",
@@ -3847,14 +3847,14 @@ dependencies = [
 
 [[package]]
 name = "qntx-id"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "qntx-indexeddb"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "js-sys",
  "qntx-core",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-proto"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "base64 0.22.1",
  "prost",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "qntx-sqlite"
-version = "0.2.28"
+version = "0.2.36"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.36"
+version = "0.2.41"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/teranos/QNTX"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.28"
+version = "0.2.36"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/teranos/QNTX"

--- a/am.example.toml
+++ b/am.example.toml
@@ -45,6 +45,31 @@ actor_contexts_limit = 64
 entity_actors_limit = 64
 
 # ════════════════════════════════════════════════════════════════
+# Attestation Distillation (ADR-020)
+# Folds old attestations into compressed summaries before deletion.
+# Enforcement-path distillation (Rust) is always on.
+# Age-based distillation (Go Pulse) requires interval_seconds.
+# ════════════════════════════════════════════════════════════════
+
+[distill]
+# How often the age-based distill cycle runs (seconds).
+# Omit or comment out to disable age-based distillation.
+# Default: disabled
+# interval_seconds = 300
+
+# Attestations older than this are candidates for distillation.
+# Default: 720 (30 days)
+# max_age_hours = 720
+
+# Maximum attestations to process per cycle.
+# Default: 500
+# batch_size = 500
+
+# Log what would be distilled without doing it.
+# Default: false
+# dry_run = false
+
+# ════════════════════════════════════════════════════════════════
 # Server Configuration (Web UI)
 # ════════════════════════════════════════════════════════════════
 

--- a/ats/storage/bounded_store.go
+++ b/ats/storage/bounded_store.go
@@ -74,6 +74,23 @@ func (bs *BoundedStore) GenerateAndCreateAttestation(ctx context.Context, cmd *t
 	return bs.store.GenerateAndCreateAttestation(ctx, cmd)
 }
 
+// BatchGenerateAndCreateAttestations delegates to the underlying store's batch method.
+func (bs *BoundedStore) BatchGenerateAndCreateAttestations(ctx context.Context, cmds []*types.AsCommand) (int, error) {
+	type batchCreator interface {
+		BatchGenerateAndCreateAttestations(ctx context.Context, cmds []*types.AsCommand) (int, error)
+	}
+	if bc, ok := bs.store.(batchCreator); ok {
+		return bc.BatchGenerateAndCreateAttestations(ctx, cmds)
+	}
+	// Fallback: individual writes
+	for i, cmd := range cmds {
+		if _, err := bs.store.GenerateAndCreateAttestation(ctx, cmd); err != nil {
+			return i, err
+		}
+	}
+	return len(cmds), nil
+}
+
 // GetAttestations retrieves attestations based on filters (implements ats.AttestationStore)
 func (bs *BoundedStore) GetAttestations(filters ats.AttestationFilter) ([]*types.As, error) {
 	return bs.store.GetAttestations(filters)

--- a/ats/storage/query_builder.go
+++ b/ats/storage/query_builder.go
@@ -26,60 +26,60 @@ func (qb *queryBuilder) build() string {
 	return strings.Join(qb.whereClauses, " AND ")
 }
 
-// buildSubjectFilter creates LIKE clauses for subject matching (OR logic)
+// buildSubjectFilter uses the attestation_subjects junction table for indexed lookups.
 func (qb *queryBuilder) buildSubjectFilter(subjects []string) {
 	if len(subjects) == 0 {
 		return
 	}
-
-	var subjectClauses []string
-	for _, subject := range subjects {
-		subjectClauses = append(subjectClauses, "subjects LIKE ? ESCAPE '\\'")
-		qb.args = append(qb.args, "%\""+escapeLikePattern(subject)+"\"%")
+	placeholders := make([]string, len(subjects))
+	for i, s := range subjects {
+		placeholders[i] = "?"
+		qb.args = append(qb.args, s)
 	}
-	qb.whereClauses = append(qb.whereClauses, "("+strings.Join(subjectClauses, " OR ")+")")
+	qb.whereClauses = append(qb.whereClauses,
+		"id IN (SELECT attestation_id FROM attestation_subjects WHERE subject IN ("+strings.Join(placeholders, ",")+"))")
 }
 
-// buildPredicateFilter creates LIKE clauses for predicate matching (OR logic)
+// buildPredicateFilter uses the attestation_predicates junction table for indexed lookups.
 func (qb *queryBuilder) buildPredicateFilter(predicates []string) {
 	if len(predicates) == 0 {
 		return
 	}
-
-	var predicateClauses []string
-	for _, predicate := range predicates {
-		predicateClauses = append(predicateClauses, "predicates LIKE ? ESCAPE '\\'")
-		qb.args = append(qb.args, "%\""+escapeLikePattern(predicate)+"\"%")
+	placeholders := make([]string, len(predicates))
+	for i, p := range predicates {
+		placeholders[i] = "?"
+		qb.args = append(qb.args, p)
 	}
-	qb.whereClauses = append(qb.whereClauses, "("+strings.Join(predicateClauses, " OR ")+")")
+	qb.whereClauses = append(qb.whereClauses,
+		"id IN (SELECT attestation_id FROM attestation_predicates WHERE predicate IN ("+strings.Join(placeholders, ",")+"))")
 }
 
-// buildContextFilter creates LIKE clauses for context matching (OR logic)
+// buildContextFilter uses the attestation_contexts junction table for indexed lookups.
 func (qb *queryBuilder) buildContextFilter(contexts []string) {
 	if len(contexts) == 0 {
 		return
 	}
-
-	var contextClauses []string
-	for _, context := range contexts {
-		contextClauses = append(contextClauses, "contexts LIKE ? COLLATE NOCASE ESCAPE '\\'")
-		qb.args = append(qb.args, "%\""+escapeLikePattern(context)+"\"%")
+	placeholders := make([]string, len(contexts))
+	for i, c := range contexts {
+		placeholders[i] = "?"
+		qb.args = append(qb.args, c)
 	}
-	qb.whereClauses = append(qb.whereClauses, "("+strings.Join(contextClauses, " OR ")+")")
+	qb.whereClauses = append(qb.whereClauses,
+		"id IN (SELECT attestation_id FROM attestation_contexts WHERE context IN ("+strings.Join(placeholders, ",")+" COLLATE NOCASE))")
 }
 
-// buildActorFilter creates LIKE clauses for actor matching (OR logic)
+// buildActorFilter uses the attestation_actors junction table for indexed lookups.
 func (qb *queryBuilder) buildActorFilter(actors []string) {
 	if len(actors) == 0 {
 		return
 	}
-
-	var actorClauses []string
-	for _, actor := range actors {
-		actorClauses = append(actorClauses, "actors LIKE ? ESCAPE '\\'")
-		qb.args = append(qb.args, "%\""+escapeLikePattern(actor)+"\"%")
+	placeholders := make([]string, len(actors))
+	for i, a := range actors {
+		placeholders[i] = "?"
+		qb.args = append(qb.args, a)
 	}
-	qb.whereClauses = append(qb.whereClauses, "("+strings.Join(actorClauses, " OR ")+")")
+	qb.whereClauses = append(qb.whereClauses,
+		"id IN (SELECT attestation_id FROM attestation_actors WHERE actor IN ("+strings.Join(placeholders, ",")+"))")
 }
 
 // BuildFilterQuery builds a SQL query from an AxFilter, returning the full SELECT
@@ -116,14 +116,6 @@ func BuildFilterQuery(filter types.AxFilter) (string, []interface{}) {
 	return query, qb.args
 }
 
-// escapeLikePattern escapes special characters in LIKE patterns for SQL ESCAPE clause
-func escapeLikePattern(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "%", "\\%")
-	s = strings.ReplaceAll(s, "_", "\\_")
-	return s
-}
-
 // buildNaturalLanguageFilter handles NL query expansion with predicate-context pairing
 func (qb *queryBuilder) buildNaturalLanguageFilter(expander ats.QueryExpander, filter types.AxFilter) {
 	if len(filter.Predicates) == 0 {
@@ -141,12 +133,9 @@ func (qb *queryBuilder) buildNaturalLanguageFilter(expander ats.QueryExpander, f
 	if len(expansions) > 0 {
 		var expansionClauses []string
 		for _, exp := range expansions {
-			escapedPred := escapeLikePattern(exp.Predicate)
-			escapedCtx := escapeLikePattern(exp.Context)
-
 			expansionClauses = append(expansionClauses,
-				"(predicates LIKE ? ESCAPE '\\' AND contexts LIKE ? COLLATE NOCASE ESCAPE '\\')")
-			qb.args = append(qb.args, "%\""+escapedPred+"\"%", "%\""+escapedCtx+"\"%")
+				"(id IN (SELECT attestation_id FROM attestation_predicates WHERE predicate = ?) AND id IN (SELECT attestation_id FROM attestation_contexts WHERE context = ? COLLATE NOCASE))")
+			qb.args = append(qb.args, exp.Predicate, exp.Context)
 		}
 		// Wrap all expansions in OR
 		qb.whereClauses = append(qb.whereClauses, "("+strings.Join(expansionClauses, " OR ")+")")
@@ -154,10 +143,13 @@ func (qb *queryBuilder) buildNaturalLanguageFilter(expander ats.QueryExpander, f
 
 	// Also add any explicit contexts from filter.Contexts
 	if len(filter.Contexts) > 0 {
-		for _, context := range filter.Contexts {
-			qb.whereClauses = append(qb.whereClauses, "contexts LIKE ?")
-			qb.args = append(qb.args, "%\""+context+"\"%")
+		placeholders := make([]string, len(filter.Contexts))
+		for i, ctx := range filter.Contexts {
+			placeholders[i] = "?"
+			qb.args = append(qb.args, ctx)
 		}
+		qb.whereClauses = append(qb.whereClauses,
+			"id IN (SELECT attestation_id FROM attestation_contexts WHERE context IN ("+strings.Join(placeholders, ",")+" COLLATE NOCASE))")
 	}
 }
 

--- a/ats/storage/query_builder_test.go
+++ b/ats/storage/query_builder_test.go
@@ -10,62 +10,6 @@ import (
 	"github.com/teranos/QNTX/ats/types"
 )
 
-// TestEscapeLikePattern tests SQL LIKE pattern escaping
-func TestEscapeLikePattern(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "normal text",
-			input:    "normal",
-			expected: "normal",
-		},
-		{
-			name:     "text with underscore",
-			input:    "test_value",
-			expected: "test\\_value",
-		},
-		{
-			name:     "text with percent",
-			input:    "test%value",
-			expected: "test\\%value",
-		},
-		{
-			name:     "text with backslash",
-			input:    "test\\value",
-			expected: "test\\\\value",
-		},
-		{
-			name:     "multiple special chars",
-			input:    "test%value_with\\backslash",
-			expected: "test\\%value\\_with\\\\backslash",
-		},
-		{
-			name:     "SQL injection attempt",
-			input:    "'; DROP TABLE attestations; --",
-			expected: "'; DROP TABLE attestations; --",
-		},
-		{
-			name:     "wildcard injection attempt",
-			input:    "user%' OR '1'='1",
-			expected: "user\\%' OR '1'='1",
-		},
-		{
-			name:     "empty string",
-			input:    "",
-			expected: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := escapeLikePattern(tc.input)
-			assert.Equal(t, tc.expected, result, "Escaping should match expected output")
-		})
-	}
-}
 
 // TestBuildSubjectFilter tests subject filter SQL generation
 func TestBuildSubjectFilter(t *testing.T) {
@@ -88,21 +32,21 @@ func TestBuildSubjectFilter(t *testing.T) {
 			subjects:         []string{"Alice"},
 			expectedClauses:  1,
 			expectedArgs:     1,
-			expectedContains: "subjects LIKE ? ESCAPE",
+			expectedContains: "attestation_subjects",
 		},
 		{
 			name:             "multiple subjects",
 			subjects:         []string{"Alice", "Bob"},
 			expectedClauses:  1,
 			expectedArgs:     2,
-			expectedContains: "OR",
+			expectedContains: "attestation_subjects",
 		},
 		{
 			name:             "subject with special chars",
 			subjects:         []string{"user_id"},
 			expectedClauses:  1,
 			expectedArgs:     1,
-			expectedContains: "subjects LIKE ? ESCAPE",
+			expectedContains: "attestation_subjects",
 		},
 	}
 
@@ -118,12 +62,9 @@ func TestBuildSubjectFilter(t *testing.T) {
 				assert.Contains(t, qb.whereClauses[0], tc.expectedContains, "Clause should contain expected SQL")
 			}
 
-			// Verify arguments are properly escaped JSON patterns
+			// Verify arguments are the raw subject values (exact match via junction table)
 			for i, subject := range tc.subjects {
-				if len(tc.subjects) > 0 {
-					expected := "%\"" + escapeLikePattern(subject) + "\"%"
-					assert.Equal(t, expected, qb.args[i], "Argument should be escaped JSON pattern")
-				}
+				assert.Equal(t, subject, qb.args[i], "Argument should be the exact subject value")
 			}
 		})
 	}
@@ -166,7 +107,7 @@ func TestBuildPredicateFilter(t *testing.T) {
 			assert.Equal(t, tc.expectedArgs, len(qb.args))
 
 			if len(tc.predicates) > 0 {
-				assert.Contains(t, qb.whereClauses[0], "predicates LIKE ? ESCAPE")
+				assert.Contains(t, qb.whereClauses[0], "attestation_predicates")
 			}
 		})
 	}
@@ -180,9 +121,9 @@ func TestBuildContextFilter(t *testing.T) {
 
 		assert.Equal(t, 1, len(qb.whereClauses))
 		assert.Equal(t, 2, len(qb.args))
-		// Context matching should be case-insensitive (COLLATE NOCASE)
-		assert.Contains(t, qb.whereClauses[0], "contexts LIKE ? COLLATE NOCASE ESCAPE")
-		assert.Contains(t, qb.whereClauses[0], "OR")
+		// Context matching should use junction table with COLLATE NOCASE
+		assert.Contains(t, qb.whereClauses[0], "attestation_contexts")
+		assert.Contains(t, qb.whereClauses[0], "COLLATE NOCASE")
 	})
 
 	t.Run("empty contexts", func(t *testing.T) {
@@ -201,7 +142,7 @@ func TestBuildActorFilter(t *testing.T) {
 
 	assert.Equal(t, 1, len(qb.whereClauses))
 	assert.Equal(t, 1, len(qb.args))
-	assert.Contains(t, qb.whereClauses[0], "actors LIKE ? ESCAPE")
+	assert.Contains(t, qb.whereClauses[0], "attestation_actors")
 }
 
 // TestBuildTemporalFilters tests timestamp range filters
@@ -354,8 +295,8 @@ func TestBuildNaturalLanguageFilter(t *testing.T) {
 		qb.buildNaturalLanguageFilter(mockExpander, filter)
 
 		assert.Equal(t, 1, len(qb.whereClauses))
-		assert.Contains(t, qb.whereClauses[0], "predicates LIKE ? ESCAPE")
-		assert.Contains(t, qb.whereClauses[0], "contexts LIKE ? COLLATE NOCASE ESCAPE")
+		assert.Contains(t, qb.whereClauses[0], "attestation_predicates")
+		assert.Contains(t, qb.whereClauses[0], "attestation_contexts")
 		assert.Contains(t, qb.whereClauses[0], "AND")
 		assert.Contains(t, qb.whereClauses[0], "OR")
 	})

--- a/ats/storage/resolution_integration_test.go
+++ b/ats/storage/resolution_integration_test.go
@@ -38,6 +38,7 @@ func setupResolutionTestDB(t *testing.T) *sql.DB {
 		time.Now().Format(time.RFC3339), time.Now().Format(time.RFC3339))
 	require.NoError(t, err, "Failed to insert resolution test fixtures")
 
+	require.NoError(t, qntxtest.SyncJunctionTables(testDB))
 	return testDB
 }
 
@@ -81,6 +82,7 @@ func TestAttestationResolution(t *testing.T) {
 		`, time.Now().Format(time.RFC3339), time.Now().Format(time.RFC3339),
 			time.Now().Format(time.RFC3339), time.Now().Format(time.RFC3339))
 		require.NoError(t, err, "Failed to insert verification test data")
+		require.NoError(t, qntxtest.SyncJunctionTables(db))
 
 		filter := types.AxFilter{
 			Subjects:   []string{"LINK"},
@@ -109,6 +111,7 @@ func TestAttestationResolution(t *testing.T) {
 		`, time.Now().AddDate(0, 0, -2).Format(time.RFC3339), time.Now().Format(time.RFC3339),
 			time.Now().AddDate(0, 0, -1).Format(time.RFC3339), time.Now().Format(time.RFC3339))
 		require.NoError(t, err, "Failed to insert conflict test data")
+		require.NoError(t, qntxtest.SyncJunctionTables(db))
 
 		filter := types.AxFilter{
 			Subjects: []string{"NIOBE"},

--- a/ats/storage/rust_backed_store.go
+++ b/ats/storage/rust_backed_store.go
@@ -135,6 +135,63 @@ func (s *RustBackedStore) GenerateAndCreateAttestation(ctx context.Context, cmd 
 	return as, nil
 }
 
+// BatchGenerateAndCreateAttestations generates vanity ASIDs, signs, and stores
+// multiple attestations in a single write queue slot.
+func (s *RustBackedStore) BatchGenerateAndCreateAttestations(ctx context.Context, cmds []*types.AsCommand) (int, error) {
+	if len(cmds) == 0 {
+		return 0, nil
+	}
+
+	checkExists := func(asid string) bool {
+		return s.rust.AttestationExists(asid)
+	}
+
+	signer := getDefaultSigner()
+	attestations := make([]*types.As, 0, len(cmds))
+
+	for _, cmd := range cmds {
+		subject := "_"
+		if len(cmd.Subjects) > 0 {
+			subject = cmd.Subjects[0]
+		}
+		predicate := "_"
+		if len(cmd.Predicates) > 0 {
+			predicate = cmd.Predicates[0]
+		}
+		ctxStr := "_"
+		if len(cmd.Contexts) > 0 {
+			ctxStr = cmd.Contexts[0]
+		}
+
+		asid, err := identity.GenerateASUIDWithRetry("AS", subject, predicate, ctxStr, checkExists)
+		if err != nil {
+			return 0, errors.Wrapf(err, "failed to generate vanity ASID for batch item %d", len(attestations))
+		}
+
+		as := cmd.ToAs(asid, "")
+		as.Actors = []string{asid}
+
+		if signer != nil {
+			if err := signer.Sign(as); err != nil {
+				return 0, errors.Wrapf(err, "failed to sign attestation %s", as.ID)
+			}
+		}
+
+		attestations = append(attestations, as)
+	}
+
+	created, err := s.rust.BatchCreateAttestations(attestations)
+	if err != nil {
+		return created, err
+	}
+
+	for _, as := range attestations {
+		notifyObservers(as)
+	}
+
+	return created, nil
+}
+
 // CreateAttestationHighPriority signs and stores with high priority.
 // POST handler uses this to jump ahead of queued plugin writes.
 func (s *RustBackedStore) CreateAttestationHighPriority(as *types.As) error {
@@ -156,5 +213,10 @@ func (s *RustBackedStore) CreateAttestationHighPriority(as *types.As) error {
 // Implements schedule.BackupProvider.
 func (s *RustBackedStore) Backup(destPath string) error {
 	return s.rust.Backup(destPath)
+}
+
+// CrashTest triggers a deliberate crash for flight recorder verification.
+func (s *RustBackedStore) CrashTest() {
+	s.rust.CrashTest()
 }
 

--- a/ats/storage/sqlitecgo/slowlog.go
+++ b/ats/storage/sqlitecgo/slowlog.go
@@ -13,7 +13,7 @@ import (
 )
 
 // slowOpThreshold is the duration above which FFI operations are collected.
-const slowOpThreshold = 500 * time.Millisecond
+const slowOpThreshold = 2 * time.Second
 
 // flushInterval controls how often collected stats are flushed to the log.
 const flushInterval = 5 * time.Minute
@@ -29,16 +29,20 @@ func logSlowOp(start time.Time, op string) {
 	collector.record(op, elapsed)
 }
 
+// mutexWaitThreshold is the duration above which mutex waits are collected.
+// Higher than slowOpThreshold because moderate contention is expected under load.
+const mutexWaitThreshold = 5 * time.Second
+
 // recordWait records a mutex-wait duration. Only records waits above the threshold.
 func recordWait(start time.Time, mutex string) {
 	elapsed := time.Since(start)
-	if elapsed < slowOpThreshold {
+	if elapsed < mutexWaitThreshold {
 		return
 	}
 	collector.record("mutex:"+mutex, elapsed)
 }
 
-const historySize = 12 // 12 x 5min = 1 hour of rolling history
+const historySize = 60 // 60 x 5min = 5 hours of rolling history
 
 // slowCollector accumulates all slow events (ops and waits) into buckets
 // keyed by operation name. Flushes summaries periodically, suppressing

--- a/ats/storage/sqlitecgo/slowlog.go
+++ b/ats/storage/sqlitecgo/slowlog.go
@@ -150,7 +150,7 @@ func (sc *slowCollector) flush() {
 		sc.lastFlush[key] = bucketSnapshot{count: b.count, avg: avg}
 
 		if name, ok := strings.CutPrefix(key, "mutex:"); ok {
-			logger.Logger.Infow("Mutex contention (5m)",
+			logger.Logger.Debugw("Mutex contention (5m)",
 				"mutex", name,
 				"waiters", b.count,
 				"min", b.min,
@@ -158,7 +158,7 @@ func (sc *slowCollector) flush() {
 				"avg", avg,
 			)
 		} else {
-			logger.Logger.Infow("Slow ops (5m)",
+			logger.Logger.Debugw("Slow ops (5m)",
 				"op", key,
 				"count", b.count,
 				"min", b.min,

--- a/ats/storage/sqlitecgo/storage_cgo.go
+++ b/ats/storage/sqlitecgo/storage_cgo.go
@@ -72,6 +72,10 @@ type RustStore struct {
 	// nil until StartWriteQueue is called (falls back to direct muWrite).
 	highPriority chan writeRequest
 	lowPriority  chan writeRequest
+
+	// Write-lock holder tracking for watchdog diagnostics.
+	writeHolder atomic.Value // string: who holds muWrite (empty = unlocked)
+	writeSince  atomic.Int64 // unix nanos when muWrite was acquired
 }
 
 // NewMemoryStore creates a new in-memory Rust storage backend.
@@ -162,6 +166,42 @@ func (rs *RustStore) MuRead() *sync.Mutex {
 	return &rs.muRead
 }
 
+// SetWriteHolder records who currently holds the write mutex (for watchdog diagnostics).
+func (rs *RustStore) SetWriteHolder(caller string) {
+	rs.writeHolder.Store(caller)
+	rs.writeSince.Store(time.Now().UnixNano())
+}
+
+// ClearWriteHolder clears the write holder when the mutex is released.
+func (rs *RustStore) ClearWriteHolder() {
+	rs.writeHolder.Store("")
+	rs.writeSince.Store(0)
+}
+
+// WriteHolderInfo returns the current write lock holder and how long it has been held.
+func (rs *RustStore) WriteHolderInfo() (holder string, held time.Duration) {
+	if v := rs.writeHolder.Load(); v != nil {
+		holder = v.(string)
+	}
+	if since := rs.writeSince.Load(); since > 0 {
+		held = time.Since(time.Unix(0, since))
+	}
+	return
+}
+
+// PauseReaders locks all pooled read connections, blocking until each is free.
+// Returns an unlock function. Used by WAL checkpoint to get exclusive access.
+func (rs *RustStore) PauseReaders() func() {
+	for _, entry := range rs.readPool {
+		entry.mu.Lock()
+	}
+	return func() {
+		for _, entry := range rs.readPool {
+			entry.mu.Unlock()
+		}
+	}
+}
+
 // acquireReadConn picks a pooled read connection.
 // Returns nil for in-memory stores (no pool) — caller must fall back to muWrite + store.
 //
@@ -207,7 +247,8 @@ func (rs *RustStore) SetEnforcementConfig(config *EnforcementConfig) error {
 	defer C.free(unsafe.Pointer(cJSON))
 
 	rs.muWrite.Lock()
-	defer rs.muWrite.Unlock()
+	rs.SetWriteHolder("set-enforcement-config")
+	defer func() { rs.ClearWriteHolder(); rs.muWrite.Unlock() }()
 	if rs.store == nil {
 		return errors.New("store is closed")
 	}
@@ -274,7 +315,11 @@ func (rs *RustStore) createAttestationWithPriority(as *types.As, high bool) erro
 	cJSON := C.CString(string(jsonBytes))
 	defer C.free(unsafe.Pointer(cJSON))
 
-	return rs.SubmitWrite(high, func() error {
+	caller := "put"
+	if high {
+		caller = "put:high"
+	}
+	return rs.SubmitWrite(high, caller, func() error {
 		if rs.store == nil {
 			return errors.New("store is closed")
 		}
@@ -319,7 +364,7 @@ func (rs *RustStore) BatchCreateAttestations(attestations []*types.As) (int, err
 			end = len(items)
 		}
 		chunk := items[i:end]
-		err := rs.SubmitWrite(false, func() error {
+		err := rs.SubmitWrite(false, "batch-put", func() error {
 			if rs.store == nil {
 				return errors.New("store is closed")
 			}
@@ -414,7 +459,8 @@ func (rs *RustStore) UpdateAttestation(as *types.As) error {
 	defer C.free(unsafe.Pointer(cJSON))
 
 	rs.muWrite.Lock()
-	defer rs.muWrite.Unlock()
+	rs.SetWriteHolder("update")
+	defer func() { rs.ClearWriteHolder(); rs.muWrite.Unlock() }()
 	if rs.store == nil {
 		return errors.New("store is closed")
 	}
@@ -544,7 +590,7 @@ func (rs *RustStore) GenerateAndCreateAttestation(ctx context.Context, cmd *type
 	}
 
 	// Low priority — GenerateAndCreate is used by plugins
-	err = rs.SubmitWrite(false, func() error {
+	err = rs.SubmitWrite(false, "generate-and-create", func() error {
 		if rs.store == nil {
 			return errors.New("store is closed")
 		}
@@ -668,7 +714,9 @@ func (rs *RustStore) EnforceLimits(actors, contexts, subjects []string, config *
 	defer C.free(unsafe.Pointer(cJSON))
 
 	rs.muWrite.Lock()
+	rs.SetWriteHolder("enforce-limits")
 	if rs.store == nil {
+		rs.ClearWriteHolder()
 		rs.muWrite.Unlock()
 		return nil, errors.New("store is closed")
 	}
@@ -684,6 +732,7 @@ func (rs *RustStore) EnforceLimits(actors, contexts, subjects []string, config *
 		jsonStr = C.GoString(result.attestation_json)
 	}
 	C.attestation_result_free(result)
+	rs.ClearWriteHolder()
 	rs.muWrite.Unlock()
 	logSlowOp(start, "storage_enforce_limits")
 
@@ -958,6 +1007,90 @@ func (rs *RustStore) QueryAttestationsRaw(sql string, params []interface{}) ([]*
 	}
 
 	return attestations, nil
+}
+
+// AgeDistill runs age-triggered distillation through Rust FFI.
+// Folds old attestations (older than cutoff) + existing sigmas into compressed summaries.
+// All within a single SQLite transaction on the Rust side.
+func (rs *RustStore) AgeDistill(cutoffRFC3339 string, batchSize int) (distilled, sigmasCreated, skipped int, err error) {
+	cCutoff := C.CString(cutoffRFC3339)
+	defer C.free(unsafe.Pointer(cCutoff))
+
+	return rs.ageDistillFFI(cCutoff, batchSize)
+}
+
+func (rs *RustStore) ageDistillFFI(cCutoff *C.char, batchSize int) (int, int, int, error) {
+	rs.muWrite.Lock()
+	rs.SetWriteHolder("age-distill")
+	defer func() { rs.ClearWriteHolder(); rs.muWrite.Unlock() }()
+	if rs.store == nil {
+		return 0, 0, 0, errors.New("store is closed")
+	}
+
+	result := C.storage_age_distill(rs.store, cCutoff, C.size_t(batchSize))
+	if !result.success {
+		errMsg := C.GoString(result.error_msg)
+		C.storage_string_free(result.error_msg)
+		return 0, 0, 0, errors.Newf("age distill failed: %s", errMsg)
+	}
+
+	return int(result.distilled), int(result.sigmas_created), int(result.skipped), nil
+}
+
+// WALCheckpointTruncate runs a TRUNCATE WAL checkpoint through Rust FFI.
+// Closes all read connections, checkpoints, and reopens them.
+// Acquires muWrite to prevent concurrent writes during checkpoint.
+func (rs *RustStore) WALCheckpointTruncate() (busy, walPages, checkpointedPages int, err error) {
+	rs.muWrite.Lock()
+	rs.SetWriteHolder("wal-checkpoint")
+	defer func() { rs.ClearWriteHolder(); rs.muWrite.Unlock() }()
+
+	if rs.store == nil {
+		return 0, 0, 0, errors.New("store is closed")
+	}
+
+	n := len(rs.readPool)
+
+	// Lock all read pool entries so no Go code is using them
+	for _, entry := range rs.readPool {
+		entry.mu.Lock()
+	}
+
+	// Build C array of read conn pointers
+	var conns **C.ReadConn
+	if n > 0 {
+		arr := make([]*C.ReadConn, n)
+		for i, entry := range rs.readPool {
+			arr[i] = entry.conn
+		}
+		conns = &arr[0]
+
+		result := C.storage_wal_checkpoint(rs.store, conns, C.size_t(n))
+
+		// Write new pointers back
+		for i, entry := range rs.readPool {
+			entry.conn = arr[i]
+		}
+
+		// Unlock all read pool entries
+		for _, entry := range rs.readPool {
+			entry.mu.Unlock()
+		}
+
+		if !result.success {
+			errMsg := C.GoString(result.error_msg)
+			C.storage_string_free(result.error_msg)
+			return 0, 0, 0, errors.Newf("WAL checkpoint failed: %s", errMsg)
+		}
+
+		return int(result.busy), int(result.wal_pages), int(result.checkpointed_pages), nil
+	}
+
+	// No read pool (in-memory store) — just unlock and return
+	for _, entry := range rs.readPool {
+		entry.mu.Unlock()
+	}
+	return 0, 0, 0, nil
 }
 
 // Version returns the library version.

--- a/ats/storage/sqlitecgo/storage_cgo.go
+++ b/ats/storage/sqlitecgo/storage_cgo.go
@@ -63,6 +63,7 @@ type RustStore struct {
 	muWrite  sync.Mutex
 	muRead   sync.Mutex // kept for backward compat (driver registration)
 	store    *C.SqliteStore
+	dbPath   string        // filesystem path (empty for in-memory)
 	readConn *C.ReadConn   // primary read conn (kept for driver/backward compat)
 	readPool []*readConnEntry // pooled read connections for concurrent reads
 	readNext atomic.Uint64    // round-robin index into readPool
@@ -92,10 +93,11 @@ func NewMemoryStore() (*RustStore, error) {
 }
 
 // readPoolSize is the number of concurrent read connections.
-// SQLite WAL supports unlimited readers. With plugins running 4+ concurrent
-// multi-second queries, 16 connections give the POST path's microsecond
-// AttestationExists lookups a high chance of hitting a free connection.
-const readPoolSize = 16
+// Each connection memory-maps the WAL -shm file; too many connections
+// increase the risk of SIGBUS when the mapping is invalidated by a
+// checkpoint. 4 connections keeps reads concurrent while limiting mmap
+// surface.
+const readPoolSize = 4
 
 // NewFileStore creates a new file-backed Rust storage backend.
 // The caller must call Close() when done to free resources.
@@ -131,7 +133,7 @@ func NewFileStore(path string) (*RustStore, error) {
 		pool[i] = &readConnEntry{conn: rc}
 	}
 
-	rs := &RustStore{store: store, readConn: readConn, readPool: pool}
+	rs := &RustStore{store: store, dbPath: path, readConn: readConn, readPool: pool}
 
 	runtime.SetFinalizer(rs, func(s *RustStore) {
 		s.Close()
@@ -283,6 +285,57 @@ func (rs *RustStore) createAttestationWithPriority(as *types.As, high bool) erro
 		}
 		return nil
 	})
+}
+
+// BatchCreateAttestations stores multiple attestations in a single write queue slot.
+// All JSON serialization happens upfront; the write function calls putLocked N times
+// under one mutex acquisition. Returns the number of successfully created attestations.
+func (rs *RustStore) BatchCreateAttestations(attestations []*types.As) (int, error) {
+	if len(attestations) == 0 {
+		return 0, nil
+	}
+
+	// Serialize all upfront (outside the write lock)
+	type prepared struct {
+		as        *types.As
+		jsonBytes []byte
+	}
+	items := make([]prepared, 0, len(attestations))
+	for _, as := range attestations {
+		jsonBytes, err := toRustJSON(as)
+		if err != nil {
+			return 0, errors.Wrapf(err, "failed to convert attestation %s", as.ID)
+		}
+		items = append(items, prepared{as: as, jsonBytes: jsonBytes})
+	}
+
+	// Chunk into groups of 500 to avoid holding the write mutex too long.
+	// Each chunk is one SubmitWrite call — readers can interleave between chunks.
+	const chunkSize = 500
+	var created int
+	for i := 0; i < len(items); i += chunkSize {
+		end := i + chunkSize
+		if end > len(items) {
+			end = len(items)
+		}
+		chunk := items[i:end]
+		err := rs.SubmitWrite(false, func() error {
+			if rs.store == nil {
+				return errors.New("store is closed")
+			}
+			for _, item := range chunk {
+				if err := rs.putLocked(item.jsonBytes); err != nil {
+					return errors.Wrapf(err, "batch put failed at attestation %s", item.as.ID)
+				}
+				created++
+			}
+			return nil
+		})
+		if err != nil {
+			return created, err
+		}
+	}
+	return created, nil
 }
 
 // CreateAttestationInbound stores a synced attestation without signing (preserves provenance).
@@ -807,18 +860,19 @@ func (rs *RustStore) IntegrityCheck() ([]string, error) {
 }
 
 // Backup creates a hot backup of the database to destPath.
-// Safe to call while the database is in use — SQLite's backup API handles
-// concurrency internally. Does not hold any mutex: the Rust side opens its
-// own read-only source connection for the backup.
+// Opens its own read-only source connection — does not touch the store pointer,
+// so it's safe to call concurrently with storage_put.
 func (rs *RustStore) Backup(destPath string) error {
-	if rs.store == nil {
-		return errors.New("store is closed")
+	if rs.dbPath == "" {
+		return errors.New("backup requires a file-backed database")
 	}
 
+	cSrc := C.CString(rs.dbPath)
+	defer C.free(unsafe.Pointer(cSrc))
 	cDest := C.CString(destPath)
 	defer C.free(unsafe.Pointer(cDest))
 
-	result := C.storage_backup(rs.store, cDest)
+	result := C.storage_backup(cSrc, cDest)
 	success := bool(result.success)
 	var errMsg string
 	if !success {
@@ -830,6 +884,12 @@ func (rs *RustStore) Backup(destPath string) error {
 		return errors.Newf("backup failed for %s: %s", destPath, errMsg)
 	}
 	return nil
+}
+
+// CrashTest deliberately triggers a SIGBUS to verify the flight recorder.
+// Development/testing only.
+func (rs *RustStore) CrashTest() {
+	C.storage_crash_test()
 }
 
 // QueryAttestationsRaw executes a raw SQL query through Rust's connection.

--- a/ats/storage/sqlitecgo/writequeue_cgo.go
+++ b/ats/storage/sqlitecgo/writequeue_cgo.go
@@ -5,8 +5,11 @@ package sqlitecgo
 import (
 	"time"
 
+	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/internal/logger"
 )
+
+const writeQueueTimeout = 30 * time.Second
 
 // writeRequest is a unit of work submitted to the write queue.
 type writeRequest struct {
@@ -73,15 +76,30 @@ func (rs *RustStore) SubmitWrite(high bool, fn func() error) error {
 	}
 
 	waitStart := time.Now()
-	ch <- req
+
+	// Backpressure: if the channel is full, wait up to writeQueueTimeout
+	// before giving up. This prevents goroutine pile-up under sustained load.
+	select {
+	case ch <- req:
+	case <-time.After(writeQueueTimeout):
+		priority := "low"
+		if high {
+			priority = "high"
+		}
+		logger.Logger.Errorw("Write queue full — dropping write",
+			"priority", priority,
+			"queue_len", len(ch),
+			"timeout", writeQueueTimeout,
+		)
+		return errors.Newf("write queue full: %s-priority write timed out after %s", priority, writeQueueTimeout)
+	}
+
 	err := <-req.result
 	elapsed := time.Since(waitStart)
 
 	if high && elapsed >= slowOpThreshold {
-		// High-priority waits are always worth logging individually.
 		logger.Logger.Warnw("High-priority write wait", "duration", elapsed)
 	} else {
-		// Low-priority waits are expected — aggregate via recordWait.
 		recordWait(waitStart, "write_queue")
 	}
 	return err

--- a/ats/storage/sqlitecgo/writequeue_cgo.go
+++ b/ats/storage/sqlitecgo/writequeue_cgo.go
@@ -14,6 +14,7 @@ const writeQueueTimeout = 30 * time.Second
 // writeRequest is a unit of work submitted to the write queue.
 type writeRequest struct {
 	fn     func() error
+	caller string // who submitted this write (for watchdog diagnostics)
 	result chan error
 }
 
@@ -51,16 +52,19 @@ func (rs *RustStore) writeLoop() {
 }
 
 func (rs *RustStore) executeWrite(req writeRequest) {
+	rs.SetWriteHolder(req.caller)
 	rs.muWrite.Lock()
 	err := req.fn()
 	rs.muWrite.Unlock()
+	rs.ClearWriteHolder()
 	req.result <- err
 }
 
 // SubmitWrite submits a write to the appropriate priority queue and blocks
 // until it completes. Returns the error from the write function.
-func (rs *RustStore) SubmitWrite(high bool, fn func() error) error {
-	req := writeRequest{fn: fn, result: make(chan error, 1)}
+// The caller label identifies who submitted this write (for watchdog diagnostics).
+func (rs *RustStore) SubmitWrite(high bool, caller string, fn func() error) error {
+	req := writeRequest{fn: fn, caller: caller, result: make(chan error, 1)}
 
 	ch := rs.lowPriority
 	if high {
@@ -70,7 +74,9 @@ func (rs *RustStore) SubmitWrite(high bool, fn func() error) error {
 	if ch == nil {
 		// Queue not started — fall back to direct execution
 		rs.muWrite.Lock()
+		rs.SetWriteHolder(caller)
 		err := fn()
+		rs.ClearWriteHolder()
 		rs.muWrite.Unlock()
 		return err
 	}

--- a/ats/watcher/engine.go
+++ b/ats/watcher/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/teranos/QNTX/ats/parser"
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
+	"github.com/teranos/QNTX/db/rustdriver"
 	"github.com/teranos/QNTX/errors"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
@@ -578,6 +579,7 @@ func (e *Engine) queryHistoricalSemantic(watcherID string, watcher *storage.Watc
 func (e *Engine) queryHistoricalStructural(watcherID string, watcher *storage.Watcher) error {
 	query, args := storage.BuildFilterQuery(watcher.Filter)
 
+	rustdriver.SetCaller("watcher:" + watcherID)
 	attestations, err := e.reader.QueryAttestationsRaw(query, args)
 	if err != nil {
 		return errors.Wrap(err, "failed to query attestations via Rust")

--- a/ats/watcher/engine.go
+++ b/ats/watcher/engine.go
@@ -110,10 +110,11 @@ const (
 	maxRetries        = 5
 	initialBackoff    = 1 * time.Second
 	maxBackoff        = 60 * time.Second
-	drainInterval     = 200 * time.Millisecond
+	drainInterval     = 2 * time.Second
 	drainBatchSize    = 50
 	purgeRetention    = 1 * time.Hour
 	purgeEveryNthTick = 100 // purge completed entries every 100th drain tick
+	maxQueuePerWatcher = 1000
 )
 
 // NewEngine creates a new watcher engine
@@ -193,6 +194,9 @@ func (e *Engine) Start() error {
 	} else if orphans > 0 {
 		e.logger.Infow("Requeued orphaned execution queue entries from previous run", "count", orphans)
 	}
+
+	// Purge excess queued entries per watcher (prevent unbounded growth)
+	e.pruneOverflowingQueues()
 
 	// Start drain loop (replaces in-memory retry loop)
 	e.wg.Add(1)
@@ -815,6 +819,29 @@ func deepCopyAttestation(as *types.As) *types.As {
 		}
 	}
 	return &asCopy
+}
+
+// pruneOverflowingQueues deletes the oldest queued entries for any watcher
+// that exceeds maxQueuePerWatcher. Runs once at startup to recover from bloat.
+func (e *Engine) pruneOverflowingQueues() {
+	stats, err := e.queueStore.Stats()
+	if err != nil {
+		e.logger.Warnw("Failed to get queue stats for startup prune", "error", err)
+		return
+	}
+	for watcherID, count := range stats.PerWatcher {
+		if count <= maxQueuePerWatcher {
+			continue
+		}
+		pruned, err := e.queueStore.PruneExcess(watcherID, maxQueuePerWatcher)
+		if err != nil {
+			e.logger.Warnw("Failed to prune excess queue entries",
+				"watcher_id", watcherID, "count", count, "error", err)
+			continue
+		}
+		e.logger.Infow("Pruned excess queue entries at startup",
+			"watcher_id", watcherID, "before", count, "pruned", pruned, "cap", maxQueuePerWatcher)
+	}
 }
 
 // GetQueueStore returns the queue store for external access (stats endpoint).

--- a/ats/watcher/engine_test.go
+++ b/ats/watcher/engine_test.go
@@ -435,6 +435,7 @@ func TestEngine_QueryHistoricalMatches(t *testing.T) {
 			t.Fatalf("Failed to insert attestation: %v", err)
 		}
 	}
+	qntxtest.SyncJunctionTables(db)
 
 	// Create watcher that matches some attestations
 	store := storage.NewWatcherStore(db)

--- a/ats/watcher/queue_store.go
+++ b/ats/watcher/queue_store.go
@@ -218,6 +218,23 @@ func (s *QueueStore) PurgeCompleted(olderThan time.Duration) (int64, error) {
 	return result.RowsAffected()
 }
 
+// PruneExcess deletes the oldest queued entries for a watcher, keeping only the
+// newest `keep` entries. Returns the number of deleted rows.
+func (s *QueueStore) PruneExcess(watcherID string, keep int) (int64, error) {
+	result, err := s.db.Exec(`
+		DELETE FROM watcher_execution_queue
+		WHERE watcher_id = ? AND status = 'queued'
+		  AND id NOT IN (
+		    SELECT id FROM watcher_execution_queue
+		    WHERE watcher_id = ? AND status = 'queued'
+		    ORDER BY id DESC LIMIT ?
+		  )`, watcherID, watcherID, keep)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to prune excess queue entries for watcher %s", watcherID)
+	}
+	return result.RowsAffected()
+}
+
 // PurgeForWatcher removes all queued entries for a specific watcher.
 func (s *QueueStore) PurgeForWatcher(watcherID string) (int64, error) {
 	result, err := s.db.Exec(`DELETE FROM watcher_execution_queue WHERE watcher_id = ? AND status = 'queued'`, watcherID)

--- a/cmd/qntx/commands/ax.go
+++ b/cmd/qntx/commands/ax.go
@@ -63,7 +63,7 @@ func runAxCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Open database
-	database, _, _, err := openDatabase("")
+	database, _, _, _, err := openDatabase("")
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
 	}

--- a/cmd/qntx/commands/ax_test.go
+++ b/cmd/qntx/commands/ax_test.go
@@ -16,13 +16,26 @@ import (
 func TestAxCommand_Integration(t *testing.T) {
 	db := qntxtest.CreateTestDB(t)
 
-	// Seed test data
+	// Seed test data — insert into both attestations and junction tables
+	// (junction tables are normally populated by Rust on insert)
 	_, err := db.Exec(`
 		INSERT INTO attestations (id, subjects, predicates, contexts, actors, timestamp)
 		VALUES
 		('TEST1', '["Bohemian Rhapsody"]', '["song"]', '["Queen"]', '["test"]', datetime('now')),
 		('TEST2', '["Imagine"]', '["song"]', '["Beatles"]', '["test"]', datetime('now')),
-		('TEST3', '["Dark Side"]', '["album"]', '["Pink Floyd"]', '["test"]', datetime('now'))
+		('TEST3', '["Dark Side"]', '["album"]', '["Pink Floyd"]', '["test"]', datetime('now'));
+
+		INSERT INTO attestation_subjects (attestation_id, subject) VALUES
+		('TEST1', 'Bohemian Rhapsody'), ('TEST2', 'Imagine'), ('TEST3', 'Dark Side');
+
+		INSERT INTO attestation_predicates (attestation_id, predicate) VALUES
+		('TEST1', 'song'), ('TEST2', 'song'), ('TEST3', 'album');
+
+		INSERT INTO attestation_contexts (attestation_id, context) VALUES
+		('TEST1', 'Queen'), ('TEST2', 'Beatles'), ('TEST3', 'Pink Floyd');
+
+		INSERT INTO attestation_actors (attestation_id, actor) VALUES
+		('TEST1', 'test'), ('TEST2', 'test'), ('TEST3', 'test');
 	`)
 	require.NoError(t, err)
 

--- a/cmd/qntx/commands/database.go
+++ b/cmd/qntx/commands/database.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,13 +24,14 @@ var driverOnce sync.Once
 
 // openDatabase creates a unified database setup: Rust owns the SQLite connection,
 // Go's *sql.DB routes all SQL through Rust via the "rustsqlite" driver.
-// Returns the sql.DB handle, the attestation store, and the resolved path.
-func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) {
+// Returns the sql.DB handle, the attestation store, the resolved path, and a
+// WALCheckpointer for Rust-side WAL checkpoint (close readers, checkpoint, reopen).
+func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, any, error) {
 	// Determine database path
 	if dbPath == "" {
 		path, err := am.GetDatabasePath()
 		if err != nil {
-			return nil, nil, "", fmt.Errorf("failed to get database path: %w", err)
+			return nil, nil, "", nil, fmt.Errorf("failed to get database path: %w", err)
 		}
 		if path == "" {
 			dbPath = "qntx.db"
@@ -41,7 +43,7 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) 
 	// Create Rust store (runs all migrations, sets up WAL/FK/busy_timeout)
 	rustStore, err := sqlitecgo.NewFileStore(dbPath)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to create Rust store at %s: %w", dbPath, err)
+		return nil, nil, "", nil, fmt.Errorf("failed to create Rust store at %s: %w", dbPath, err)
 	}
 
 	// Start priority write queue — POST (high) jumps ahead of plugin writes (low).
@@ -62,7 +64,7 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) 
 	database, err := sql.Open("rustsqlite", dbPath)
 	if err != nil {
 		rustStore.Close()
-		return nil, nil, "", fmt.Errorf("failed to open rustsqlite driver: %w", err)
+		return nil, nil, "", nil, fmt.Errorf("failed to open rustsqlite driver: %w", err)
 	}
 	database.SetMaxOpenConns(4)
 
@@ -71,7 +73,7 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) 
 	if err != nil {
 		database.Close()
 		rustStore.Close()
-		return nil, nil, "", fmt.Errorf("failed to create attestation store: %w", err)
+		return nil, nil, "", nil, fmt.Errorf("failed to create attestation store: %w", err)
 	}
 
 	// Start mutex watchdog — alerts when RustStore mutex is held too long.
@@ -82,6 +84,7 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) 
 		OnAlert: func(blocked time.Duration) {
 			buf := make([]byte, 64*1024)
 			n := runtime.Stack(buf, true)
+			dump := string(buf[:n])
 
 			dir := "tmp/watchdog"
 			os.MkdirAll(dir, 0755)
@@ -92,9 +95,63 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) 
 				logger.Logger.Warnf("RustStore mutex held for %s — failed to write dump: %s", blocked, err)
 				return
 			}
-			logger.Logger.Warnf("RustStore mutex held for %s — goroutine dump: %s", blocked, path)
+
+			// Use write-holder tracking (set by executeWrite) for the current operation,
+			// and scan the dump for goroutines waiting to acquire the lock.
+			holder, held := rustStore.WriteHolderInfo()
+			if holder == "" {
+				holder = "unknown"
+			}
+			waiters := extractWaiters(dump)
+			logger.Logger.Warnf("RustStore mutex held for %s — op: %s (held %s) — waiters: [%s] — dump: %s",
+				blocked, holder, held.Truncate(time.Millisecond), waiters, path)
 		},
 	})
 
-	return database, atsStore, dbPath, nil
+	return database, atsStore, dbPath, rustStore, nil
+}
+
+// extractWaiters scans a goroutine dump for goroutines blocked waiting on
+// the write mutex or write queue result. Returns a comma-separated list of
+// callers, e.g. "put:high, batch-put, watcher:evaluate".
+func extractWaiters(dump string) string {
+	blocks := strings.Split(dump, "\n\n")
+	var waiters []string
+	for _, block := range blocks {
+		lines := strings.Split(block, "\n")
+		// A waiter is a goroutine that contains "semacquire" (mutex contention)
+		// or is blocked on chan receive after SubmitWrite.
+		isWaiting := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.Contains(trimmed, "semacquire") || strings.Contains(trimmed, "SubmitWrite") {
+				isWaiting = true
+				break
+			}
+		}
+		if !isWaiting {
+			continue
+		}
+		// Find the deepest QNTX application frame to identify the caller
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.Contains(trimmed, "QNTX/") &&
+				!strings.Contains(trimmed, "writequeue") &&
+				!strings.Contains(trimmed, "watchdog") &&
+				!strings.Contains(trimmed, "runtime") {
+				if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+					caller := trimmed[idx+1:]
+					if spaceIdx := strings.Index(caller, " "); spaceIdx > 0 {
+						caller = caller[:spaceIdx]
+					}
+					waiters = append(waiters, caller)
+				}
+				break
+			}
+		}
+	}
+	if len(waiters) == 0 {
+		return "none"
+	}
+	return strings.Join(waiters, ", ")
 }

--- a/cmd/qntx/commands/database.go
+++ b/cmd/qntx/commands/database.go
@@ -76,35 +76,36 @@ func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, any, er
 		return nil, nil, "", nil, fmt.Errorf("failed to create attestation store: %w", err)
 	}
 
-	// Start mutex watchdog — alerts when RustStore mutex is held too long.
-	// Dumps all goroutine stacks to tmp/watchdog/ so the log stays scannable.
+	// Start mutex watchdog — only logs + dumps when there are actual waiters.
+	// Write holder info is surfaced in the UI via live status; the watchdog
+	// is now exclusively for diagnosing real contention (blocked goroutines).
 	sqlitecgo.StartMutexWatchdog(rustStore.Mu(), sqlitecgo.WatchdogConfig{
 		Interval: 30 * time.Second,
 		Timeout:  5 * time.Second,
 		OnAlert: func(blocked time.Duration) {
+			holder, held := rustStore.WriteHolderInfo()
+			if holder == "" {
+				holder = "unknown"
+			}
+
 			buf := make([]byte, 64*1024)
 			n := runtime.Stack(buf, true)
 			dump := string(buf[:n])
+			waiters := extractWaiters(dump)
+
+			// No waiters = lock is held but nobody is blocked. Skip the log.
+			if waiters == "none" {
+				return
+			}
 
 			dir := "tmp/watchdog"
 			os.MkdirAll(dir, 0755)
 			filename := time.Now().Format("2006-01-02T15-04-05") + ".txt"
 			path := filepath.Join(dir, filename)
+			os.WriteFile(path, buf[:n], 0644)
 
-			if err := os.WriteFile(path, buf[:n], 0644); err != nil {
-				logger.Logger.Warnf("RustStore mutex held for %s — failed to write dump: %s", blocked, err)
-				return
-			}
-
-			// Use write-holder tracking (set by executeWrite) for the current operation,
-			// and scan the dump for goroutines waiting to acquire the lock.
-			holder, held := rustStore.WriteHolderInfo()
-			if holder == "" {
-				holder = "unknown"
-			}
-			waiters := extractWaiters(dump)
-			logger.Logger.Warnf("RustStore mutex held for %s — op: %s (held %s) — waiters: [%s] — dump: %s",
-				blocked, holder, held.Truncate(time.Millisecond), waiters, path)
+			logger.Logger.Warnf("RustStore mutex contention — op: %s (held %s) — waiters: [%s] — dump: %s",
+				holder, held.Truncate(time.Millisecond), waiters, path)
 		},
 	})
 

--- a/cmd/qntx/commands/database_nocgo.go
+++ b/cmd/qntx/commands/database_nocgo.go
@@ -10,6 +10,6 @@ import (
 )
 
 // openDatabase is unavailable without CGO — requires Rust SQLite driver.
-func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, error) {
-	return nil, nil, "", fmt.Errorf("database unavailable: this binary was built without CGO (use Nix build for full functionality)")
+func openDatabase(dbPath string) (*sql.DB, ats.AttestationStore, string, any, error) {
+	return nil, nil, "", nil, fmt.Errorf("database unavailable: this binary was built without CGO (use Nix build for full functionality)")
 }

--- a/cmd/qntx/commands/db.go
+++ b/cmd/qntx/commands/db.go
@@ -48,7 +48,7 @@ func runDbStats(cmd *cobra.Command, args []string) error {
 	}
 
 	// Open and migrate database
-	database, _, _, err := openDatabase("")
+	database, _, _, _, err := openDatabase("")
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
 	}

--- a/cmd/qntx/commands/handler.go
+++ b/cmd/qntx/commands/handler.go
@@ -78,7 +78,7 @@ func runHandlerCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Open database
-	database, atsStore, _, err := openDatabase("")
+	database, atsStore, _, _, err := openDatabase("")
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
 	}

--- a/cmd/qntx/commands/pulse.go
+++ b/cmd/qntx/commands/pulse.go
@@ -65,7 +65,7 @@ The daemon will:
 		}
 
 		// Open and migrate database
-		database, _, _, err := openDatabase("")
+		database, _, _, _, err := openDatabase("")
 		if err != nil {
 			return errors.Wrap(err, "failed to open pulse database")
 		}

--- a/cmd/qntx/commands/server.go
+++ b/cmd/qntx/commands/server.go
@@ -81,7 +81,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	// Open and migrate database
 	dbStart := time.Now()
-	database, atsStore, dbPath, err := openDatabase(dbPath)
+	database, atsStore, dbPath, rustStore, err := openDatabase(dbPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
 	}
@@ -105,6 +105,16 @@ func runServer(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to create server")
 	}
 	bootLog.Infow("NewQNTXServer complete", "took", time.Since(srvStart))
+
+	// Wire Rust-side WAL checkpointer (closes read conns, checkpoints, reopens)
+	if cp, ok := rustStore.(server.WALCheckpointer); ok {
+		srv.SetWALCheckpointer(cp)
+	}
+
+	// Wire Rust-side age distiller (fold old attestations into sigmas)
+	if ad, ok := rustStore.(server.AgeDistiller); ok {
+		srv.SetAgeDistiller(ad)
+	}
 
 	// Wire deferred plugin initialization — fires when server is fully ready
 	// (migrations done, HTTP listening), not before.

--- a/cmd/qntx/commands/server.go
+++ b/cmd/qntx/commands/server.go
@@ -116,6 +116,11 @@ func runServer(cmd *cobra.Command, args []string) error {
 		srv.SetAgeDistiller(ad)
 	}
 
+	// Wire write lock inspector (diagnostics for UI)
+	if wl, ok := rustStore.(server.WriteLockInspector); ok {
+		srv.SetWriteLockInspector(wl)
+	}
+
 	// Wire deferred plugin initialization — fires when server is fully ready
 	// (migrations done, HTTP listening), not before.
 	if DeferredPluginInit != nil {

--- a/crates/qntx-sqlite/include/storage_ffi.h
+++ b/crates/qntx-sqlite/include/storage_ffi.h
@@ -345,6 +345,14 @@ ExecResultC sql_rollback(SqliteStore *store);
 QueryResultC read_conn_sql_query(const ReadConn *rc, const char *sql, const char *params_json);
 
 /**
+ * Set the caller tag for the current thread's flight recorder entries.
+ * Call before issuing FFI calls to attribute queries to their source.
+ *
+ * @param caller Caller identifier (e.g. "db-stats", "watcher:ax-1234", "plugin:village")
+ */
+void flight_recorder_set_caller(const char *caller);
+
+/**
  * Free an ExecResultC.
  */
 void exec_result_free(ExecResultC result);
@@ -372,14 +380,20 @@ StringArrayResultC storage_integrity_check(const SqliteStore *store);
 // ============================================================================
 
 /**
- * Create a hot backup of the database to the given path.
- * Uses SQLite's online backup API — safe to call while the database is in use.
+ * Create a hot backup of the database.
+ * Opens its own read-only source connection — does not touch the store pointer.
  *
- * @param store Store handle
+ * @param src_path Source database path
  * @param dest_path Filesystem path for the backup file
  * @return Result indicating success/failure
  */
-StorageResultC storage_backup(const SqliteStore *store, const char *dest_path);
+StorageResultC storage_backup(const char *src_path, const char *dest_path);
+
+/**
+ * Deliberately trigger SIGBUS to verify flight recorder.
+ * Development/testing only.
+ */
+void storage_crash_test(void);
 
 // ============================================================================
 // Memory Management

--- a/crates/qntx-sqlite/include/storage_ffi.h
+++ b/crates/qntx-sqlite/include/storage_ffi.h
@@ -376,6 +376,61 @@ void query_result_free(QueryResultC result);
 StringArrayResultC storage_integrity_check(const SqliteStore *store);
 
 // ============================================================================
+// Age Distillation
+// ============================================================================
+
+typedef struct {
+    bool success;
+    char *error_msg;
+    size_t distilled;
+    size_t sigmas_created;
+    size_t skipped;
+} DistillResultC;
+
+/**
+ * Run age-triggered distillation: fold old attestations into sigmas.
+ * Queries attestations older than cutoff plus all existing sigmas,
+ * groups by predicate, creates one sigma per group, deletes originals.
+ * All within a single transaction.
+ *
+ * Caller must hold the write mutex before calling.
+ *
+ * @param store Store handle
+ * @param cutoff_rfc3339 RFC3339 timestamp cutoff for old attestations
+ * @param batch_size Maximum number of attestations to process
+ * @return Result with distilled/sigmas_created/skipped counts
+ */
+DistillResultC storage_age_distill(SqliteStore *store, const char *cutoff_rfc3339, size_t batch_size);
+
+// ============================================================================
+// WAL Checkpoint
+// ============================================================================
+
+typedef struct {
+    bool success;
+    char *error_msg;
+    int32_t busy;
+    int32_t wal_pages;
+    int32_t checkpointed_pages;
+} CheckpointResultC;
+
+/**
+ * Run a TRUNCATE WAL checkpoint. Closes all provided read connections,
+ * checkpoints the write connection, then reopens read connections.
+ *
+ * read_conns is a mutable array of `count` ReadConn pointers. On return,
+ * each slot is replaced with a fresh connection (or NULL on reopen failure).
+ *
+ * Caller must hold the write mutex before calling.
+ *
+ * @param store Store handle
+ * @param read_conns Array of ReadConn pointers (mutated in place)
+ * @param count Number of read connections
+ * @return Checkpoint result with busy/wal_pages/checkpointed_pages
+ */
+CheckpointResultC storage_wal_checkpoint(SqliteStore *store, ReadConn **read_conns, size_t count);
+
+// ============================================================================
 // Backup
 // ============================================================================
 

--- a/crates/qntx-sqlite/src/enforcement.rs
+++ b/crates/qntx-sqlite/src/enforcement.rs
@@ -5,10 +5,7 @@
 //! - N contexts per actor — delete least-used contexts
 //! - N actors per entity/subject — delete least-recent actors
 //!
-//! Enforcement checks use counter tables (enforcement_actor_context, etc.)
-//! for O(1) lookups instead of scanning junction tables with JOINs.
-//! Counters are maintained incrementally in put().
-//!
+//! Enforcement checks use junction table COUNT queries with existing indices.
 //! Also handles telemetry logging to the storage_events table.
 
 use qntx_core::attestation::Attestation;
@@ -53,18 +50,20 @@ impl SqliteStore {
         &mut self,
         input: &EnforcementInput,
     ) -> Result<Vec<EnforcementEvent>, SqliteError> {
-        // Wrap all enforcement in a transaction — distill inserts + deletes + counter
-        // updates must be atomic to prevent corruption under write pressure.
-        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        // Use SAVEPOINT instead of BEGIN IMMEDIATE — enforce_limits is called
+        // from put(), which may already be inside a transaction (e.g. when Go's
+        // database/sql driver calls sql_begin before routing through storage_put).
+        // SAVEPOINTs nest safely within existing transactions.
+        self.conn.execute_batch("SAVEPOINT enforce_limits")?;
 
         let result = self.enforce_limits_inner(input);
 
         match &result {
             Ok(_) => {
-                self.conn.execute_batch("COMMIT")?;
+                self.conn.execute_batch("RELEASE SAVEPOINT enforce_limits")?;
             }
             Err(_) => {
-                let _ = self.conn.execute_batch("ROLLBACK");
+                let _ = self.conn.execute_batch("ROLLBACK TO SAVEPOINT enforce_limits");
             }
         }
 
@@ -75,9 +74,11 @@ impl SqliteStore {
         &mut self,
         input: &EnforcementInput,
     ) -> Result<Vec<EnforcementEvent>, SqliteError> {
+        let total_start = std::time::Instant::now();
         let mut events = Vec::new();
 
         // 1. Enforce N attestations per (actor, context) pair
+        let t1 = std::time::Instant::now();
         for actor in &input.actors {
             for context in &input.contexts {
                 match self.enforce_actor_context_limit(
@@ -96,8 +97,10 @@ impl SqliteStore {
                 }
             }
         }
+        let d1 = t1.elapsed();
 
         // 2. Enforce N contexts per actor
+        let t2 = std::time::Instant::now();
         for actor in &input.actors {
             match self.enforce_actor_contexts_limit(actor, input.config.actor_contexts_limit) {
                 Ok(Some(ev)) => events.push(ev),
@@ -110,8 +113,10 @@ impl SqliteStore {
                 }
             }
         }
+        let d2 = t2.elapsed();
 
         // 3. Enforce N actors per entity/subject
+        let t3 = std::time::Instant::now();
         for subject in &input.subjects {
             match self.enforce_entity_actors_limit(subject, input.config.entity_actors_limit) {
                 Ok(Some(ev)) => events.push(ev),
@@ -124,6 +129,7 @@ impl SqliteStore {
                 }
             }
         }
+        let d3 = t3.elapsed();
 
         // Log all events to storage_events table
         for ev in &events {
@@ -132,40 +138,68 @@ impl SqliteStore {
             }
         }
 
+        let total = total_start.elapsed();
+        if total.as_millis() > 100 {
+            eprintln!(
+                "qntx-sqlite: enforce_limits took {}ms (ac={}ms acs={}ms ea={}ms) evictions={}",
+                total.as_millis(),
+                d1.as_millis(),
+                d2.as_millis(),
+                d3.as_millis(),
+                events.len(),
+            );
+        }
+
         Ok(events)
     }
 
     /// Enforce actor_context_limit: keep only N most recent attestations per (actor, context).
     /// Uses half-bound threshold: triggers at `limit + limit/2`, evicts down to `limit`.
-    /// Counter lookup is O(1) — only runs DELETE when threshold is exceeded.
+    /// Uses in-memory counter for threshold check (O(1)), falls back to DB COUNT for actual count.
     fn enforce_actor_context_limit(
         &mut self,
         actor: &str,
         context: &str,
         limit: usize,
     ) -> Result<Option<EnforcementEvent>, SqliteError> {
-        // O(1) counter lookup instead of COUNT + JOIN
+        let threshold = limit + limit / 2;
+
+        // O(1) threshold check from in-memory counter (skip if not initialized — e.g. FlushEnforcement)
+        if self.enforcement_counters.initialized {
+            let cached_count = self
+                .enforcement_counters
+                .actor_context
+                .get(&(actor.to_string(), context.to_string()))
+                .copied()
+                .unwrap_or(0);
+
+            if cached_count <= threshold {
+                return Ok(None);
+            }
+        }
+
+        // Get exact count from DB
         let count: i64 = self
             .conn
             .query_row(
-                "SELECT count FROM enforcement_actor_context WHERE actor = ?1 AND context = ?2",
+                "SELECT COUNT(*) FROM attestation_actors a
+                 JOIN attestation_contexts c ON a.attestation_id = c.attestation_id
+                 WHERE a.actor = ?1 AND c.context = ?2",
                 rusqlite::params![actor, context],
                 |row| row.get::<_, i64>(0),
             )
             .unwrap_or(0);
 
-        // Half-bound threshold: trigger at limit + limit/2
-        let threshold = limit + limit / 2;
+        // Re-check with exact count (counter might be slightly off)
         if (count as usize) <= threshold {
+            // Correct the in-memory counter
+            self.enforcement_counters
+                .actor_context
+                .insert((actor.to_string(), context.to_string()), count as usize);
             return Ok(None);
         }
 
-        // +1 accounts for the distill attestation inserted after deletion.
-        // put_attestation() increments the enforcement counter even when
-        // self.distilling=true (enforcement is skipped but counter update isn't).
-        // Without +1: delete 8 from 24, counter drops to 16, distill insert
-        // bumps to 17 — one over limit. With +1: delete 9, counter=15,
-        // distill insert bumps to 16 = exactly limit.
+        // +1 accounts for the distill attestation inserted after deletion
         let delete_count = count as usize - limit + 1;
 
         // Load full attestation data for the eviction batch
@@ -205,7 +239,7 @@ impl SqliteStore {
         };
 
         // Delete oldest attestations first (CASCADE deletes junction rows)
-        let deleted = self.conn.execute(
+        let _deleted = self.conn.execute(
             "DELETE FROM attestations
              WHERE id IN (
                  SELECT att.id FROM attestations att
@@ -218,19 +252,7 @@ impl SqliteStore {
             rusqlite::params![actor, context, delete_count],
         )?;
 
-        // Update counter to reflect deletions, delete if zero
-        self.conn.execute(
-            "UPDATE enforcement_actor_context SET count = count - ?3
-             WHERE actor = ?1 AND context = ?2",
-            rusqlite::params![actor, context, deleted],
-        )?;
-        self.conn.execute(
-            "DELETE FROM enforcement_actor_context WHERE actor = ?1 AND context = ?2 AND count <= 0",
-            rusqlite::params![actor, context],
-        )?;
-
-        // Σ Insert sigma after deleting originals so the sigma's
-        // counter increment doesn't inflate the count.
+        // Σ Insert sigma after deleting originals.
         if !eviction_batch.is_empty() {
             let sigma = distill::build_distill_attestation(&eviction_batch, context);
             self.distilling = true;
@@ -243,6 +265,10 @@ impl SqliteStore {
                 );
             }
         }
+
+        // Update in-memory counter: deleted delete_count, inserted 1 distill = net -(delete_count-1)
+        self.enforcement_counters
+            .decrement_actor_context(actor, context, delete_count.saturating_sub(1));
 
         Ok(Some(EnforcementEvent {
             event_type: "actor_context_limit".to_string(),
@@ -257,30 +283,29 @@ impl SqliteStore {
 
     /// Enforce actor_contexts_limit: keep only N most-used contexts per actor.
     /// Uses half-bound threshold: triggers at `limit + limit/2`, evicts down to `limit`.
-    /// Counter lookup is O(1) — only queries context details when threshold is exceeded.
+    /// Uses in-memory counter for threshold check (O(1)), falls back to DB query for eviction.
     fn enforce_actor_contexts_limit(
         &mut self,
         actor: &str,
         limit: usize,
     ) -> Result<Option<EnforcementEvent>, SqliteError> {
-        // O(1) counter lookup
-        let count: i64 = self
-            .conn
-            .query_row(
-                "SELECT count FROM enforcement_actor_contexts WHERE actor = ?1",
-                rusqlite::params![actor],
-                |row| row.get::<_, i64>(0),
-            )
-            .unwrap_or(0);
-
-        // Half-bound threshold
         let threshold = limit + limit / 2;
-        if (count as usize) <= threshold {
-            return Ok(None);
+
+        // O(1) threshold check (skip if not initialized — e.g. FlushEnforcement)
+        if self.enforcement_counters.initialized {
+            let cached_count = self
+                .enforcement_counters
+                .actor_contexts
+                .get(actor)
+                .map(|s| s.len())
+                .unwrap_or(0);
+
+            if cached_count <= threshold {
+                return Ok(None);
+            }
         }
 
-        // Only now do we need to find which contexts to evict — query the
-        // counter table (small) instead of junction tables (huge).
+        // Counter says threshold exceeded — get exact data from DB for eviction
         struct ContextUsage {
             context: String,
             _usage_count: i64,
@@ -288,9 +313,12 @@ impl SqliteStore {
 
         let contexts: Vec<ContextUsage> = {
             let mut stmt = self.conn.prepare(
-                "SELECT context, count FROM enforcement_actor_context
-                 WHERE actor = ?1
-                 ORDER BY count ASC",
+                "SELECT c.context, COUNT(*) as cnt
+                 FROM attestation_contexts c
+                 JOIN attestation_actors a ON c.attestation_id = a.attestation_id
+                 WHERE a.actor = ?1
+                 GROUP BY c.context
+                 ORDER BY cnt ASC",
             )?;
             let mut rows = stmt.query(rusqlite::params![actor])?;
             let mut result = Vec::new();
@@ -303,7 +331,8 @@ impl SqliteStore {
             result
         };
 
-        if contexts.len() <= limit {
+        // Re-check with exact count
+        if contexts.len() <= threshold {
             return Ok(None);
         }
 
@@ -398,7 +427,7 @@ impl SqliteStore {
 
             // Σ Insert sigma after deleting originals
             if !eviction_batch.is_empty() {
-                let sigma = distill::build_distill_attestation(&eviction_batch, "_distill");
+                let sigma = distill::build_distill_attestation(&eviction_batch, &cu.context);
                 self.distilling = true;
                 let insert_result = put_attestation(&self.conn, &sigma);
                 self.distilling = false;
@@ -410,33 +439,13 @@ impl SqliteStore {
                 }
             }
 
-            // Remove counter row for this evicted (actor, context) pair
-            self.conn.execute(
-                "DELETE FROM enforcement_actor_context WHERE actor = ?1 AND context = ?2",
-                rusqlite::params![actor, cu.context],
-            )?;
-        }
-
-        // Update distinct context count for this actor
-        let remaining: i64 = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM enforcement_actor_context WHERE actor = ?1",
-                rusqlite::params![actor],
-                |row| row.get(0),
-            )
-            .unwrap_or(0);
-        if remaining <= 0 {
-            self.conn.execute(
-                "DELETE FROM enforcement_actor_contexts WHERE actor = ?1",
-                rusqlite::params![actor],
-            )?;
-        } else {
-            self.conn.execute(
-                "INSERT INTO enforcement_actor_contexts (actor, count) VALUES (?1, ?2)
-                 ON CONFLICT(actor) DO UPDATE SET count = ?2",
-                rusqlite::params![actor, remaining],
-            )?;
+            // Update in-memory counters: remove evicted context
+            self.enforcement_counters
+                .actor_context
+                .remove(&(actor.to_string(), cu.context.clone()));
+            if let Some(ctx_set) = self.enforcement_counters.actor_contexts.get_mut(actor) {
+                ctx_set.remove(&cu.context);
+            }
         }
 
         if total_deleted == 0 {
@@ -456,29 +465,29 @@ impl SqliteStore {
 
     /// Enforce entity_actors_limit: keep only N most-recent actors per entity/subject.
     /// Uses half-bound threshold: triggers at `limit + limit/2`, evicts down to `limit`.
-    /// Counter lookup is O(1) — only queries actor details when threshold is exceeded.
+    /// Uses in-memory counter for threshold check (O(1)), falls back to DB query for eviction.
     fn enforce_entity_actors_limit(
         &mut self,
         entity: &str,
         limit: usize,
     ) -> Result<Option<EnforcementEvent>, SqliteError> {
-        // O(1) counter lookup
-        let count: i64 = self
-            .conn
-            .query_row(
-                "SELECT count FROM enforcement_entity_actors WHERE subject = ?1",
-                rusqlite::params![entity],
-                |row| row.get::<_, i64>(0),
-            )
-            .unwrap_or(0);
-
-        // Half-bound threshold
         let threshold = limit + limit / 2;
-        if (count as usize) <= threshold {
-            return Ok(None);
+
+        // O(1) threshold check (skip if not initialized — e.g. FlushEnforcement)
+        if self.enforcement_counters.initialized {
+            let cached_count = self
+                .enforcement_counters
+                .entity_actors
+                .get(entity)
+                .map(|s| s.len())
+                .unwrap_or(0);
+
+            if cached_count <= threshold {
+                return Ok(None);
+            }
         }
 
-        // Only now query which actors to evict
+        // Counter says threshold exceeded — get exact data from DB for eviction
         let actors: Vec<String> = {
             let mut stmt = self.conn.prepare(
                 "SELECT a.actor, MAX(att.timestamp) as last_seen
@@ -497,7 +506,8 @@ impl SqliteStore {
             result
         };
 
-        if actors.len() <= limit {
+        // Re-check with exact count
+        if actors.len() <= threshold {
             return Ok(None);
         }
 
@@ -602,33 +612,14 @@ impl SqliteStore {
                 }
             }
 
-            // Remove detail tracking row
-            self.conn.execute(
-                "DELETE FROM enforcement_entity_actors_detail WHERE subject = ?1 AND actor = ?2",
-                rusqlite::params![entity, actor],
-            )?;
-        }
-
-        // Update counter to reflect actual remaining actors
-        let remaining: i64 = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM enforcement_entity_actors_detail WHERE subject = ?1",
-                rusqlite::params![entity],
-                |row| row.get(0),
-            )
-            .unwrap_or(0);
-        if remaining <= 0 {
-            self.conn.execute(
-                "DELETE FROM enforcement_entity_actors WHERE subject = ?1",
-                rusqlite::params![entity],
-            )?;
-        } else {
-            self.conn.execute(
-                "INSERT INTO enforcement_entity_actors (subject, count) VALUES (?1, ?2)
-                 ON CONFLICT(subject) DO UPDATE SET count = ?2",
-                rusqlite::params![entity, remaining],
-            )?;
+            // Update in-memory counters: remove evicted actor from entity
+            if let Some(actor_set) = self.enforcement_counters.entity_actors.get_mut(entity) {
+                actor_set.remove(actor);
+            }
+            // Remove actor_context entries for this actor (all contexts)
+            self.enforcement_counters
+                .actor_context
+                .retain(|(a, _), _| a != actor);
         }
 
         if total_deleted == 0 {
@@ -792,10 +783,10 @@ mod tests {
         let events = store.enforce_limits(&input).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_type, "actor_context_limit");
-        assert_eq!(events[0].deleted_count, 3); // 4 - 2 + 1 = 3 (the +1 compensates for distill insert)
+        assert_eq!(events[0].deleted_count, 3); // 4 - 2 + 1 = 3 (+1 for distill)
         assert_eq!(events[0].limit_value, 2);
 
-        // Verify: 1 original kept + 1 distill attestation = 2
+        // Verify: 1 original kept + 1 distill attestation = 2 = limit
         let count = store.count().unwrap();
         assert_eq!(count, 2);
 
@@ -936,7 +927,7 @@ mod tests {
 
         let events = store.enforce_limits(&input).unwrap();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].deleted_count, 3); // 4 - 2 + 1 = 3 (the +1 compensates for distill insert)
+        assert_eq!(events[0].deleted_count, 3); // 4 - 2 + 1 = 3 (+1 for distill)
 
         // Find the distill attestation
         let all_ids = store.ids().unwrap();
@@ -962,27 +953,27 @@ mod tests {
         );
         assert_eq!(
             distill_att.attributes.get("_count").unwrap(),
-            &serde_json::json!(3) // batch size: 3 evicted attestations
+            &serde_json::json!(3) // batch size: 3 evicted attestations (AS-1, AS-2, AS-3)
         );
         assert_eq!(
             distill_att.attributes.get("_total").unwrap(),
             &serde_json::json!(3) // no prior distills, so _total == _count
         );
 
-        // Check merged elapsed_ms: min=50, max=200, sum=350, count=3
+        // Check merged elapsed_ms: min=50, max=200, sum=350, count=3 (AS-1 + AS-2 + AS-3)
         let elapsed = distill_att.attributes.get("elapsed_ms").unwrap();
-        assert_eq!(elapsed.get("min").unwrap(), &serde_json::json!(50)); // AS-3
+        assert_eq!(elapsed.get("min").unwrap(), &serde_json::json!(50));  // AS-3
         assert_eq!(elapsed.get("max").unwrap(), &serde_json::json!(200)); // AS-2
         assert_eq!(elapsed.get("sum").unwrap(), &serde_json::json!(350)); // 100+200+50
         assert_eq!(elapsed.get("count").unwrap(), &serde_json::json!(3));
 
-        // Check merged stage: frequencies should contain "connecting" and "discovered"
+        // Check merged stage: AS-1, AS-2, AS-3 have stage values
         let stage = distill_att.attributes.get("stage").unwrap();
         let freqs = stage.get("frequencies").unwrap().as_object().unwrap();
         assert!(freqs.contains_key("connecting"));
         assert!(freqs.contains_key("discovered"));
 
-        // Predicates should be distill-prefixed
+        // Predicates should include the evicted predicates
         assert!(distill_att
             .predicates
             .iter()

--- a/crates/qntx-sqlite/src/ffi.rs
+++ b/crates/qntx-sqlite/src/ffi.rs
@@ -690,6 +690,8 @@ pub extern "C" fn storage_put(
     };
     let attestation = proto_convert::from_proto(proto);
 
+    crate::flight_recorder::record_fmt("storage_put", &attestation.id);
+
     match store.put(attestation) {
         Ok(()) => StorageResultC::ok(),
         Err(e) => StorageResultC::error(&format!("{}", e)),
@@ -1115,28 +1117,66 @@ pub extern "C" fn storage_integrity_check(store: *const SqliteStore) -> StringAr
 // Backup
 // ============================================================================
 
-/// Create a hot backup of the database to the given path.
-/// Safe to call while the database is in use.
+/// Create a hot backup of the database.
+/// Does NOT take a store pointer — opens its own read-only source connection
+/// to avoid concurrent access with storage_put (which caused SIGBUS).
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn storage_backup(
-    store: *const SqliteStore,
+    src_path: *const c_char,
     dest_path: *const c_char,
 ) -> StorageResultC {
-    let store = unsafe {
-        match store.as_ref() {
-            Some(s) => s,
-            None => return StorageResultC::error("null store pointer"),
-        }
+    let src = match unsafe { cstr_to_str(src_path) } {
+        Ok(s) => s,
+        Err(e) => return StorageResultC::error(e),
     };
     let dest = match unsafe { cstr_to_str(dest_path) } {
         Ok(s) => s,
         Err(e) => return StorageResultC::error(e),
     };
-    match store.backup(dest) {
+    crate::flight_recorder::record_fmt("storage_backup", dest);
+    match backup_standalone(src, dest) {
         Ok(()) => StorageResultC::ok(),
         Err(e) => StorageResultC::error(&format!("backup failed: {}", e)),
     }
+}
+
+/// Standalone backup — no SqliteStore reference needed.
+fn backup_standalone(src_path: &str, dest_path: &str) -> crate::error::Result<()> {
+    use crate::error::SqliteError;
+
+    let src = rusqlite::Connection::open_with_flags(
+        src_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(SqliteError::from)?;
+    let mut dest = rusqlite::Connection::open(dest_path).map_err(SqliteError::from)?;
+    let b = rusqlite::backup::Backup::new(&src, &mut dest).map_err(SqliteError::from)?;
+
+    loop {
+        match b.step(5_000).map_err(SqliteError::from)? {
+            rusqlite::backup::StepResult::Done => break,
+            rusqlite::backup::StepResult::More => {
+                std::thread::yield_now();
+            }
+            rusqlite::backup::StepResult::Busy | rusqlite::backup::StepResult::Locked | _ => {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Crash test
+// ============================================================================
+
+/// Deliberately abort the process to verify the flight recorder works.
+/// Only for development/testing — never call in production.
+#[no_mangle]
+pub extern "C" fn storage_crash_test() {
+    crate::flight_recorder::record("storage_crash_test: deliberate crash");
+    std::process::abort();
 }
 
 // ============================================================================

--- a/crates/qntx-sqlite/src/ffi.rs
+++ b/crates/qntx-sqlite/src/ffi.rs
@@ -234,6 +234,157 @@ pub extern "C" fn read_conn_free(rc: *mut ReadConn) {
     unsafe { free_boxed(rc) };
 }
 
+/// WAL checkpoint result
+#[repr(C)]
+pub struct CheckpointResultC {
+    pub success: bool,
+    pub error_msg: *mut c_char,
+    pub busy: i32,
+    pub wal_pages: i32,
+    pub checkpointed_pages: i32,
+}
+
+/// Run a TRUNCATE checkpoint. Closes all provided read connections first,
+/// runs the checkpoint on the write connection, then reopens read connections
+/// and writes new pointers back to the array.
+///
+/// `read_conns` is a mutable array of `count` ReadConn pointers. On success,
+/// each slot is replaced with a fresh read connection. On failure, slots that
+/// were closed are set to NULL.
+///
+/// Caller must hold the write mutex (muWrite) before calling.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn storage_wal_checkpoint(
+    store: *mut SqliteStore,
+    read_conns: *mut *mut ReadConn,
+    count: usize,
+) -> CheckpointResultC {
+    if store.is_null() {
+        return CheckpointResultC {
+            success: false,
+            error_msg: cstring_new_or_empty("null store pointer"),
+            busy: 0,
+            wal_pages: 0,
+            checkpointed_pages: 0,
+        };
+    }
+    let store = unsafe { &*store };
+    let slots = if read_conns.is_null() || count == 0 {
+        &mut [][..]
+    } else {
+        unsafe { std::slice::from_raw_parts_mut(read_conns, count) }
+    };
+
+    // Phase 1: close all read connections (drops SQLite file handles)
+    for slot in slots.iter_mut() {
+        if !slot.is_null() {
+            unsafe { free_boxed(*slot) };
+            *slot = ptr::null_mut();
+        }
+    }
+
+    // Phase 2: TRUNCATE checkpoint on write connection
+    let (busy, wal_pages, checkpointed_pages) = match store.wal_checkpoint_truncate() {
+        Ok(r) => r,
+        Err(e) => {
+            // Reopen read connections even on checkpoint failure
+            for slot in slots.iter_mut() {
+                match store.open_read_conn() {
+                    Ok(rc) => *slot = Box::into_raw(Box::new(rc)),
+                    Err(_) => *slot = ptr::null_mut(),
+                }
+            }
+            return CheckpointResultC {
+                success: false,
+                error_msg: cstring_new_or_empty(&format!("{}", e)),
+                busy: 0,
+                wal_pages: 0,
+                checkpointed_pages: 0,
+            };
+        }
+    };
+
+    // Phase 3: reopen all read connections
+    for slot in slots.iter_mut() {
+        match store.open_read_conn() {
+            Ok(rc) => *slot = Box::into_raw(Box::new(rc)),
+            Err(e) => {
+                eprintln!("qntx-sqlite: failed to reopen read connection after checkpoint: {}", e);
+                *slot = ptr::null_mut();
+            }
+        }
+    }
+
+    CheckpointResultC {
+        success: true,
+        error_msg: ptr::null_mut(),
+        busy,
+        wal_pages,
+        checkpointed_pages,
+    }
+}
+
+/// C-compatible distill result
+#[repr(C)]
+pub struct DistillResultC {
+    pub success: bool,
+    pub error_msg: *mut c_char,
+    pub distilled: usize,
+    pub sigmas_created: usize,
+    pub skipped: usize,
+}
+
+/// Run age-triggered distillation: fold old attestations into sigmas.
+/// Caller must hold the write mutex (muWrite) before calling.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn storage_age_distill(
+    store: *mut SqliteStore,
+    cutoff_rfc3339: *const c_char,
+    batch_size: usize,
+) -> DistillResultC {
+    if store.is_null() {
+        return DistillResultC {
+            success: false,
+            error_msg: cstring_new_or_empty("null store pointer"),
+            distilled: 0,
+            sigmas_created: 0,
+            skipped: 0,
+        };
+    }
+    let store = unsafe { &*store };
+    let cutoff = match unsafe { cstr_to_str(cutoff_rfc3339) } {
+        Ok(s) => s,
+        Err(e) => {
+            return DistillResultC {
+                success: false,
+                error_msg: cstring_new_or_empty(e),
+                distilled: 0,
+                sigmas_created: 0,
+                skipped: 0,
+            }
+        }
+    };
+
+    match store.age_distill(cutoff, batch_size) {
+        Ok((distilled, sigmas_created, skipped)) => DistillResultC {
+            success: true,
+            error_msg: ptr::null_mut(),
+            distilled,
+            sigmas_created,
+            skipped,
+        },
+        Err(e) => DistillResultC {
+            success: false,
+            error_msg: cstring_new_or_empty(&format!("{}", e)),
+            distilled: 0,
+            sigmas_created: 0,
+            skipped: 0,
+        },
+    }
+}
+
 /// Get an attestation by ID through the read connection.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/crates/qntx-sqlite/src/flight_recorder.rs
+++ b/crates/qntx-sqlite/src/flight_recorder.rs
@@ -1,0 +1,115 @@
+//! Flight recorder for FFI boundary observability.
+//!
+//! Records the last FFI operation per thread to a file so it survives crashes.
+//! Does NOT install signal handlers — Go's runtime handles signals
+//! and produces the goroutine dump. We just ensure the context is
+//! available in a file after the crash.
+//!
+//! Each thread gets its own file: `{db}.flight.{thread_id}`
+//! so concurrent operations don't overwrite each other.
+//!
+//! Caller attribution: Go sets a thread-local caller tag via
+//! `flight_recorder_set_caller` before issuing FFI calls. The tag
+//! is included in every recorded entry so crashes can be traced
+//! back to the originating component (watcher engine, plugin, Pulse, etc).
+
+use std::cell::RefCell;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+static RECORDER_DIR: OnceLock<String> = OnceLock::new();
+static START_TIME: OnceLock<Instant> = OnceLock::new();
+
+thread_local! {
+    static THREAD_FILE: RefCell<Option<String>> = const { RefCell::new(None) };
+    static CALLER: RefCell<[u8; 64]> = const { RefCell::new([0u8; 64]) };
+    static CALLER_LEN: RefCell<usize> = const { RefCell::new(0) };
+}
+
+/// Set the base path for flight recorder files.
+/// Called once at store initialization.
+pub fn init(base_path: &str) {
+    let _ = RECORDER_DIR.set(base_path.to_string());
+    let _ = START_TIME.set(Instant::now());
+}
+
+/// Set the caller tag for the current thread.
+/// Called from Go before issuing FFI calls.
+pub fn set_caller(caller: &str) {
+    CALLER.with(|c| {
+        let mut buf = c.borrow_mut();
+        let len = caller.len().min(64);
+        buf[..len].copy_from_slice(&caller.as_bytes()[..len]);
+        CALLER_LEN.with(|cl| *cl.borrow_mut() = len);
+    });
+}
+
+fn get_caller() -> Option<String> {
+    CALLER_LEN.with(|cl| {
+        let len = *cl.borrow();
+        if len == 0 {
+            return None;
+        }
+        CALLER.with(|c| {
+            let buf = c.borrow();
+            Some(String::from_utf8_lossy(&buf[..len]).into_owned())
+        })
+    })
+}
+
+fn get_thread_file() -> Option<String> {
+    THREAD_FILE.with(|tf| {
+        let mut tf = tf.borrow_mut();
+        if tf.is_none() {
+            if let Some(base) = RECORDER_DIR.get() {
+                let tid = std::thread::current().id();
+                let path = format!("{}.{:?}", base, tid);
+                *tf = Some(path);
+            }
+        }
+        tf.clone()
+    })
+}
+
+fn uptime_secs() -> u64 {
+    START_TIME.get().map_or(0, |t| t.elapsed().as_secs())
+}
+
+/// Record the current FFI operation.
+pub fn record(op: &str) {
+    if let Some(path) = get_thread_file() {
+        let secs = uptime_secs();
+        let entry = match get_caller() {
+            Some(caller) => format!("t={}s caller={} {}", secs, caller, op),
+            None => format!("t={}s {}", secs, op),
+        };
+        write_to_file(&path, &entry);
+    }
+}
+
+/// Record with context detail.
+pub fn record_fmt(op: &str, detail: &str) {
+    if let Some(path) = get_thread_file() {
+        let secs = uptime_secs();
+        let entry = match get_caller() {
+            Some(caller) => format!("t={}s caller={} {}: {}", secs, caller, op, detail),
+            None => format!("t={}s {}: {}", secs, op, detail),
+        };
+        write_to_file(&path, &entry);
+    }
+}
+
+fn write_to_file(path: &str, entry: &str) {
+    if let Ok(mut f) = OpenOptions::new().create(true).write(true).truncate(true).open(path) {
+        let _ = writeln!(f, "{}", entry);
+        let _ = f.flush();
+    }
+}
+
+/// Install crash handler — no-op. Kept for API compatibility.
+/// Go's runtime handles SIGBUS/SIGSEGV and produces goroutine dumps.
+pub fn install_crash_handler() {
+    // Intentionally empty — we don't intercept signals.
+}

--- a/crates/qntx-sqlite/src/lib.rs
+++ b/crates/qntx-sqlite/src/lib.rs
@@ -66,6 +66,7 @@ pub mod bounded;
 pub mod distill;
 pub mod enforcement;
 pub mod error;
+pub mod flight_recorder;
 pub mod json;
 pub mod migrate;
 pub mod store;

--- a/crates/qntx-sqlite/src/sql_ffi.rs
+++ b/crates/qntx-sqlite/src/sql_ffi.rs
@@ -170,6 +170,8 @@ pub extern "C" fn sql_exec(
 
     let store = unsafe { &mut *store };
 
+    crate::flight_recorder::record_fmt("sql_exec", sql_str);
+
     let param_refs = match parse_params(params_str) {
         Ok(p) => p,
         Err(e) => return ExecResultC::error(&e),
@@ -220,6 +222,8 @@ pub extern "C" fn sql_query(
     }
 
     let store = unsafe { &*store };
+
+    crate::flight_recorder::record_fmt("sql_query", sql_str);
 
     let param_refs = match parse_params(params_str) {
         Ok(p) => p,
@@ -302,6 +306,7 @@ pub extern "C" fn sql_begin(store: *mut SqliteStore) -> ExecResultC {
         return ExecResultC::error("null store pointer");
     }
     let store = unsafe { &mut *store };
+    crate::flight_recorder::record("sql_begin");
     match store.conn.execute_batch("BEGIN IMMEDIATE") {
         Ok(()) => ExecResultC::ok(0, 0),
         Err(e) => ExecResultC::error(&format!("{}", e)),
@@ -316,9 +321,20 @@ pub extern "C" fn sql_commit(store: *mut SqliteStore) -> ExecResultC {
         return ExecResultC::error("null store pointer");
     }
     let store = unsafe { &mut *store };
+    crate::flight_recorder::record("sql_commit");
     match store.conn.execute_batch("COMMIT") {
         Ok(()) => ExecResultC::ok(0, 0),
         Err(e) => ExecResultC::error(&format!("{}", e)),
+    }
+}
+
+/// Set the caller tag for the current thread's flight recorder entries.
+/// Called from Go before issuing FFI calls to attribute queries to their source.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn flight_recorder_set_caller(caller: *const c_char) {
+    if let Ok(s) = unsafe { cstr_to_str(caller) } {
+        crate::flight_recorder::set_caller(s);
     }
 }
 
@@ -330,6 +346,7 @@ pub extern "C" fn sql_rollback(store: *mut SqliteStore) -> ExecResultC {
         return ExecResultC::error("null store pointer");
     }
     let store = unsafe { &mut *store };
+    crate::flight_recorder::record("sql_rollback");
     match store.conn.execute_batch("ROLLBACK") {
         Ok(()) => ExecResultC::ok(0, 0),
         Err(e) => ExecResultC::error(&format!("{}", e)),
@@ -365,6 +382,8 @@ pub extern "C" fn read_conn_sql_query(
     }
 
     let rc = unsafe { &*rc };
+
+    crate::flight_recorder::record_fmt("read_conn_sql_query", sql_str);
 
     let param_refs = match parse_params(params_str) {
         Ok(p) => p,

--- a/crates/qntx-sqlite/src/store.rs
+++ b/crates/qntx-sqlite/src/store.rs
@@ -197,6 +197,129 @@ impl SqliteStore {
         Ok(ReadConn { conn })
     }
 
+    /// Run a TRUNCATE checkpoint on the write connection.
+    /// Caller MUST ensure no read connections are open — TRUNCATE requires
+    /// exclusive access to the WAL. Returns (busy, wal_pages, checkpointed_pages).
+    pub fn wal_checkpoint_truncate(&self) -> StoreResult<(i32, i32, i32)> {
+        let mut busy = 0i32;
+        let mut log = 0i32;
+        let mut checkpointed = 0i32;
+        self.conn
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+                busy = row.get(0)?;
+                log = row.get(1)?;
+                checkpointed = row.get(2)?;
+                Ok(())
+            })
+            .map_err(SqliteError::from)?;
+        Ok((busy, log, checkpointed))
+    }
+
+    /// Age-triggered distillation: fold old attestations into sigmas.
+    ///
+    /// Queries attestations older than `cutoff_rfc3339` plus all existing sigmas
+    /// (source='distill'). Groups by first predicate, builds a sigma per group,
+    /// deletes originals. All within a single transaction.
+    ///
+    /// Returns (distilled_count, sigmas_created, skipped_singles).
+    pub fn age_distill(
+        &self,
+        cutoff_rfc3339: &str,
+        batch_size: usize,
+    ) -> StoreResult<(usize, usize, usize)> {
+        use crate::distill::build_distill_attestation;
+
+        // Load candidates
+        let mut stmt = self.conn.prepare(
+            "SELECT id, subjects, predicates, contexts, actors, timestamp, source, attributes, created_at, signature, signer_did
+             FROM attestations
+             WHERE (timestamp < ?1 OR source = 'distill')
+             ORDER BY timestamp ASC
+             LIMIT ?2"
+        ).map_err(SqliteError::from)?;
+
+        let rows = stmt.query_map(
+            rusqlite::params![cutoff_rfc3339, batch_size as i64],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                    row.get::<_, String>(8)?,
+                    row.get::<_, Option<Vec<u8>>>(9)?,
+                    row.get::<_, Option<String>>(10)?,
+                ))
+            },
+        ).map_err(SqliteError::from)?;
+
+        let mut candidates: Vec<Attestation> = Vec::new();
+        for row in rows {
+            let row_data = row.map_err(SqliteError::from)?;
+            match Self::row_to_attestation(row_data) {
+                Ok(att) => candidates.push(att),
+                Err(_) => continue,
+            }
+        }
+        drop(stmt);
+
+        if candidates.is_empty() {
+            return Ok((0, 0, 0));
+        }
+
+        // Group by first predicate
+        let mut groups: HashMap<String, Vec<Attestation>> = HashMap::new();
+        for att in candidates {
+            let predicate = att.predicates.first().cloned().unwrap_or_else(|| "_".to_string());
+            groups.entry(predicate).or_default().push(att);
+        }
+
+        let tx = self.conn.unchecked_transaction().map_err(SqliteError::from)?;
+
+        let mut total_distilled = 0usize;
+        let mut total_created = 0usize;
+        let mut total_skipped = 0usize;
+
+        for (predicate, batch) in &groups {
+            if batch.len() < 2 {
+                total_skipped += batch.len();
+                continue;
+            }
+
+            // Build sigma — uses distill:<predicate> as context
+            let context = format!("distill:{}", predicate.trim_start_matches("distill:"));
+            let sigma = build_distill_attestation(batch, &context);
+
+            // The sigma predicate should be distill:<original_predicate>
+            let sigma = Attestation {
+                subjects: vec![format!("distill:{}", predicate.trim_start_matches("distill:"))],
+                predicates: vec![format!("distill:{}", predicate.trim_start_matches("distill:"))],
+                ..sigma
+            };
+
+            // Delete originals (CASCADE handles junction tables)
+            for att in batch {
+                tx.execute(
+                    "DELETE FROM attestations WHERE id = ?1",
+                    rusqlite::params![att.id],
+                ).map_err(SqliteError::from)?;
+                total_distilled += 1;
+            }
+
+            // Insert sigma
+            put_attestation(&tx, &sigma)?;
+            total_created += 1;
+        }
+
+        tx.commit().map_err(SqliteError::from)?;
+
+        Ok((total_distilled, total_created, total_skipped))
+    }
+
     /// Run PRAGMA integrity_check and return the result lines.
     /// A healthy database returns a single line: "ok".
     pub fn integrity_check(&self) -> StoreResult<Vec<String>> {

--- a/crates/qntx-sqlite/src/store.rs
+++ b/crates/qntx-sqlite/src/store.rs
@@ -5,7 +5,7 @@ use qntx_core::{
     storage::{AttestationStore, QueryStore, StorageStats, StoreError},
 };
 use rusqlite::{backup, Connection, OptionalExtension};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::SqliteError;
 
@@ -44,10 +44,68 @@ pub struct SqliteStore {
     /// Database file path, if file-backed. Used by backup to open a separate read connection.
     pub(crate) db_path: Option<String>,
     /// Enforcement config for bounded storage limits (16/64/64 default).
-    /// When set, enforcement runs on every put() using O(1) counter lookups.
+    /// When set, enforcement runs every 50 puts using junction table COUNT queries.
     pub(crate) enforcement_config: Option<EnforcementConfig>,
     /// When true, put() skips enforcement to prevent infinite loops during distillation.
     pub(crate) distilling: bool,
+    /// Counter for amortized enforcement: only run enforcement every N puts.
+    put_count: u64,
+    /// In-memory enforcement counters for O(1) threshold checks.
+    /// Populated lazily from DB on first access, then maintained on put/delete.
+    pub(crate) enforcement_counters: EnforcementCounters,
+}
+
+/// In-memory counters for O(1) enforcement threshold checks.
+/// Avoids expensive COUNT queries with JOINs on every put().
+#[derive(Default)]
+pub struct EnforcementCounters {
+    /// (actor, context) → attestation count
+    pub(crate) actor_context: HashMap<(String, String), usize>,
+    /// actor → set of distinct contexts
+    pub(crate) actor_contexts: HashMap<String, HashSet<String>>,
+    /// subject → set of distinct actors
+    pub(crate) entity_actors: HashMap<String, HashSet<String>>,
+    /// Whether counters have been populated from DB
+    pub(crate) initialized: bool,
+}
+
+impl EnforcementCounters {
+    /// Check if any counter exceeds its half-bound threshold.
+    /// O(1) — just checks the in-memory maps for the attestation's dimensions.
+    pub fn any_threshold_exceeded(
+        &self,
+        config: &qntx_core::storage::enforcement::EnforcementConfig,
+    ) -> bool {
+        let ac_threshold = config.actor_context_limit + config.actor_context_limit / 2;
+        for count in self.actor_context.values() {
+            if *count > ac_threshold {
+                return true;
+            }
+        }
+
+        let acs_threshold = config.actor_contexts_limit + config.actor_contexts_limit / 2;
+        for contexts in self.actor_contexts.values() {
+            if contexts.len() > acs_threshold {
+                return true;
+            }
+        }
+
+        let ea_threshold = config.entity_actors_limit + config.entity_actors_limit / 2;
+        for actors in self.entity_actors.values() {
+            if actors.len() > ea_threshold {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Decrement actor_context counter after enforcement deletes.
+    pub fn decrement_actor_context(&mut self, actor: &str, context: &str, count: usize) {
+        if let Some(val) = self.actor_context.get_mut(&(actor.to_string(), context.to_string())) {
+            *val = val.saturating_sub(count);
+        }
+    }
 }
 
 /// Read-only SQLite connection for concurrent queries.
@@ -70,6 +128,8 @@ impl SqliteStore {
             db_path: None,
             enforcement_config: None,
             distilling: false,
+            put_count: 0,
+            enforcement_counters: EnforcementCounters::default(),
         }
     }
 
@@ -92,11 +152,22 @@ impl SqliteStore {
         crate::vec::init_vec_extension();
 
         let path_str = path.as_ref().to_string_lossy().to_string();
+
+        // Initialize flight recorder next to the database file
+        let recorder_path = format!("{}.flight", path_str);
+        crate::flight_recorder::init(&recorder_path);
         let conn = Connection::open(&path)?;
 
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.pragma_update(None, "busy_timeout", "5000")?;
+        conn.pragma_update(None, "mmap_size", "0")?;
+        // WAL always memory-maps the -shm index file for reader/writer coordination.
+        // With many connections sharing the same mmap, auto-checkpoints during writes
+        // can invalidate the mapping → SIGBUS at _platform_memmove with page-aligned
+        // fault addresses. Disable auto-checkpoint; put() runs PASSIVE checkpoints
+        // every 5000 writes instead (PASSIVE never truncates WAL or -shm).
+        conn.pragma_update(None, "wal_autocheckpoint", "0")?;
         crate::migrate::migrate(&conn)?;
 
         Ok(Self {
@@ -104,6 +175,8 @@ impl SqliteStore {
             db_path: Some(path_str),
             enforcement_config: None,
             distilling: false,
+            put_count: 0,
+            enforcement_counters: EnforcementCounters::default(),
         })
     }
 
@@ -120,6 +193,7 @@ impl SqliteStore {
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
         conn.pragma_update(None, "busy_timeout", "5000")?;
+        conn.pragma_update(None, "mmap_size", "0")?;
         Ok(ReadConn { conn })
     }
 
@@ -141,13 +215,14 @@ impl SqliteStore {
     }
 
     /// Create a hot backup of the database to the given path.
-    /// Opens a separate read-only source connection so the backup does not need
-    /// exclusive access to `self.conn` — callers do NOT need to hold the mutex.
+    /// Flushes WAL to the main DB first via TRUNCATE checkpoint, then opens a
+    /// separate read-only source connection — callers do NOT need to hold the mutex.
     pub fn backup(&self, dest_path: &str) -> StoreResult<()> {
         let src_path = self
             .db_path
             .as_deref()
             .ok_or_else(|| StoreError::Backend("backup requires a file-backed database".into()))?;
+
         let src = Connection::open_with_flags(
             src_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -320,6 +395,7 @@ pub(crate) fn put_attestation(conn: &Connection, attestation: &Attestation) -> S
     let timestamp_sql = timestamp_to_sql(attestation.timestamp);
     let created_at_sql = timestamp_to_sql(attestation.created_at);
 
+    crate::flight_recorder::record_fmt("put:insert_main", &attestation.id);
     conn.execute(
         "INSERT INTO attestations (id, subjects, predicates, contexts, actors, timestamp, source, attributes, created_at, signature, signer_did)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -340,6 +416,7 @@ pub(crate) fn put_attestation(conn: &Connection, attestation: &Attestation) -> S
     .map_err(SqliteError::from)?;
 
     // Populate junction tables for indexed lookups
+    crate::flight_recorder::record_fmt("put:junction_actors", &attestation.id);
     for actor in &attestation.actors {
         conn.execute(
             "INSERT INTO attestation_actors (attestation_id, actor) VALUES (?, ?)",
@@ -347,6 +424,7 @@ pub(crate) fn put_attestation(conn: &Connection, attestation: &Attestation) -> S
         )
         .map_err(SqliteError::from)?;
     }
+    crate::flight_recorder::record_fmt("put:junction_contexts", &attestation.id);
     for context in &attestation.contexts {
         conn.execute(
             "INSERT INTO attestation_contexts (attestation_id, context) VALUES (?, ?)",
@@ -354,6 +432,7 @@ pub(crate) fn put_attestation(conn: &Connection, attestation: &Attestation) -> S
         )
         .map_err(SqliteError::from)?;
     }
+    crate::flight_recorder::record_fmt("put:junction_subjects", &attestation.id);
     for subject in &attestation.subjects {
         conn.execute(
             "INSERT INTO attestation_subjects (attestation_id, subject) VALUES (?, ?)",
@@ -361,6 +440,7 @@ pub(crate) fn put_attestation(conn: &Connection, attestation: &Attestation) -> S
         )
         .map_err(SqliteError::from)?;
     }
+    crate::flight_recorder::record_fmt("put:junction_predicates", &attestation.id);
     for predicate in &attestation.predicates {
         conn.execute(
             "INSERT INTO attestation_predicates (attestation_id, predicate) VALUES (?, ?)",
@@ -369,52 +449,7 @@ pub(crate) fn put_attestation(conn: &Connection, attestation: &Attestation) -> S
         .map_err(SqliteError::from)?;
     }
 
-    // Update enforcement counters (O(1) per combination).
-    for actor in &attestation.actors {
-        for context in &attestation.contexts {
-            let new_count: i64 = conn
-                .query_row(
-                    "INSERT INTO enforcement_actor_context (actor, context, count)
-                 VALUES (?1, ?2, 1)
-                 ON CONFLICT(actor, context) DO UPDATE SET count = count + 1
-                 RETURNING count",
-                    rusqlite::params![actor, context],
-                    |row| row.get(0),
-                )
-                .map_err(SqliteError::from)?;
-
-            if new_count == 1 {
-                conn.execute(
-                    "INSERT INTO enforcement_actor_contexts (actor, count)
-                     VALUES (?1, 1)
-                     ON CONFLICT(actor) DO UPDATE SET count = count + 1",
-                    rusqlite::params![actor],
-                )
-                .map_err(SqliteError::from)?;
-            }
-        }
-    }
-    for subject in &attestation.subjects {
-        for actor in &attestation.actors {
-            let changed = conn
-                .execute(
-                    "INSERT OR IGNORE INTO enforcement_entity_actors_detail (subject, actor)
-                 VALUES (?1, ?2)",
-                    rusqlite::params![subject, actor],
-                )
-                .map_err(SqliteError::from)?;
-            if changed > 0 {
-                conn.execute(
-                    "INSERT INTO enforcement_entity_actors (subject, count)
-                     VALUES (?1, 1)
-                     ON CONFLICT(subject) DO UPDATE SET count = count + 1",
-                    rusqlite::params![subject],
-                )
-                .map_err(SqliteError::from)?;
-            }
-        }
-    }
-
+    crate::flight_recorder::record_fmt("put:done", &attestation.id);
     Ok(())
 }
 
@@ -430,20 +465,57 @@ impl AttestationStore for SqliteStore {
 
         put_attestation(&self.conn, &attestation)?;
 
-        // Enforce bounded storage limits using counter lookups (O(1) per check).
+        // Update in-memory counters and check thresholds.
         // Skip enforcement when distilling to prevent infinite loops (distill insert → enforce → distill).
         if !self.distilling {
+            self.enforcement_counters.initialized = true;
+
+            // Update counters for every put
+            for actor in &actors {
+                for context in &contexts {
+                    *self
+                        .enforcement_counters
+                        .actor_context
+                        .entry((actor.clone(), context.clone()))
+                        .or_insert(0) += 1;
+                }
+                self.enforcement_counters
+                    .actor_contexts
+                    .entry(actor.clone())
+                    .or_default()
+                    .extend(contexts.iter().cloned());
+            }
+            for subject in &subjects {
+                self.enforcement_counters
+                    .entity_actors
+                    .entry(subject.clone())
+                    .or_default()
+                    .extend(actors.iter().cloned());
+            }
+
+            // Only run enforcement when a threshold is exceeded (O(1) check)
             if let Some(ref config) = self.enforcement_config {
-                let input = EnforcementInput {
-                    actors,
-                    contexts,
-                    subjects,
-                    config: config.clone(),
-                };
-                if let Err(e) = self.enforce_limits(&input) {
-                    eprintln!("qntx-sqlite: post-put enforcement failed: {}", e);
+                let needs_enforcement = self.enforcement_counters.any_threshold_exceeded(config);
+                if needs_enforcement {
+                    let input = EnforcementInput {
+                        actors,
+                        contexts,
+                        subjects,
+                        config: config.clone(),
+                    };
+                    if let Err(e) = self.enforce_limits(&input) {
+                        eprintln!("qntx-sqlite: post-put enforcement failed: {}", e);
+                    }
                 }
             }
+        }
+
+        // Periodic PASSIVE checkpoint — moves WAL pages to the main DB without
+        // truncating WAL or -shm. Safe with concurrent readers (PASSIVE skips
+        // pages that readers hold). Every 5000 puts keeps WAL bounded at ~20MB.
+        self.put_count += 1;
+        if self.put_count.is_multiple_of(5000) {
+            let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE)");
         }
 
         Ok(())

--- a/db/connection.go
+++ b/db/connection.go
@@ -93,6 +93,26 @@ func Open(path string, log *zap.SugaredLogger) (*sql.DB, error) {
 	return db, nil
 }
 
+// OpenReadOnly opens a read-only SQLite connection without _txlock=immediate.
+// Reads through this connection never contend with writers in WAL mode.
+func OpenReadOnly(path string, log *zap.SugaredLogger) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", path+"?mode=ro")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open read-only database at %s", path)
+	}
+
+	if _, err := db.Exec("PRAGMA busy_timeout = 1000"); err != nil {
+		db.Close()
+		return nil, errors.Wrapf(err, "failed to set busy timeout for read-only %s", path)
+	}
+
+	if log != nil {
+		logger.AddDBSymbol(log).Infow("Read-only database opened", "path", path)
+	}
+
+	return db, nil
+}
+
 // OpenWithMigrations opens a SQLite database and runs migrations.
 // This is a convenience function that combines Open() and Migrate().
 // Migrations are idempotent and have low overhead for SQLite.

--- a/db/rustdriver/driver.go
+++ b/db/rustdriver/driver.go
@@ -45,16 +45,43 @@ func Register(storePtr, readConnPtr unsafe.Pointer, muWrite, muRead *sync.Mutex)
 	})
 }
 
+// RegisterNamed registers an additional named driver that tags all operations
+// with the given caller in the flight recorder. Use for components that open
+// their own sql.DB (db stats, watcher handlers, etc).
+func RegisterNamed(name, caller string, storePtr, readConnPtr unsafe.Pointer, muWrite, muRead *sync.Mutex) {
+	sql.Register(name, &RustDriver{
+		store:    (*C.SqliteStore)(storePtr),
+		readConn: (*C.ReadConn)(readConnPtr),
+		muWrite:  muWrite,
+		muRead:   muRead,
+		caller:   caller,
+	})
+}
+
+// SetCaller sets the flight recorder caller tag for the current OS thread.
+// Call this before issuing queries to attribute them to their source component.
+// The tag persists on the thread until changed.
+func SetCaller(caller string) {
+	setCaller(caller)
+}
+
+func setCaller(caller string) {
+	cCaller := C.CString(caller)
+	defer C.free(unsafe.Pointer(cCaller))
+	C.flight_recorder_set_caller(cCaller)
+}
+
 // RustDriver implements driver.Driver.
 type RustDriver struct {
 	store    *C.SqliteStore
 	readConn *C.ReadConn
 	muWrite  *sync.Mutex
 	muRead   *sync.Mutex
+	caller   string // flight recorder caller tag (empty = unattributed)
 }
 
 func (d *RustDriver) Open(_ string) (driver.Conn, error) {
-	return &RustConn{store: d.store, readConn: d.readConn, muWrite: d.muWrite, muRead: d.muRead}, nil
+	return &RustConn{store: d.store, readConn: d.readConn, muWrite: d.muWrite, muRead: d.muRead, caller: d.caller}, nil
 }
 
 // RustConn implements driver.Conn.
@@ -63,13 +90,20 @@ type RustConn struct {
 	readConn *C.ReadConn
 	muWrite  *sync.Mutex
 	muRead   *sync.Mutex
+	inTx     bool   // true while Begin() holds muWrite — Exec/Query skip write lock
+	caller   string // flight recorder caller tag
 }
 
 func (c *RustConn) Prepare(query string) (driver.Stmt, error) {
-	return &RustStmt{store: c.store, readConn: c.readConn, muWrite: c.muWrite, muRead: c.muRead, query: query}, nil
+	return &RustStmt{store: c.store, readConn: c.readConn, muWrite: c.muWrite, muRead: c.muRead, conn: c, query: query, caller: c.caller}, nil
 }
 
 func (c *RustConn) Begin() (driver.Tx, error) {
+	// Hold muWrite for the entire transaction lifetime — released by Commit/Rollback.
+	// All connections share one rusqlite::Connection, so only one transaction
+	// can be active at a time. Without holding across the lifetime, a second
+	// goroutine's Begin() would succeed between Lock/Unlock but hit
+	// "cannot start a transaction within a transaction" on the shared connection.
 	c.muWrite.Lock()
 	result := C.sql_begin(c.store)
 	success := bool(result.success)
@@ -78,12 +112,14 @@ func (c *RustConn) Begin() (driver.Tx, error) {
 		errMsg = C.GoString(result.error_msg)
 	}
 	C.exec_result_free(result)
-	c.muWrite.Unlock()
 
 	if !success {
+		c.muWrite.Unlock()
 		return nil, errors.Newf("BEGIN IMMEDIATE failed: %s", errMsg)
 	}
-	return &RustTx{store: c.store, muWrite: c.muWrite}, nil
+	// muWrite stays locked — Commit/Rollback will unlock it.
+	c.inTx = true
+	return &RustTx{store: c.store, muWrite: c.muWrite, conn: c}, nil
 }
 
 func (c *RustConn) Close() error {
@@ -95,10 +131,13 @@ func (c *RustConn) Close() error {
 type RustTx struct {
 	store   *C.SqliteStore
 	muWrite *sync.Mutex
+	conn    *RustConn
 }
 
 func (tx *RustTx) Commit() error {
-	tx.muWrite.Lock()
+	// muWrite is held since Begin() — release it after COMMIT.
+	defer tx.muWrite.Unlock()
+	tx.conn.inTx = false
 	result := C.sql_commit(tx.store)
 	success := bool(result.success)
 	var errMsg string
@@ -106,7 +145,6 @@ func (tx *RustTx) Commit() error {
 		errMsg = C.GoString(result.error_msg)
 	}
 	C.exec_result_free(result)
-	tx.muWrite.Unlock()
 
 	if !success {
 		return errors.Newf("COMMIT failed: %s", errMsg)
@@ -115,7 +153,9 @@ func (tx *RustTx) Commit() error {
 }
 
 func (tx *RustTx) Rollback() error {
-	tx.muWrite.Lock()
+	// muWrite is held since Begin() — release it after ROLLBACK.
+	defer tx.muWrite.Unlock()
+	tx.conn.inTx = false
 	result := C.sql_rollback(tx.store)
 	success := bool(result.success)
 	var errMsg string
@@ -123,7 +163,6 @@ func (tx *RustTx) Rollback() error {
 		errMsg = C.GoString(result.error_msg)
 	}
 	C.exec_result_free(result)
-	tx.muWrite.Unlock()
 
 	if !success {
 		return errors.Newf("ROLLBACK failed: %s", errMsg)
@@ -137,7 +176,9 @@ type RustStmt struct {
 	readConn *C.ReadConn
 	muWrite  *sync.Mutex
 	muRead   *sync.Mutex
+	conn     *RustConn // back-pointer to check inTx
 	query    string
+	caller   string // flight recorder caller tag
 }
 
 // NumInput returns -1 to indicate variable number of args.
@@ -160,7 +201,14 @@ func (s *RustStmt) Exec(args []driver.Value) (driver.Result, error) {
 	cParams := C.CString(paramsJSON)
 	defer C.free(unsafe.Pointer(cParams))
 
-	s.muWrite.Lock()
+	// If inside a transaction, muWrite is already held by Begin() — don't re-lock.
+	if !s.conn.inTx {
+		s.muWrite.Lock()
+		defer s.muWrite.Unlock()
+	}
+	if s.caller != "" {
+		setCaller(s.caller)
+	}
 	result := C.sql_exec(s.store, cSQL, cParams)
 	success := bool(result.success)
 	var errMsg string
@@ -172,7 +220,6 @@ func (s *RustStmt) Exec(args []driver.Value) (driver.Result, error) {
 		errMsg = C.GoString(result.error_msg)
 	}
 	C.exec_result_free(result)
-	s.muWrite.Unlock()
 
 	if !success {
 		return nil, errors.Newf("exec failed: %s", errMsg)
@@ -191,10 +238,17 @@ func (s *RustStmt) Query(args []driver.Value) (driver.Rows, error) {
 	cParams := C.CString(paramsJSON)
 	defer C.free(unsafe.Pointer(cParams))
 
+	// Lock appropriately: readConn uses muRead, write conn uses muWrite.
+	// Inside a transaction, muWrite is already held — skip locking.
 	if s.readConn != nil {
 		s.muRead.Lock()
-	} else {
+		defer s.muRead.Unlock()
+	} else if !s.conn.inTx {
 		s.muWrite.Lock()
+		defer s.muWrite.Unlock()
+	}
+	if s.caller != "" {
+		setCaller(s.caller)
 	}
 	var result C.QueryResultC
 	if s.readConn != nil {
@@ -216,11 +270,6 @@ func (s *RustStmt) Query(args []driver.Value) (driver.Rows, error) {
 		}
 	}
 	C.query_result_free(result)
-	if s.readConn != nil {
-		s.muRead.Unlock()
-	} else {
-		s.muWrite.Unlock()
-	}
 
 	if !success {
 		return nil, errors.Newf("query failed: %s", errMsg)

--- a/docs/adr/ADR-020-attestation-distillation.md
+++ b/docs/adr/ADR-020-attestation-distillation.md
@@ -1,7 +1,7 @@
 # ADR-020: Attestation Distillation (Sigma)
 
 Date: 2026-05-12
-Updated: 2026-05-14
+Updated: 2026-05-15
 Status: Accepted
 
 ## Context

--- a/docs/adr/ADR-020-attestation-distillation.md
+++ b/docs/adr/ADR-020-attestation-distillation.md
@@ -1,6 +1,7 @@
 # ADR-020: Attestation Distillation (Sigma)
 
 Date: 2026-05-12
+Updated: 2026-05-14
 Status: Accepted
 
 ## Context
@@ -21,7 +22,11 @@ Fires when bounded limits are exceeded. The eviction batch is loaded, distilled 
 
 ### 2. Age-triggered (Go, `server/distill_pulse.go`)
 
-A Pulse handler that runs on a configurable interval. Queries attestations older than `max_age_hours`, groups by predicate, creates one sigma per predicate group, deletes originals. Handles meta-distillation: old sigmas are re-distilled alongside regular attestations.
+A Pulse handler that runs on a configurable interval. Queries attestations older than `max_age_hours` **plus all existing sigmas regardless of age**. Sigmas are exempt from the age rule — they are always eligible for re-distillation. This means every cycle absorbs the existing sigma for a predicate alongside any newly-aged raw attestations, producing a single growing sigma per predicate.
+
+Groups by predicate, creates one sigma per predicate group, deletes originals.
+
+**Minimum group size:** Groups with fewer than 2 attestations are skipped. A sigma that absorbs a single attestation is a 1:1 copy — it adds no compression, wastes a write, and deletes the original (net negative). Singles remain until more attestations with the same predicate age in.
 
 Also performs ghost row cleanup (NULL/empty IDs, zero timestamps) at the start of each cycle.
 
@@ -51,10 +56,11 @@ attributes: {
   _subjects_sample: ["sub_1", "sub_2", ...],         // up to 10
   _first_seen: "2026-05-04T...",
   _last_seen:  "2026-05-12T...",
+  _histogram: {"2026-05-04T12:10": 3, ...},          // temporal distribution
   _version: "v0.8.0 (fd7326d)",                   // Go binary version
   _rust_version: "0.2.3",                          // Cargo workspace version
   some_number: {min: 0, max: 4500, sum: 14640, count: 8},
-  some_string: {values: ["a", "b"], count: 2},
+  some_string: {frequencies: {"a": 5, "b": 3}, count: 8},
   some_constant: "abc123"                          // constant across all -- kept as scalar
 }
 ```
@@ -63,8 +69,13 @@ attributes: {
 
 - **Number** -> `{min, max, sum, count}` — avg derived as sum/count
 - **String** -> `{frequencies: {val: count, ...}, count}` — frequency-tracked distribution, capped at 50 unique values. Legacy `{values: [...], count}` format (pre-frequency sigmas) passes values through as `unplaced` without fabricating counts. If constant across all attestations, kept as scalar.
-- **Already-aggregated** (from prior sigma, detected by `{min, max, sum}` keys) -> merge: min the mins, max the maxes, sum the sums, add counts; union frequency maps
 - **Sigma metadata keys** (`_distill`, `_count`, `_total`, `_first_seen`, `_last_seen`, `_version`, `_rust_version`, `_subjects_count`, `_subjects_sample`, `_actors_count`, `_actors_sample`, `_histogram`) are skipped during merging and rebuilt from the batch
+
+### Re-distillation attribute stripping
+
+When re-distilling sigmas, nested aggregate maps (numeric `{min,max,sum,count}` and string `{frequencies,count}`) from prior sigmas are **stripped before merging**. Without this, frequency maps and numeric aggregates compound across re-distillation cycles, growing unboundedly until they exceed the 1MB attestation JSON limit.
+
+The first distill (raw -> sigma) preserves full attribute aggregates. Subsequent re-distillation preserves only scalar attributes and distill metadata. The temporal story (`_total`, `_histogram`, `_first_seen`, `_last_seen`) is the primary value of a sigma — attribute aggregates are secondary.
 
 ## Observation Counting: `_count` vs `_total`
 
@@ -74,7 +85,9 @@ attributes: {
 
 ## Meta-Distillation
 
-Sigmas are normal attestations. When they age past `max_age_hours`, the Pulse handler re-distills them alongside any regular attestations in the same predicate group.
+Sigmas are always eligible for re-distillation — they are not gated by `max_age_hours`. Every distill cycle picks up all existing sigmas and merges them with any raw attestations that have aged past the threshold. This produces a single growing sigma per predicate that absorbs more observations each cycle.
+
+The number of sigmas is bounded by the number of unique predicates — a small fixed set. Rewriting ~20-30 sigmas every cycle is negligible cost.
 
 ### Float64 Interop
 
@@ -94,9 +107,9 @@ Go and Rust versions are independent. Rust version lives in `Cargo.toml` workspa
 
 ```toml
 [distill]
-interval_seconds = 120    # omit to disable
-max_age_hours = 350
-batch_size = 500           # default
+interval_seconds = 360    # omit to disable
+max_age_hours = 54
+batch_size = 5000          # default 500
 dry_run = false            # default
 ```
 
@@ -123,11 +136,12 @@ The `_histogram` attribute preserves temporal distribution as bucketed observati
 
 Distillation preserves aggregate statistical properties but destroys:
 
-- **Temporal distribution** — reduced to `_first_seen`/`_last_seen` (mitigated by `_histogram` when implemented)
+- **Temporal distribution** — reduced to `_first_seen`/`_last_seen`, mitigated by `_histogram`
 - **Per-event correlation** — numeric ranges are global, not per-context or per-actor
 - **Ordering** — event sequence within the time window is lost
 - **String value long tail** — capped at 50 unique values, then just a count
 - **Batch boundaries** — meta-distilled sigmas don't record which intermediate contributed what proportion
+- **Attribute aggregates across re-distillation** — stripped to prevent unbounded growth; only first-generation sigmas carry full attribute statistics
 
 ## Consequences
 
@@ -136,3 +150,4 @@ Distillation preserves aggregate statistical properties but destroys:
 - Sigmas carry `source = "distill"` and `_distill: true` in attributes for identification
 - `_version` and `_rust_version` provide deployment traceability across sigma generations
 - High-volume predicates with attribute-level semantic differences (e.g. `crawl-stage-changed` with 7 stages) lose granularity — the fix is upstream: emit distinct predicates per semantic category
+- Sigma count is bounded by unique predicates, not by attestation volume

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,9 +16,9 @@ Complete API documentation for the QNTX server.
 - **[Pulse Executions](./pulse-executions.md)** (1 endpoint)
 - **[Plugins](./plugins.md)** (6 endpoints)
 - **[Prose (Documents)](./prose-documents.md)** (2 endpoints)
-- **[Other](./other.md)** (30 endpoints)
+- **[Other](./other.md)** (31 endpoints)
 
-**Total: 55 HTTP endpoints**
+**Total: 56 HTTP endpoints**
 
 ## WebSocket Protocol
 
@@ -26,7 +26,7 @@ Complete API documentation for the QNTX server.
 
 ## gRPC APIs
 
-- **[ATSStoreService gRPC API](./grpc-atsstore.md)** (5 methods)
+- **[ATSStoreService gRPC API](./grpc-atsstore.md)** (6 methods)
 - **[Plugin gRPC API](./grpc-plugin.md)** (10 methods)
 - **[EmbeddingService gRPC API](./grpc-embedding.md)** (7 methods)
 - **[FileService gRPC API](./grpc-fileservice.md)** (1 method)

--- a/docs/api/grpc-atsstore.md
+++ b/docs/api/grpc-atsstore.md
@@ -14,6 +14,7 @@ ATSStoreService provides attestation storage operations for gRPC plugins
 | CreateAttestation | CreateAttestationRequest | CreateAttestationResponse | No |
 | AttestationExists | AttestationExistsRequest | AttestationExistsResponse | No |
 | GenerateAndCreateAttestation | GenerateAttestationRequest | GenerateAttestationResponse | No |
+| BatchGenerateAndCreateAttestations | BatchGenerateAttestationRequest | BatchGenerateAttestationResponse | No |
 | GetAttestations | GetAttestationsRequest | GetAttestationsResponse | No |
 | GetAttestationsStream | GetAttestationsRequest | Attestation | Server |
 
@@ -41,6 +42,15 @@ GenerateAndCreateAttestation generates an attestation ID and creates it
 
 - **Request**: `GenerateAttestationRequest`
 - **Response**: `GenerateAttestationResponse`
+
+---
+
+### BatchGenerateAndCreateAttestations
+
+BatchGenerateAndCreateAttestations generates IDs and creates multiple attestations in one write transaction
+
+- **Request**: `BatchGenerateAttestationRequest`
+- **Response**: `BatchGenerateAttestationResponse`
 
 ---
 
@@ -149,6 +159,21 @@ AttestationFilter for querying attestations
 | success | bool | - |
 | error | string | - |
 | attestation | Attestation | - |
+
+### BatchGenerateAttestationRequest
+
+| Field | Type | Description |
+|-------|------|-------------|
+| auth_token | string | - |
+| commands | AttestationCommand | - |
+
+### BatchGenerateAttestationResponse
+
+| Field | Type | Description |
+|-------|------|-------------|
+| success | bool | - |
+| error | string | - |
+| created | int32 | - |
 
 ### GetAttestationsRequest
 

--- a/docs/api/other.md
+++ b/docs/api/other.md
@@ -13,6 +13,7 @@
 | GET | `/api/canvas/glyphs/` | canvasHandler.HandleGlyphs |
 | GET | `/api/canvas/minimized-windows` | canvasHandler.HandleMinimizedWindows |
 | GET | `/api/canvas/minimized-windows/` | canvasHandler.HandleMinimizedWindows |
+| GET | `/api/crash-test` | HandleCrashTest |
 | GET | `/api/embeddings/batch` | embeddingsHandler.HandleEmbeddingBatch |
 | GET | `/api/embeddings/by-source` | embeddingsHandler.HandleEmbeddingsBySource |
 | GET | `/api/embeddings/cluster` | embeddingsHandler.HandleCluster |
@@ -83,6 +84,15 @@
 ### `GET` /api/canvas/minimized-windows/
 
 **Handler**: `canvasHandler.HandleMinimizedWindows`
+
+---
+
+### `GET` /api/crash-test
+
+HandleCrashTest triggers a deliberate crash to verify the flight recorder.
+Dev mode only.
+
+**Handler**: `HandleCrashTest`
 
 ---
 

--- a/docs/development/grace.md
+++ b/docs/development/grace.md
@@ -63,7 +63,7 @@ This pattern solves parent-child job coordination without blocking worker thread
 
 ### Smart Phase Recovery (Implemented)
 
-**Location**: `pulse/async/worker.go:requeueOrphanedJob()`
+**Location**: `pulse/async/worker.go:failOrphanedJob()`
 
 When recovering orphaned jobs, GRACE validates phase consistency:
 

--- a/docs/types/server.md
+++ b/docs/types/server.md
@@ -772,7 +772,7 @@ type WatcherBroadcastStats struct {
 
 ## WatcherCreateRequest {#watchercreaterequest}
 
-**Source**: [`server/watcher_handlers.go:24`](https://github.com/teranos/QNTX/blob/main/server/watcher_handlers.go#L24)
+**Source**: [`server/watcher_handlers.go:25`](https://github.com/teranos/QNTX/blob/main/server/watcher_handlers.go#L25)
 
 
 ```go
@@ -845,7 +845,7 @@ type WatcherQueueStatusMessage struct {
 
 ## WatcherResponse {#watcherresponse}
 
-**Source**: [`server/watcher_handlers.go:43`](https://github.com/teranos/QNTX/blob/main/server/watcher_handlers.go#L43)
+**Source**: [`server/watcher_handlers.go:44`](https://github.com/teranos/QNTX/blob/main/server/watcher_handlers.go#L44)
 
 
 ```go

--- a/internal/testing/database.go
+++ b/internal/testing/database.go
@@ -210,5 +210,51 @@ func (s *sqlTestStore) insertAttestation(as *types.As) error {
 		string(attrsJSON),
 		createdAt,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	// Populate junction tables (mirrors what Rust does in production)
+	insertJunction(s.db, as.ID, as.Subjects, as.Predicates, as.Contexts, as.Actors)
+	return nil
+}
+
+// insertJunction populates the four junction tables for an attestation.
+func insertJunction(db *sql.DB, id string, subjects, predicates, contexts, actors []string) {
+	for _, s := range subjects {
+		db.Exec("INSERT INTO attestation_subjects (attestation_id, subject) VALUES (?, ?)", id, s)
+	}
+	for _, p := range predicates {
+		db.Exec("INSERT INTO attestation_predicates (attestation_id, predicate) VALUES (?, ?)", id, p)
+	}
+	for _, c := range contexts {
+		db.Exec("INSERT INTO attestation_contexts (attestation_id, context) VALUES (?, ?)", id, c)
+	}
+	for _, a := range actors {
+		db.Exec("INSERT INTO attestation_actors (attestation_id, actor) VALUES (?, ?)", id, a)
+	}
+}
+
+// SyncJunctionTables populates junction tables from the JSON columns in attestations.
+// Use after raw SQL INSERT into attestations in tests.
+func SyncJunctionTables(db *sql.DB) error {
+	statements := []string{
+		`INSERT OR IGNORE INTO attestation_subjects (attestation_id, subject)
+		 SELECT a.id, j.value FROM attestations a, json_each(a.subjects) j
+		 WHERE a.id NOT IN (SELECT DISTINCT attestation_id FROM attestation_subjects)`,
+		`INSERT OR IGNORE INTO attestation_predicates (attestation_id, predicate)
+		 SELECT a.id, j.value FROM attestations a, json_each(a.predicates) j
+		 WHERE a.id NOT IN (SELECT DISTINCT attestation_id FROM attestation_predicates)`,
+		`INSERT OR IGNORE INTO attestation_contexts (attestation_id, context)
+		 SELECT a.id, j.value FROM attestations a, json_each(a.contexts) j
+		 WHERE a.id NOT IN (SELECT DISTINCT attestation_id FROM attestation_contexts)`,
+		`INSERT OR IGNORE INTO attestation_actors (attestation_id, actor)
+		 SELECT a.id, j.value FROM attestations a, json_each(a.actors) j
+		 WHERE a.id NOT IN (SELECT DISTINCT attestation_id FROM attestation_actors)`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/plugin/grpc/atsstore_server.go
+++ b/plugin/grpc/atsstore_server.go
@@ -142,6 +142,73 @@ func (s *ATSStoreServer) GenerateAndCreateAttestation(ctx context.Context, req *
 	}, nil
 }
 
+// BatchGenerateAndCreateAttestations generates IDs and creates multiple attestations in one write transaction
+func (s *ATSStoreServer) BatchGenerateAndCreateAttestations(ctx context.Context, req *protocol.BatchGenerateAttestationRequest) (*protocol.BatchGenerateAttestationResponse, error) {
+	if err := ValidateToken(req.AuthToken, s.authToken); err != nil {
+		return &protocol.BatchGenerateAttestationResponse{
+			Success: false,
+			Error:   err.Error(),
+		}, nil
+	}
+
+	if len(req.Commands) == 0 {
+		return &protocol.BatchGenerateAttestationResponse{
+			Success: true,
+			Created: 0,
+		}, nil
+	}
+
+	cmds := make([]*types.AsCommand, 0, len(req.Commands))
+	for i, proto := range req.Commands {
+		cmd, err := protoToCommand(proto)
+		if err != nil {
+			return &protocol.BatchGenerateAttestationResponse{
+				Success: false,
+				Error:   fmt.Sprintf("failed to convert command %d: %v", i, err),
+			}, nil
+		}
+		cmds = append(cmds, cmd)
+	}
+
+	// RustBackedStore implements this; other stores fall back to individual writes
+	type batchCreator interface {
+		BatchGenerateAndCreateAttestations(ctx context.Context, cmds []*types.AsCommand) (int, error)
+	}
+	if bs, ok := s.store.(batchCreator); ok {
+		created, err := bs.BatchGenerateAndCreateAttestations(ctx, cmds)
+		if err != nil {
+			s.logger.Errorw("BatchGenerateAndCreateAttestations failed", "count", len(cmds), "created", created, "error", err)
+			return &protocol.BatchGenerateAttestationResponse{
+				Success: false,
+				Error:   fmt.Sprintf("batch write failed after %d/%d: %v", created, len(cmds), err),
+				Created: int32(created),
+			}, nil
+		}
+		return &protocol.BatchGenerateAttestationResponse{
+			Success: true,
+			Created: int32(created),
+		}, nil
+	}
+
+	// Fallback: individual writes
+	var created int32
+	for _, cmd := range cmds {
+		if _, err := s.store.GenerateAndCreateAttestation(ctx, cmd); err != nil {
+			s.logger.Errorw("BatchGenerateAndCreateAttestations fallback failed", "created", created, "total", len(cmds), "error", err)
+			return &protocol.BatchGenerateAttestationResponse{
+				Success: false,
+				Error:   fmt.Sprintf("individual write failed at %d/%d: %v", created, len(cmds), err),
+				Created: created,
+			}, nil
+		}
+		created++
+	}
+	return &protocol.BatchGenerateAttestationResponse{
+		Success: true,
+		Created: created,
+	}, nil
+}
+
 // GetAttestations queries attestations with filters
 func (s *ATSStoreServer) GetAttestations(ctx context.Context, req *protocol.GetAttestationsRequest) (*protocol.GetAttestationsResponse, error) {
 	if err := ValidateToken(req.AuthToken, s.authToken); err != nil {

--- a/plugin/grpc/client.go
+++ b/plugin/grpc/client.go
@@ -681,7 +681,7 @@ func (h *wsProxyHandler) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.logger.Info("WebSocket connection established, bridging to gRPC stream")
+	h.logger.Debug("WebSocket connection established, bridging to gRPC stream")
 
 	// Send CONNECT message to plugin
 	if err := stream.Send(&protocol.WebSocketMessage{
@@ -837,7 +837,7 @@ func (h *wsProxyHandler) ServeWS(w http.ResponseWriter, r *http.Request) {
 
 	// Log connection metrics
 	metrics := h.keepalive.Metrics()
-	h.logger.Infow("WebSocket connection closed",
+	h.logger.Debugw("WebSocket connection closed",
 		"uptime", metrics.GetConnectionUptime(),
 		"pings_sent", metrics.GetTotalPings(),
 		"pongs_received", metrics.GetTotalPongs(),

--- a/plugin/grpc/ocaml/proto/atsstore.ml
+++ b/plugin/grpc/ocaml/proto/atsstore.ml
@@ -427,6 +427,77 @@ module rec Protocol : sig
     (**/**)
   end
 
+  and BatchGenerateAttestationRequest : sig
+    type t = {
+      auth_token:string;
+      commands:AttestationCommand.t list;
+    }
+    val make: ?auth_token:string -> ?commands:AttestationCommand.t list -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?auth_token:string -> ?commands:AttestationCommand.t list -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end
+
+  and BatchGenerateAttestationResponse : sig
+    type t = {
+      success:bool;
+      error:string;
+      created:int;
+      (**
+{%html:
+<p>Number of attestations successfully created</p>
+%}
+      *)
+
+    }
+    val make: ?success:bool -> ?error:string -> ?created:int -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?success:bool -> ?error:string -> ?created:int -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end
+
   and GetAttestationsRequest : sig
     type t = {
       auth_token:string;
@@ -526,6 +597,17 @@ module rec Protocol : sig
     end
 
     val generateAndCreateAttestation : (module Runtime'.Spec.Message with type t = GenerateAttestationRequest.t) * (module Runtime'.Spec.Message with type t = GenerateAttestationResponse.t)
+    module BatchGenerateAndCreateAttestations : sig
+      include Runtime'.Service.Rpc with type Request.t = BatchGenerateAttestationRequest.t and type Response.t = BatchGenerateAttestationResponse.t
+      module Request : Runtime'.Spec.Message with type t = BatchGenerateAttestationRequest.t and type make_t = BatchGenerateAttestationRequest.make_t
+      (** Module alias for the request message for this method call *)
+
+      module Response : Runtime'.Spec.Message with type t = BatchGenerateAttestationResponse.t and type make_t = BatchGenerateAttestationResponse.make_t
+      (** Module alias for the response message for this method call *)
+
+    end
+
+    val batchGenerateAndCreateAttestations : (module Runtime'.Spec.Message with type t = BatchGenerateAttestationRequest.t) * (module Runtime'.Spec.Message with type t = BatchGenerateAttestationResponse.t)
     module GetAttestations : sig
       include Runtime'.Service.Rpc with type Request.t = GetAttestationsRequest.t and type Response.t = GetAttestationsResponse.t
       module Request : Runtime'.Spec.Message with type t = GetAttestationsRequest.t and type make_t = GetAttestationsRequest.make_t
@@ -1288,6 +1370,146 @@ end = struct
     let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
   end
 
+  and BatchGenerateAttestationRequest : sig
+    type t = {
+      auth_token:string;
+      commands:AttestationCommand.t list;
+    }
+    val make: ?auth_token:string -> ?commands:AttestationCommand.t list -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?auth_token:string -> ?commands:AttestationCommand.t list -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end = struct
+    module This'_ = BatchGenerateAttestationRequest
+    let name () = ".protocol.BatchGenerateAttestationRequest"
+    type t = {
+      auth_token:string;
+      commands:AttestationCommand.t list;
+    }
+    type make_t = ?auth_token:string -> ?commands:AttestationCommand.t list -> unit -> t
+    let make ?(auth_token = {||}) ?(commands = []) () = { auth_token; commands }
+    let merge =
+    let merge_auth_token = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "auth_token", "authToken"), string, ({||})) ) in
+    let merge_commands = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "commands", "commands"), (message (module AttestationCommand)), not_packed) ) in
+    fun t1 t2 -> {
+    	auth_token = (merge_auth_token t1.auth_token t2.auth_token);
+    	commands = (merge_commands t1.commands t2.commands);
+     }
+    let spec () = Runtime'.Spec.( basic ((1, "auth_token", "authToken"), string, ({||})) ^:: repeated ((2, "commands", "commands"), (message (module AttestationCommand)), not_packed) ^:: nil )
+    let to_proto' =
+      let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
+      fun writer { auth_token; commands } -> serialize writer auth_token commands
+
+    let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
+    let from_proto_exn =
+      let constructor auth_token commands = { auth_token; commands } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
+    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
+    let to_json options =
+      let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
+      fun { auth_token; commands } -> serialize auth_token commands
+    let from_json_exn =
+      let constructor auth_token commands = { auth_token; commands } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
+    let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
+  end
+
+  and BatchGenerateAttestationResponse : sig
+    type t = {
+      success:bool;
+      error:string;
+      created:int;
+      (**
+{%html:
+<p>Number of attestations successfully created</p>
+%}
+      *)
+
+    }
+    val make: ?success:bool -> ?error:string -> ?created:int -> unit -> t
+    (** Helper function to generate a message using default values *)
+
+    val to_proto: t -> Runtime'.Writer.t
+    (** Serialize the message to binary format *)
+
+    val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from binary format *)
+
+    val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+    (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+    val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+    (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+    val name: unit -> string
+    (** Fully qualified protobuf name of this message *)
+
+    (**/**)
+    type make_t = ?success:bool -> ?error:string -> ?created:int -> unit -> t
+    val merge: t -> t -> t
+    val to_proto': Runtime'.Writer.t -> t -> unit
+    val from_proto_exn: Runtime'.Reader.t -> t
+    val from_json_exn: Runtime'.Json.t -> t
+    (**/**)
+  end = struct
+    module This'_ = BatchGenerateAttestationResponse
+    let name () = ".protocol.BatchGenerateAttestationResponse"
+    type t = {
+      success:bool;
+      error:string;
+      created:int;
+    }
+    type make_t = ?success:bool -> ?error:string -> ?created:int -> unit -> t
+    let make ?(success = false) ?(error = {||}) ?(created = 0) () = { success; error; created }
+    let merge =
+    let merge_success = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "success", "success"), bool, (false)) ) in
+    let merge_error = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "error", "error"), string, ({||})) ) in
+    let merge_created = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "created", "created"), int32_int, (0)) ) in
+    fun t1 t2 -> {
+    	success = (merge_success t1.success t2.success);
+    	error = (merge_error t1.error t2.error);
+    	created = (merge_created t1.created t2.created);
+     }
+    let spec () = Runtime'.Spec.( basic ((1, "success", "success"), bool, (false)) ^:: basic ((2, "error", "error"), string, ({||})) ^:: basic ((3, "created", "created"), int32_int, (0)) ^:: nil )
+    let to_proto' =
+      let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
+      fun writer { success; error; created } -> serialize writer success error created
+
+    let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
+    let from_proto_exn =
+      let constructor success error created = { success; error; created } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
+    let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
+    let to_json options =
+      let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
+      fun { success; error; created } -> serialize success error created
+    let from_json_exn =
+      let constructor success error created = { success; error; created } in
+      Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
+    let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
+  end
+
   and GetAttestationsRequest : sig
     type t = {
       auth_token:string;
@@ -1461,6 +1683,19 @@ end = struct
     let generateAndCreateAttestation =
       (module GenerateAttestationRequest : Runtime'.Spec.Message with type t = GenerateAttestationRequest.t ),
       (module GenerateAttestationResponse : Runtime'.Spec.Message with type t = GenerateAttestationResponse.t )
+
+    module BatchGenerateAndCreateAttestations = struct
+      let package_name = Some "protocol"
+      let service_name = "ATSStoreService"
+      let method_name = "BatchGenerateAndCreateAttestations"
+      let name = "/protocol.ATSStoreService/BatchGenerateAndCreateAttestations"
+      module Request = BatchGenerateAttestationRequest
+      module Response = BatchGenerateAttestationResponse
+    end
+
+    let batchGenerateAndCreateAttestations =
+      (module BatchGenerateAttestationRequest : Runtime'.Spec.Message with type t = BatchGenerateAttestationRequest.t ),
+      (module BatchGenerateAttestationResponse : Runtime'.Spec.Message with type t = BatchGenerateAttestationResponse.t )
 
     module GetAttestations = struct
       let package_name = Some "protocol"

--- a/plugin/grpc/protocol/atsstore.pb.go
+++ b/plugin/grpc/protocol/atsstore.pb.go
@@ -653,6 +653,118 @@ func (x *GenerateAttestationResponse) GetAttestation() *Attestation {
 	return nil
 }
 
+type BatchGenerateAttestationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AuthToken     string                 `protobuf:"bytes,1,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
+	Commands      []*AttestationCommand  `protobuf:"bytes,2,rep,name=commands,proto3" json:"commands,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGenerateAttestationRequest) Reset() {
+	*x = BatchGenerateAttestationRequest{}
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGenerateAttestationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGenerateAttestationRequest) ProtoMessage() {}
+
+func (x *BatchGenerateAttestationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGenerateAttestationRequest.ProtoReflect.Descriptor instead.
+func (*BatchGenerateAttestationRequest) Descriptor() ([]byte, []int) {
+	return file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *BatchGenerateAttestationRequest) GetAuthToken() string {
+	if x != nil {
+		return x.AuthToken
+	}
+	return ""
+}
+
+func (x *BatchGenerateAttestationRequest) GetCommands() []*AttestationCommand {
+	if x != nil {
+		return x.Commands
+	}
+	return nil
+}
+
+type BatchGenerateAttestationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	Created       int32                  `protobuf:"varint,3,opt,name=created,proto3" json:"created,omitempty"` // Number of attestations successfully created
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGenerateAttestationResponse) Reset() {
+	*x = BatchGenerateAttestationResponse{}
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGenerateAttestationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGenerateAttestationResponse) ProtoMessage() {}
+
+func (x *BatchGenerateAttestationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGenerateAttestationResponse.ProtoReflect.Descriptor instead.
+func (*BatchGenerateAttestationResponse) Descriptor() ([]byte, []int) {
+	return file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *BatchGenerateAttestationResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *BatchGenerateAttestationResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *BatchGenerateAttestationResponse) GetCreated() int32 {
+	if x != nil {
+		return x.Created
+	}
+	return 0
+}
+
 type GetAttestationsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AuthToken     string                 `protobuf:"bytes,1,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
@@ -663,7 +775,7 @@ type GetAttestationsRequest struct {
 
 func (x *GetAttestationsRequest) Reset() {
 	*x = GetAttestationsRequest{}
-	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[9]
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +787,7 @@ func (x *GetAttestationsRequest) String() string {
 func (*GetAttestationsRequest) ProtoMessage() {}
 
 func (x *GetAttestationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[9]
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +800,7 @@ func (x *GetAttestationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAttestationsRequest.ProtoReflect.Descriptor instead.
 func (*GetAttestationsRequest) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP(), []int{9}
+	return file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetAttestationsRequest) GetAuthToken() string {
@@ -716,7 +828,7 @@ type GetAttestationsResponse struct {
 
 func (x *GetAttestationsResponse) Reset() {
 	*x = GetAttestationsResponse{}
-	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[10]
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -728,7 +840,7 @@ func (x *GetAttestationsResponse) String() string {
 func (*GetAttestationsResponse) ProtoMessage() {}
 
 func (x *GetAttestationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[10]
+	mi := &file_plugin_grpc_protocol_atsstore_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -741,7 +853,7 @@ func (x *GetAttestationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAttestationsResponse.ProtoReflect.Descriptor instead.
 func (*GetAttestationsResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP(), []int{10}
+	return file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GetAttestationsResponse) GetSuccess() bool {
@@ -838,7 +950,15 @@ const file_plugin_grpc_protocol_atsstore_proto_rawDesc = "" +
 	"\x1bGenerateAttestationResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x127\n" +
-	"\vattestation\x18\x03 \x01(\v2\x15.protocol.AttestationR\vattestation\"l\n" +
+	"\vattestation\x18\x03 \x01(\v2\x15.protocol.AttestationR\vattestation\"z\n" +
+	"\x1fBatchGenerateAttestationRequest\x12\x1d\n" +
+	"\n" +
+	"auth_token\x18\x01 \x01(\tR\tauthToken\x128\n" +
+	"\bcommands\x18\x02 \x03(\v2\x1c.protocol.AttestationCommandR\bcommands\"l\n" +
+	" BatchGenerateAttestationResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\x12\x18\n" +
+	"\acreated\x18\x03 \x01(\x05R\acreated\"l\n" +
 	"\x16GetAttestationsRequest\x12\x1d\n" +
 	"\n" +
 	"auth_token\x18\x01 \x01(\tR\tauthToken\x123\n" +
@@ -846,11 +966,12 @@ const file_plugin_grpc_protocol_atsstore_proto_rawDesc = "" +
 	"\x17GetAttestationsResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x129\n" +
-	"\fattestations\x18\x03 \x03(\v2\x15.protocol.AttestationR\fattestations2\xe6\x03\n" +
+	"\fattestations\x18\x03 \x03(\v2\x15.protocol.AttestationR\fattestations2\xe3\x04\n" +
 	"\x0fATSStoreService\x12\\\n" +
 	"\x11CreateAttestation\x12\".protocol.CreateAttestationRequest\x1a#.protocol.CreateAttestationResponse\x12\\\n" +
 	"\x11AttestationExists\x12\".protocol.AttestationExistsRequest\x1a#.protocol.AttestationExistsResponse\x12k\n" +
-	"\x1cGenerateAndCreateAttestation\x12$.protocol.GenerateAttestationRequest\x1a%.protocol.GenerateAttestationResponse\x12V\n" +
+	"\x1cGenerateAndCreateAttestation\x12$.protocol.GenerateAttestationRequest\x1a%.protocol.GenerateAttestationResponse\x12{\n" +
+	"\"BatchGenerateAndCreateAttestations\x12).protocol.BatchGenerateAttestationRequest\x1a*.protocol.BatchGenerateAttestationResponse\x12V\n" +
 	"\x0fGetAttestations\x12 .protocol.GetAttestationsRequest\x1a!.protocol.GetAttestationsResponse\x12R\n" +
 	"\x15GetAttestationsStream\x12 .protocol.GetAttestationsRequest\x1a\x15.protocol.Attestation0\x01B.Z,github.com/teranos/QNTX/plugin/grpc/protocolb\x06proto3"
 
@@ -866,44 +987,49 @@ func file_plugin_grpc_protocol_atsstore_proto_rawDescGZIP() []byte {
 	return file_plugin_grpc_protocol_atsstore_proto_rawDescData
 }
 
-var file_plugin_grpc_protocol_atsstore_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_plugin_grpc_protocol_atsstore_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_plugin_grpc_protocol_atsstore_proto_goTypes = []any{
-	(*Attestation)(nil),                 // 0: protocol.Attestation
-	(*AttestationCommand)(nil),          // 1: protocol.AttestationCommand
-	(*AttestationFilter)(nil),           // 2: protocol.AttestationFilter
-	(*CreateAttestationRequest)(nil),    // 3: protocol.CreateAttestationRequest
-	(*CreateAttestationResponse)(nil),   // 4: protocol.CreateAttestationResponse
-	(*AttestationExistsRequest)(nil),    // 5: protocol.AttestationExistsRequest
-	(*AttestationExistsResponse)(nil),   // 6: protocol.AttestationExistsResponse
-	(*GenerateAttestationRequest)(nil),  // 7: protocol.GenerateAttestationRequest
-	(*GenerateAttestationResponse)(nil), // 8: protocol.GenerateAttestationResponse
-	(*GetAttestationsRequest)(nil),      // 9: protocol.GetAttestationsRequest
-	(*GetAttestationsResponse)(nil),     // 10: protocol.GetAttestationsResponse
-	(*structpb.Struct)(nil),             // 11: google.protobuf.Struct
+	(*Attestation)(nil),                      // 0: protocol.Attestation
+	(*AttestationCommand)(nil),               // 1: protocol.AttestationCommand
+	(*AttestationFilter)(nil),                // 2: protocol.AttestationFilter
+	(*CreateAttestationRequest)(nil),         // 3: protocol.CreateAttestationRequest
+	(*CreateAttestationResponse)(nil),        // 4: protocol.CreateAttestationResponse
+	(*AttestationExistsRequest)(nil),         // 5: protocol.AttestationExistsRequest
+	(*AttestationExistsResponse)(nil),        // 6: protocol.AttestationExistsResponse
+	(*GenerateAttestationRequest)(nil),       // 7: protocol.GenerateAttestationRequest
+	(*GenerateAttestationResponse)(nil),      // 8: protocol.GenerateAttestationResponse
+	(*BatchGenerateAttestationRequest)(nil),  // 9: protocol.BatchGenerateAttestationRequest
+	(*BatchGenerateAttestationResponse)(nil), // 10: protocol.BatchGenerateAttestationResponse
+	(*GetAttestationsRequest)(nil),           // 11: protocol.GetAttestationsRequest
+	(*GetAttestationsResponse)(nil),          // 12: protocol.GetAttestationsResponse
+	(*structpb.Struct)(nil),                  // 13: google.protobuf.Struct
 }
 var file_plugin_grpc_protocol_atsstore_proto_depIdxs = []int32{
-	11, // 0: protocol.Attestation.attributes:type_name -> google.protobuf.Struct
-	11, // 1: protocol.AttestationCommand.attributes:type_name -> google.protobuf.Struct
+	13, // 0: protocol.Attestation.attributes:type_name -> google.protobuf.Struct
+	13, // 1: protocol.AttestationCommand.attributes:type_name -> google.protobuf.Struct
 	0,  // 2: protocol.CreateAttestationRequest.attestation:type_name -> protocol.Attestation
 	1,  // 3: protocol.GenerateAttestationRequest.command:type_name -> protocol.AttestationCommand
 	0,  // 4: protocol.GenerateAttestationResponse.attestation:type_name -> protocol.Attestation
-	2,  // 5: protocol.GetAttestationsRequest.filter:type_name -> protocol.AttestationFilter
-	0,  // 6: protocol.GetAttestationsResponse.attestations:type_name -> protocol.Attestation
-	3,  // 7: protocol.ATSStoreService.CreateAttestation:input_type -> protocol.CreateAttestationRequest
-	5,  // 8: protocol.ATSStoreService.AttestationExists:input_type -> protocol.AttestationExistsRequest
-	7,  // 9: protocol.ATSStoreService.GenerateAndCreateAttestation:input_type -> protocol.GenerateAttestationRequest
-	9,  // 10: protocol.ATSStoreService.GetAttestations:input_type -> protocol.GetAttestationsRequest
-	9,  // 11: protocol.ATSStoreService.GetAttestationsStream:input_type -> protocol.GetAttestationsRequest
-	4,  // 12: protocol.ATSStoreService.CreateAttestation:output_type -> protocol.CreateAttestationResponse
-	6,  // 13: protocol.ATSStoreService.AttestationExists:output_type -> protocol.AttestationExistsResponse
-	8,  // 14: protocol.ATSStoreService.GenerateAndCreateAttestation:output_type -> protocol.GenerateAttestationResponse
-	10, // 15: protocol.ATSStoreService.GetAttestations:output_type -> protocol.GetAttestationsResponse
-	0,  // 16: protocol.ATSStoreService.GetAttestationsStream:output_type -> protocol.Attestation
-	12, // [12:17] is the sub-list for method output_type
-	7,  // [7:12] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	1,  // 5: protocol.BatchGenerateAttestationRequest.commands:type_name -> protocol.AttestationCommand
+	2,  // 6: protocol.GetAttestationsRequest.filter:type_name -> protocol.AttestationFilter
+	0,  // 7: protocol.GetAttestationsResponse.attestations:type_name -> protocol.Attestation
+	3,  // 8: protocol.ATSStoreService.CreateAttestation:input_type -> protocol.CreateAttestationRequest
+	5,  // 9: protocol.ATSStoreService.AttestationExists:input_type -> protocol.AttestationExistsRequest
+	7,  // 10: protocol.ATSStoreService.GenerateAndCreateAttestation:input_type -> protocol.GenerateAttestationRequest
+	9,  // 11: protocol.ATSStoreService.BatchGenerateAndCreateAttestations:input_type -> protocol.BatchGenerateAttestationRequest
+	11, // 12: protocol.ATSStoreService.GetAttestations:input_type -> protocol.GetAttestationsRequest
+	11, // 13: protocol.ATSStoreService.GetAttestationsStream:input_type -> protocol.GetAttestationsRequest
+	4,  // 14: protocol.ATSStoreService.CreateAttestation:output_type -> protocol.CreateAttestationResponse
+	6,  // 15: protocol.ATSStoreService.AttestationExists:output_type -> protocol.AttestationExistsResponse
+	8,  // 16: protocol.ATSStoreService.GenerateAndCreateAttestation:output_type -> protocol.GenerateAttestationResponse
+	10, // 17: protocol.ATSStoreService.BatchGenerateAndCreateAttestations:output_type -> protocol.BatchGenerateAttestationResponse
+	12, // 18: protocol.ATSStoreService.GetAttestations:output_type -> protocol.GetAttestationsResponse
+	0,  // 19: protocol.ATSStoreService.GetAttestationsStream:output_type -> protocol.Attestation
+	14, // [14:20] is the sub-list for method output_type
+	8,  // [8:14] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_plugin_grpc_protocol_atsstore_proto_init() }
@@ -919,7 +1045,7 @@ func file_plugin_grpc_protocol_atsstore_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_grpc_protocol_atsstore_proto_rawDesc), len(file_plugin_grpc_protocol_atsstore_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/plugin/grpc/protocol/atsstore.proto
+++ b/plugin/grpc/protocol/atsstore.proto
@@ -17,6 +17,9 @@ service ATSStoreService {
   // GenerateAndCreateAttestation generates an attestation ID and creates it
   rpc GenerateAndCreateAttestation(GenerateAttestationRequest) returns (GenerateAttestationResponse);
 
+  // BatchGenerateAndCreateAttestations generates IDs and creates multiple attestations in one write transaction
+  rpc BatchGenerateAndCreateAttestations(BatchGenerateAttestationRequest) returns (BatchGenerateAttestationResponse);
+
   // GetAttestations queries attestations with filters
   rpc GetAttestations(GetAttestationsRequest) returns (GetAttestationsResponse);
 
@@ -91,6 +94,17 @@ message GenerateAttestationResponse {
   bool success = 1;
   string error = 2;
   Attestation attestation = 3; // The created attestation with generated ID
+}
+
+message BatchGenerateAttestationRequest {
+  string auth_token = 1;
+  repeated AttestationCommand commands = 2;
+}
+
+message BatchGenerateAttestationResponse {
+  bool success = 1;
+  string error = 2;
+  int32 created = 3;  // Number of attestations successfully created
 }
 
 message GetAttestationsRequest {

--- a/plugin/grpc/protocol/atsstore_grpc.pb.go
+++ b/plugin/grpc/protocol/atsstore_grpc.pb.go
@@ -19,11 +19,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ATSStoreService_CreateAttestation_FullMethodName            = "/protocol.ATSStoreService/CreateAttestation"
-	ATSStoreService_AttestationExists_FullMethodName            = "/protocol.ATSStoreService/AttestationExists"
-	ATSStoreService_GenerateAndCreateAttestation_FullMethodName = "/protocol.ATSStoreService/GenerateAndCreateAttestation"
-	ATSStoreService_GetAttestations_FullMethodName              = "/protocol.ATSStoreService/GetAttestations"
-	ATSStoreService_GetAttestationsStream_FullMethodName        = "/protocol.ATSStoreService/GetAttestationsStream"
+	ATSStoreService_CreateAttestation_FullMethodName                  = "/protocol.ATSStoreService/CreateAttestation"
+	ATSStoreService_AttestationExists_FullMethodName                  = "/protocol.ATSStoreService/AttestationExists"
+	ATSStoreService_GenerateAndCreateAttestation_FullMethodName       = "/protocol.ATSStoreService/GenerateAndCreateAttestation"
+	ATSStoreService_BatchGenerateAndCreateAttestations_FullMethodName = "/protocol.ATSStoreService/BatchGenerateAndCreateAttestations"
+	ATSStoreService_GetAttestations_FullMethodName                    = "/protocol.ATSStoreService/GetAttestations"
+	ATSStoreService_GetAttestationsStream_FullMethodName              = "/protocol.ATSStoreService/GetAttestationsStream"
 )
 
 // ATSStoreServiceClient is the client API for ATSStoreService service.
@@ -38,6 +39,8 @@ type ATSStoreServiceClient interface {
 	AttestationExists(ctx context.Context, in *AttestationExistsRequest, opts ...grpc.CallOption) (*AttestationExistsResponse, error)
 	// GenerateAndCreateAttestation generates an attestation ID and creates it
 	GenerateAndCreateAttestation(ctx context.Context, in *GenerateAttestationRequest, opts ...grpc.CallOption) (*GenerateAttestationResponse, error)
+	// BatchGenerateAndCreateAttestations generates IDs and creates multiple attestations in one write transaction
+	BatchGenerateAndCreateAttestations(ctx context.Context, in *BatchGenerateAttestationRequest, opts ...grpc.CallOption) (*BatchGenerateAttestationResponse, error)
 	// GetAttestations queries attestations with filters
 	GetAttestations(ctx context.Context, in *GetAttestationsRequest, opts ...grpc.CallOption) (*GetAttestationsResponse, error)
 	// GetAttestationsStream queries attestations and streams them back individually.
@@ -77,6 +80,16 @@ func (c *aTSStoreServiceClient) GenerateAndCreateAttestation(ctx context.Context
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GenerateAttestationResponse)
 	err := c.cc.Invoke(ctx, ATSStoreService_GenerateAndCreateAttestation_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *aTSStoreServiceClient) BatchGenerateAndCreateAttestations(ctx context.Context, in *BatchGenerateAttestationRequest, opts ...grpc.CallOption) (*BatchGenerateAttestationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BatchGenerateAttestationResponse)
+	err := c.cc.Invoke(ctx, ATSStoreService_BatchGenerateAndCreateAttestations_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -124,6 +137,8 @@ type ATSStoreServiceServer interface {
 	AttestationExists(context.Context, *AttestationExistsRequest) (*AttestationExistsResponse, error)
 	// GenerateAndCreateAttestation generates an attestation ID and creates it
 	GenerateAndCreateAttestation(context.Context, *GenerateAttestationRequest) (*GenerateAttestationResponse, error)
+	// BatchGenerateAndCreateAttestations generates IDs and creates multiple attestations in one write transaction
+	BatchGenerateAndCreateAttestations(context.Context, *BatchGenerateAttestationRequest) (*BatchGenerateAttestationResponse, error)
 	// GetAttestations queries attestations with filters
 	GetAttestations(context.Context, *GetAttestationsRequest) (*GetAttestationsResponse, error)
 	// GetAttestationsStream queries attestations and streams them back individually.
@@ -147,6 +162,9 @@ func (UnimplementedATSStoreServiceServer) AttestationExists(context.Context, *At
 }
 func (UnimplementedATSStoreServiceServer) GenerateAndCreateAttestation(context.Context, *GenerateAttestationRequest) (*GenerateAttestationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GenerateAndCreateAttestation not implemented")
+}
+func (UnimplementedATSStoreServiceServer) BatchGenerateAndCreateAttestations(context.Context, *BatchGenerateAttestationRequest) (*BatchGenerateAttestationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method BatchGenerateAndCreateAttestations not implemented")
 }
 func (UnimplementedATSStoreServiceServer) GetAttestations(context.Context, *GetAttestationsRequest) (*GetAttestationsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAttestations not implemented")
@@ -229,6 +247,24 @@ func _ATSStoreService_GenerateAndCreateAttestation_Handler(srv interface{}, ctx 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ATSStoreService_BatchGenerateAndCreateAttestations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BatchGenerateAttestationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ATSStoreServiceServer).BatchGenerateAndCreateAttestations(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ATSStoreService_BatchGenerateAndCreateAttestations_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ATSStoreServiceServer).BatchGenerateAndCreateAttestations(ctx, req.(*BatchGenerateAttestationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ATSStoreService_GetAttestations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetAttestationsRequest)
 	if err := dec(in); err != nil {
@@ -276,6 +312,10 @@ var ATSStoreService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GenerateAndCreateAttestation",
 			Handler:    _ATSStoreService_GenerateAndCreateAttestation_Handler,
+		},
+		{
+			MethodName: "BatchGenerateAndCreateAttestations",
+			Handler:    _ATSStoreService_BatchGenerateAndCreateAttestations_Handler,
 		},
 		{
 			MethodName: "GetAttestations",

--- a/plugin/grpc/websocket_keepalive.go
+++ b/plugin/grpc/websocket_keepalive.go
@@ -247,7 +247,7 @@ func (h *KeepaliveHandler) Start(ctx context.Context, sendPing func(timestamp in
 	h.lastPong = time.Now()
 	h.mu.Unlock()
 
-	h.logger.Infow("Starting keepalive handler",
+	h.logger.Debugw("Starting keepalive handler",
 		"ping_interval", h.config.PingInterval,
 		"pong_timeout", h.config.PongTimeout,
 	)

--- a/pulse/async/grace_test.go
+++ b/pulse/async/grace_test.go
@@ -263,25 +263,26 @@ func TestGRACEGracefulStart(t *testing.T) {
 	// Give recovery time to run
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify both jobs were recovered (re-queued)
+	// Verify both jobs were failed (orphan recovery marks them failed so
+	// the scheduler creates fresh jobs on the next tick)
 	recoveredJob1, err := queue.GetJob(job1.ID)
 	if err != nil {
 		t.Fatalf("Failed to get job1 after recovery: %v", err)
 	}
-	if recoveredJob1.Status != JobStatusQueued {
-		t.Errorf("Expected job1 to be re-queued, got status '%s'", recoveredJob1.Status)
+	if recoveredJob1.Status != JobStatusFailed {
+		t.Errorf("Expected job1 to be failed, got status '%s'", recoveredJob1.Status)
 	} else {
-		t.Log("✓ Orphaned job 1 recovered and re-queued")
+		t.Log("✓ Orphaned job 1 marked as failed")
 	}
 
 	recoveredJob2, err := queue.GetJob(job2.ID)
 	if err != nil {
 		t.Fatalf("Failed to get job2 after recovery: %v", err)
 	}
-	if recoveredJob2.Status != JobStatusQueued {
-		t.Errorf("Expected job2 to be re-queued, got status '%s'", recoveredJob2.Status)
+	if recoveredJob2.Status != JobStatusFailed {
+		t.Errorf("Expected job2 to be failed, got status '%s'", recoveredJob2.Status)
 	} else {
-		t.Log("✓ Orphaned job 2 recovered and re-queued")
+		t.Log("✓ Orphaned job 2 marked as failed")
 	}
 }
 
@@ -539,11 +540,11 @@ func TestGRACEPhaseRecoveryNoChildTasks(t *testing.T) {
 		t.Fatalf("Failed to get job after recovery: %v", err)
 	}
 
-	// Verify job status is queued (ready to re-run)
-	if recovered.Status != JobStatusQueued {
-		t.Errorf("Expected job to be queued, got status '%s'", recovered.Status)
+	// Verify job status is failed (scheduler creates fresh job on next tick)
+	if recovered.Status != JobStatusFailed {
+		t.Errorf("Expected job to be failed, got status '%s'", recovered.Status)
 	} else {
-		t.Log("✓ Job re-queued after recovery")
+		t.Log("✓ Job marked as failed after recovery")
 	}
 }
 
@@ -601,11 +602,11 @@ func TestGRACEPhaseRecoveryWithChildTasks(t *testing.T) {
 		t.Fatalf("Failed to get job after recovery: %v", err)
 	}
 
-	// Verify job status is queued (ready to continue processing)
-	if recovered.Status != JobStatusQueued {
-		t.Errorf("Expected job to be queued, got status '%s'", recovered.Status)
+	// Verify job status is failed (scheduler creates fresh job on next tick)
+	if recovered.Status != JobStatusFailed {
+		t.Errorf("Expected job to be failed, got status '%s'", recovered.Status)
 	} else {
-		t.Log("✓ Parent job re-queued after recovery")
+		t.Log("✓ Parent job marked as failed after recovery")
 	}
 
 	// Verify child tasks remain queued

--- a/pulse/async/worker.go
+++ b/pulse/async/worker.go
@@ -241,45 +241,39 @@ func (wp *WorkerPool) recoverOrphanedJobs() error {
 
 	wp.logger.Starting("Opening - found orphaned jobs from previous crash", "count", len(orphanedJobs))
 
-	// Strategy: Super gradual warm start to avoid overwhelming the system
-	// Phase 0 (Immediate): First job only
-	// Phase 1 (0-10s): 1 job per second for next 9 jobs (jobs 2-10)
-	// Phase 2 (10s-15min): Remaining jobs spread over 15 minutes
-
-	if len(orphanedJobs) == 0 {
-		return nil
+	// Fail all orphaned jobs immediately. Scheduled jobs will create fresh
+	// ones on their next tick. No gradual recovery needed — failing is instant.
+	failed := 0
+	for _, job := range orphanedJobs {
+		if err := wp.failOrphanedJob(job); err != nil {
+			wp.logger.SugaredLogger.Warnw("Failed to mark orphaned job as failed", "job_id", job.ID, "error", err)
+		} else {
+			failed++
+		}
 	}
-
-	// Recover first job immediately
-	if err := wp.requeueOrphanedJob(orphanedJobs[0]); err != nil {
-		wp.logger.SugaredLogger.Warnw("Failed to recover orphaned job", "job_id", orphanedJobs[0].ID, "error", err)
-	} else {
-		wp.logger.Starting("Immediately recovered first job", "current", 1, "total", len(orphanedJobs))
-	}
-
-	// Gradual recovery for remaining jobs in background
-	if len(orphanedJobs) > 1 {
-		wp.logger.Starting("Will gradually recover remaining jobs (warm start over 15 minutes)", "count", len(orphanedJobs)-1)
-		go wp.gradualRecovery(orphanedJobs[1:])
-	}
+	wp.logger.Starting("Orphaned jobs cleared", "failed", failed, "total", len(orphanedJobs))
 
 	return nil
 }
 
-// requeueOrphanedJob re-queues a single orphaned job
-func (wp *WorkerPool) requeueOrphanedJob(job *Job) error {
-	job.Status = JobStatusQueued
-	job.Error = "" // Clear any stale error message
+// failOrphanedJob marks an orphaned running job as failed so the scheduler
+// can create a fresh one on its next tick. Re-queuing orphans is unsafe:
+// the job may have partially mutated state before the crash.
+func (wp *WorkerPool) failOrphanedJob(job *Job) error {
+	job.Status = JobStatusFailed
+	job.Error = "orphaned: server restart while running"
+	now := time.Now()
+	job.CompletedAt = &now
 
 	if err := wp.queue.UpdateJob(job); err != nil {
-		err = errors.Wrapf(err, "failed to update recovered job %s", job.ID)
+		err = errors.Wrapf(err, "failed to fail orphaned job %s", job.ID)
 		err = errors.WithDetail(err, fmt.Sprintf("Job ID: %s", job.ID))
 		err = errors.WithDetail(err, fmt.Sprintf("Handler: %s", job.HandlerName))
 		err = errors.WithDetail(err, fmt.Sprintf("Source: %s", job.Source))
 		return err
 	}
 
-	wp.logger.Starting("Recovered orphaned job", "job_id", job.ID, "handler", job.HandlerName)
+	wp.logger.Starting("Failed orphaned job", "job_id", job.ID, "handler", job.HandlerName)
 	return nil
 }
 
@@ -289,43 +283,6 @@ func (wp *WorkerPool) requeueOrphanedJob(job *Job) error {
 // Warm Start Strategy:
 // - Phase 1 (0-10s): Jobs 2-10 at 1 job per second (9 jobs total)
 // - Phase 2 (10s-15min): Remaining jobs spread over 15 minutes
-func (wp *WorkerPool) gradualRecovery(jobs []*Job) {
-	if len(jobs) == 0 {
-		return
-	}
-
-	startTime := time.Now()
-
-	// Calculate phase durations (configurable for testing)
-	warmStartDuration := 10 * time.Second
-	slowStartDuration := 15 * time.Minute
-	if wp.poolConfig.GracefulStartPhase > 0 {
-		warmStartDuration = wp.poolConfig.GracefulStartPhase / 5
-		slowStartDuration = wp.poolConfig.GracefulStartPhase * 3
-	}
-
-	// Warm start: first 9 jobs (or fewer if less available)
-	warmStartLimit := min(9, len(jobs))
-	warmStartInterval := warmStartDuration / time.Duration(warmStartLimit)
-	wp.logger.Starting("Warm start phase", "count", warmStartLimit, "interval", warmStartInterval)
-
-	warmRecovered := wp.recoverJobsWithInterval(jobs[:warmStartLimit], warmStartInterval, "warm start")
-	wp.logger.Starting("Warm start complete", "recovered", warmRecovered, "duration", time.Since(startTime))
-
-	// Slow start: remaining jobs
-	remainingJobs := jobs[warmStartLimit:]
-	if len(remainingJobs) == 0 {
-		wp.logger.Starting("All jobs recovered during warm start")
-		return
-	}
-
-	slowStartInterval := slowStartDuration / time.Duration(len(remainingJobs))
-	wp.logger.Starting("Slow start phase", "count", len(remainingJobs), "interval", slowStartInterval)
-
-	slowRecovered := wp.recoverJobsWithInterval(remainingJobs, slowStartInterval, "slow start")
-	wp.logger.Starting("Gradual recovery complete", "recovered", warmRecovered+slowRecovered, "total", len(jobs), "duration", time.Since(startTime))
-}
-
 // Stop gracefully stops the worker pool
 // ❀ Closing: Workers checkpoint and exit cleanly on context cancellation
 // Uses a configurable timeout (default 20s) to allow jobs to checkpoint without blocking indefinitely
@@ -710,37 +667,6 @@ func (wp *WorkerPool) updateJobPulseState(job *Job) {
 	if err := wp.queue.UpdateJob(job); err != nil {
 		wp.logger.SugaredLogger.Warnw("Failed to update job pulse state", "error", err)
 	}
-}
-
-// recoverJobsWithInterval recovers a batch of jobs with a delay between each.
-// Returns the number of jobs successfully recovered.
-func (wp *WorkerPool) recoverJobsWithInterval(jobs []*Job, interval time.Duration, phase string) int {
-	recovered := 0
-	for i, job := range jobs {
-		select {
-		case <-wp.ctx.Done():
-			wp.logger.Closing("Gradual recovery cancelled during "+phase, "recovered", recovered, "total", len(jobs))
-			return recovered
-		default:
-		}
-
-		if err := wp.requeueOrphanedJob(job); err != nil {
-			wp.logger.SugaredLogger.Warnw("Failed to recover job during "+phase, "job_id", job.ID, "error", err)
-			continue
-		}
-		recovered++
-
-		// Progress logging every 10 jobs
-		if recovered%10 == 0 {
-			wp.logger.Starting("Gradual recovery progress", "current", recovered, "total", len(jobs), "phase", phase)
-		}
-
-		// Wait before next job (unless it's the last one)
-		if i < len(jobs)-1 {
-			time.Sleep(interval)
-		}
-	}
-	return recovered
 }
 
 // GetQueue returns the job queue (useful for enqueuing jobs)

--- a/pulse/schedule/ticker.go
+++ b/pulse/schedule/ticker.go
@@ -287,9 +287,8 @@ func (t *Ticker) logNextJobInfo(now time.Time) {
 // logActivitySummary logs a combined creation + eviction summary.
 func (t *Ticker) logActivitySummary() {
 	var created int
-	var topPCs []string
 	if t.creationStats != nil {
-		created, topPCs = t.creationStats.DrainCreationCounts()
+		created, _ = t.creationStats.DrainCreationCounts()
 	}
 
 	var evictionEvents, evicted int
@@ -332,8 +331,9 @@ func (t *Ticker) logActivitySummary() {
 
 	msg := strings.Join(parts, ", ")
 
-	if len(topPCs) > 0 {
-		msg += " (top: " + strings.Join(topPCs, ", ") + ")"
+	if created > 0 && evicted > 0 {
+		ratio := float64(evicted) * 100 / float64(created)
+		msg += fmt.Sprintf(" (%.0f%% evicted)", ratio)
 	}
 	if len(clusterCounts) > 0 {
 		msg += " [clusters: " + strings.Join(clusterCounts, ", ") + "]"

--- a/server/checkpoint_pulse.go
+++ b/server/checkpoint_pulse.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appcfg "github.com/teranos/QNTX/am"
+	"github.com/teranos/QNTX/pulse/async"
+	"github.com/teranos/QNTX/pulse/schedule"
+	"go.uber.org/zap"
+)
+
+const checkpointHandlerName = "wal-checkpoint"
+
+// WALCheckpointer runs a TRUNCATE WAL checkpoint.
+// Implemented by RustStore.WALCheckpointTruncate (closes read conns, checkpoints, reopens).
+type WALCheckpointer interface {
+	WALCheckpointTruncate() (busy, walPages, checkpointedPages int, err error)
+}
+
+// checkpointHandler runs WAL TRUNCATE checkpoint periodically through Rust FFI.
+// Rust closes all read connections, runs the checkpoint, and reopens them.
+// References the server's walCheckpointer field so late wiring (after NewQNTXServer) works.
+type checkpointHandler struct {
+	server *QNTXServer
+	logger *zap.SugaredLogger
+}
+
+func (h *checkpointHandler) Name() string { return checkpointHandlerName }
+
+func (h *checkpointHandler) Execute(ctx context.Context, job *async.Job) error {
+	checkpointer := h.server.walCheckpointer
+	if checkpointer == nil {
+		return nil
+	}
+
+	start := time.Now()
+	busy, walPages, checkpointed, err := checkpointer.WALCheckpointTruncate()
+	dur := time.Since(start)
+	if err != nil {
+		h.logger.Warnw("WAL checkpoint failed", "error", err, "took_ms", dur.Milliseconds())
+		return err
+	}
+	if walPages > 0 || checkpointed > 0 {
+		h.logger.Infow("WAL checkpoint",
+			"busy", busy,
+			"wal_pages", walPages,
+			"checkpointed_pages", checkpointed,
+			"took_ms", dur.Milliseconds())
+	}
+	return nil
+}
+
+func (s *QNTXServer) setupCheckpointSchedule(cfg *appcfg.Config) {
+	handler := &checkpointHandler{
+		server: s,
+		logger: s.logger.Named("checkpoint"),
+	}
+
+	registry := s.daemon.Registry()
+	registry.Register(handler)
+
+	schedStore := schedule.NewStore(s.db)
+
+	// Check for existing schedule
+	existing, err := schedStore.ListAllScheduledJobs()
+	if err != nil {
+		s.logger.Errorw("Failed to list scheduled jobs for checkpoint", "error", err)
+		return
+	}
+	for _, j := range existing {
+		if j.HandlerName == checkpointHandlerName && j.State == schedule.StateActive {
+			return
+		}
+	}
+
+	now := time.Now()
+	job := &schedule.Job{
+		ID:              fmt.Sprintf("SPJ_checkpoint_%d", now.Unix()),
+		HandlerName:     checkpointHandlerName,
+		IntervalSeconds: 300, // every 5 minutes
+		State:           schedule.StateActive,
+		NextRunAt:       &now,
+	}
+
+	if err := schedStore.CreateJob(job); err != nil {
+		s.logger.Errorw("Failed to create checkpoint schedule", "error", err)
+		return
+	}
+	s.logger.Infow("Auto-created WAL checkpoint schedule", "interval_seconds", 300)
+}

--- a/server/db_stats_cache.go
+++ b/server/db_stats_cache.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/storage/sqlitecgo"
+	"github.com/teranos/QNTX/db/rustdriver"
 	"github.com/teranos/QNTX/server/syscap"
 )
 
@@ -57,6 +58,7 @@ func (s *QNTXServer) refreshDBStats() {
 	}
 	defer statsDB.Close()
 
+	rustdriver.SetCaller("db-stats")
 	queryStart := time.Now()
 	if err := statsDB.QueryRow("SELECT COUNT(*) FROM attestations").Scan(&totalAttestations); err != nil {
 		s.logger.Warnw("Failed to refresh database stats cache", "error", err, "elapsed", time.Since(queryStart))
@@ -381,8 +383,8 @@ func queryPredicateHistograms(db *sql.DB) map[string]map[string]int64 {
 	return result
 }
 
-func queryRecentEvictions(db *sql.DB) []map[string]interface{} {
-	var evictions []map[string]interface{}
+func queryRecentEvictions(db *sql.DB) []map[string]any {
+	var evictions []map[string]any
 	rows, err := db.Query(`
 		SELECT event_type, actor, context, entity, deletions_count, limit_value, timestamp, eviction_details
 		FROM storage_events
@@ -425,7 +427,7 @@ func queryRecentEvictions(db *sql.DB) []map[string]interface{} {
 			message = fmt.Sprintf("Evicted %d attestations (%s)", deletionsCount, eventType)
 		}
 
-		ev := map[string]interface{}{
+		ev := map[string]any{
 			"event_type":      eventType,
 			"actor":           actor.String,
 			"context":         ctx.String,
@@ -436,7 +438,7 @@ func queryRecentEvictions(db *sql.DB) []map[string]interface{} {
 		}
 
 		if evictionDetails.Valid && evictionDetails.String != "" {
-			var details map[string]interface{}
+			var details map[string]any
 			if err := json.Unmarshal([]byte(evictionDetails.String), &details); err == nil {
 				if preds, ok := details["predicates"]; ok {
 					ev["predicates"] = preds

--- a/server/db_stats_cache.go
+++ b/server/db_stats_cache.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"strings"
@@ -11,8 +12,15 @@ import (
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/storage/sqlitecgo"
 	"github.com/teranos/QNTX/db/rustdriver"
+	"github.com/teranos/QNTX/pulse/async"
 	"github.com/teranos/QNTX/server/syscap"
 )
+
+// WriteLockInspector exposes write lock holder diagnostics.
+// Implemented by RustStore.WriteHolderInfo.
+type WriteLockInspector interface {
+	WriteHolderInfo() (holder string, held time.Duration)
+}
 
 const dbStatsRefreshInterval = 30 * time.Second
 
@@ -97,6 +105,9 @@ func (s *QNTXServer) refreshDBStats() {
 	// Performance snapshot (slow ops + mutex contention)
 	perfData := buildPerformanceData()
 
+	// Live system status: write lock, WAL, dilation
+	liveStatus := buildLiveStatus(s)
+
 	response := map[string]interface{}{
 		"type":               "database_stats",
 		"path":               s.dbPath,
@@ -112,9 +123,46 @@ func (s *QNTXServer) refreshDBStats() {
 		"distillation":          distillStats,
 		"predicate_histograms": predicateHistograms,
 		"performance":          perfData,
+		"live":                 liveStatus,
 	}
 
 	s.dbStatsCache.Store(&cachedDBStats{response: response})
+}
+
+// buildLiveStatus collects real-time system metrics for the frontend:
+// write lock holder, WAL file size, and dilation state.
+func buildLiveStatus(s *QNTXServer) map[string]interface{} {
+	status := make(map[string]interface{})
+
+	// Write lock holder
+	if s.writeLockInspector != nil {
+		holder, held := s.writeLockInspector.WriteHolderInfo()
+		if holder != "" {
+			status["write_lock"] = map[string]interface{}{
+				"holder":  holder,
+				"held_ms": held.Milliseconds(),
+			}
+		}
+	}
+
+	// WAL file size (just stat the file — no queries needed)
+	walPath := s.dbPath + "-wal"
+	if info, err := os.Stat(walPath); err == nil {
+		status["wal_bytes"] = info.Size()
+	}
+
+	// DB file size
+	if info, err := os.Stat(s.dbPath); err == nil {
+		status["db_bytes"] = info.Size()
+	}
+
+	// Dilation + system pressure
+	status["dilation"] = async.CalculateDilation()
+	memPct, cpuPct := async.GetPressure()
+	status["mem_pct"] = memPct
+	status["cpu_pct"] = cpuPct
+
+	return status
 }
 
 // buildPerformanceData converts the slow log collector's rolling history

--- a/server/debug_handler.go
+++ b/server/debug_handler.go
@@ -67,6 +67,29 @@ func (cb *ConsoleBuffer) GetAll() []ConsoleLog {
 	return result
 }
 
+// HandleCrashTest triggers a deliberate crash to verify the flight recorder.
+// Dev mode only.
+func (s *QNTXServer) HandleCrashTest(w http.ResponseWriter, r *http.Request) {
+	if !s.isDevMode() {
+		writeError(w, http.StatusForbidden, "Crash test only available in dev mode")
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "POST only")
+		return
+	}
+	type crashTester interface {
+		CrashTest()
+	}
+	if ct, ok := s.atsStore.(crashTester); ok {
+		w.Write([]byte("triggering crash test — check qntx.db.flight\n"))
+		w.(http.Flusher).Flush()
+		ct.CrashTest()
+	} else {
+		writeError(w, http.StatusNotImplemented, "store does not support crash test")
+	}
+}
+
 // HandleDebug handles browser console debugging endpoint
 // POST: Add console log to buffer
 // GET: Retrieve all console logs from buffer

--- a/server/distill_pulse.go
+++ b/server/distill_pulse.go
@@ -50,7 +50,7 @@ func (h *distillHandler) Execute(ctx context.Context, job *async.Job) error {
 		SELECT id, subjects, predicates, actors, contexts,
 		       timestamp, source, attributes
 		FROM attestations
-		WHERE timestamp < ?
+		WHERE (timestamp < ? OR source = 'distill')
 		ORDER BY timestamp ASC
 		LIMIT ?
 	`, cutoff, h.batchSize)
@@ -117,9 +117,18 @@ func (h *distillHandler) Execute(ctx context.Context, job *async.Job) error {
 	totalDistilled := 0
 	totalCreated := 0
 
+	totalSkipped := 0
 	for predicate, batch := range groups {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+
+		// Skip groups with fewer than 2 attestations — a sigma that absorbs
+		// a single attestation adds no information, wastes a write, and
+		// deletes the original (net negative).
+		if len(batch) < 2 {
+			totalSkipped += len(batch)
+			continue
 		}
 
 		buildStart := time.Now()
@@ -180,7 +189,8 @@ func (h *distillHandler) Execute(ctx context.Context, job *async.Job) error {
 		h.logger.Infow("Σ Sigma complete",
 			"distilled", totalDistilled,
 			"sigmas_created", totalCreated,
-			"groups", len(groups))
+			"groups", len(groups),
+			"skipped_singles", totalSkipped)
 	}
 	return nil
 }
@@ -318,6 +328,23 @@ func buildDistillAttestation(batch []*types.As, predicate string) *types.As {
 	// Actors: use canonical "distill" actor to avoid inflating entity_actors_limit.
 	// The original actor union is preserved as _actors_sample in attributes.
 	actorsSample := setToSlice(actorSet, 50)
+
+	// Strip already-merged attribute aggregates from prior sigmas before merging.
+	// Without this, re-distilled sigmas accumulate nested frequency maps unboundedly,
+	// eventually exceeding the 1MB JSON limit.
+	for _, as_ := range batch {
+		if as_.Source == "distill" && as_.Attributes != nil {
+			for k, v := range as_.Attributes {
+				if strings.HasPrefix(k, "_") {
+					continue // keep distill metadata
+				}
+				// Drop nested aggregate maps (num aggs, string freq maps)
+				if _, isMap := v.(map[string]interface{}); isMap {
+					delete(as_.Attributes, k)
+				}
+			}
+		}
+	}
 
 	// Merge attributes
 	merged := mergeAttributes(batch)

--- a/server/distill_pulse.go
+++ b/server/distill_pulse.go
@@ -353,6 +353,25 @@ func buildDistillAttestation(batch []*types.As, predicate string) *types.As {
 	merged["_rust_version"] = syscap.GetStorageVersion()
 	merged["_count"] = len(batch)
 
+	// Track original source — if all inputs share the same source, preserve it.
+	sourceSet := make(map[string]struct{})
+	for _, as_ := range batch {
+		if as_.Source != "" && as_.Source != "distill" {
+			sourceSet[as_.Source] = struct{}{}
+		}
+	}
+	if len(sourceSet) == 1 {
+		for s := range sourceSet {
+			merged["_source"] = s
+		}
+	} else if len(sourceSet) > 1 {
+		sources := make([]string, 0, len(sourceSet))
+		for s := range sourceSet {
+			sources = append(sources, s)
+		}
+		merged["_source"] = sources
+	}
+
 	// _total: transitive total of original observations this attestation represents.
 	// For raw attestations, each counts as 1. For prior distill attestations,
 	// use their _total (or fall back to _count for pre-_total distill attestations).

--- a/server/distill_pulse.go
+++ b/server/distill_pulse.go
@@ -2,832 +2,71 @@ package server
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	appcfg "github.com/teranos/QNTX/am"
-	"github.com/teranos/QNTX/ats"
-	"github.com/teranos/QNTX/ats/types"
-	"github.com/teranos/QNTX/errors"
-	"github.com/teranos/QNTX/internal/version"
 	"github.com/teranos/QNTX/pulse/async"
-	"github.com/teranos/QNTX/server/syscap"
 	"github.com/teranos/QNTX/pulse/schedule"
 	"go.uber.org/zap"
 )
 
 const distillHandlerName = "distill"
 
-// distillHandler folds old attestations into compressed summaries.
+// AgeDistiller runs age-triggered distillation through Rust FFI.
+// Implemented by RustStore.AgeDistill.
+type AgeDistiller interface {
+	AgeDistill(cutoffRFC3339 string, batchSize int) (distilled, sigmasCreated, skipped int, err error)
+}
+
+// distillHandler folds old attestations into compressed summaries via Rust FFI.
 // Implements async.JobHandler for the Pulse scheduler.
+// References the server's ageDistiller field so late wiring (after NewQNTXServer) works.
 type distillHandler struct {
-	db        *sql.DB
-	atsStore  ats.AttestationStore
+	server    *QNTXServer
 	maxAge    time.Duration
 	batchSize int
-	dryRun    bool
 	logger    *zap.SugaredLogger
 }
 
 func (h *distillHandler) Name() string { return distillHandlerName }
 
 func (h *distillHandler) Execute(ctx context.Context, job *async.Job) error {
-	// Clean up ghost rows (NULL/empty IDs, zero timestamps) on each cycle
-	if result, err := h.db.ExecContext(ctx, `DELETE FROM attestations WHERE id IS NULL OR id = '' OR timestamp = '0' OR timestamp < '0002'`); err == nil {
-		if n, _ := result.RowsAffected(); n > 0 {
-			h.logger.Infow("Cleaned ghost rows", "deleted", n)
-		}
-	}
-
-	cutoff := time.Now().Add(-h.maxAge).UTC().Format(time.RFC3339)
-	h.logger.Debugw("Σ Sigma query starting", "cutoff", cutoff, "batch_size", h.batchSize)
-
-	// Find old attestations, grouped by (actor, context)
-	rows, err := h.db.QueryContext(ctx, `
-		SELECT id, subjects, predicates, actors, contexts,
-		       timestamp, source, attributes
-		FROM attestations
-		WHERE (timestamp < ? OR source = 'distill')
-		ORDER BY timestamp ASC
-		LIMIT ?
-	`, cutoff, h.batchSize)
-	if err != nil {
-		return errors.Wrapf(err, "distill query failed (cutoff=%s, batch=%d)", cutoff, h.batchSize)
-	}
-	defer rows.Close()
-
-	// Load all candidates
-	var candidates []*types.As
-	scanned := 0
-	scanErrors := 0
-	for rows.Next() {
-		scanned++
-		var (
-			id                                                     sql.NullString
-			subjectsJSON, predicatesJSON, actorsJSON, contextsJSON string
-			timestamp, source                                      string
-			attrsJSON                                              sql.NullString
-		)
-		if err := rows.Scan(&id, &subjectsJSON, &predicatesJSON, &actorsJSON, &contextsJSON,
-			&timestamp, &source, &attrsJSON); err != nil {
-			scanErrors++
-			h.logger.Warnw("Failed to scan attestation row", "error", err, "row", scanned)
-			continue
-		}
-
-		if !id.Valid || id.String == "" {
-			continue // skip ghost rows with NULL/empty IDs
-		}
-		as := &types.As{ID: id.String, Source: source}
-		json.Unmarshal([]byte(subjectsJSON), &as.Subjects)
-		json.Unmarshal([]byte(predicatesJSON), &as.Predicates)
-		json.Unmarshal([]byte(actorsJSON), &as.Actors)
-		json.Unmarshal([]byte(contextsJSON), &as.Contexts)
-		if t, err := time.Parse(time.RFC3339Nano, timestamp); err == nil {
-			as.Timestamp = t
-		}
-		if attrsJSON.Valid {
-			json.Unmarshal([]byte(attrsJSON.String), &as.Attributes)
-		}
-
-		candidates = append(candidates, as)
-	}
-
-	h.logger.Debugw("Σ Sigma scan complete", "scanned", scanned, "scan_errors", scanErrors, "candidates", len(candidates))
-
-	if len(candidates) == 0 {
-		h.logger.Debugw("Σ Nothing to distill", "cutoff", cutoff)
+	distiller := h.server.ageDistiller
+	if distiller == nil {
 		return nil
 	}
 
-	// Group by predicate — one sigma per predicate.
-	// Subjects collapse into a count, actors/contexts into sets.
-	groups := make(map[string][]*types.As)
-	for _, as := range candidates {
-		predicate := "_"
-		if len(as.Predicates) > 0 {
-			predicate = as.Predicates[0]
-		}
-		groups[predicate] = append(groups[predicate], as)
+	cutoff := time.Now().Add(-h.maxAge).UTC().Format(time.RFC3339)
+
+	start := time.Now()
+	distilled, sigmasCreated, skipped, err := distiller.AgeDistill(cutoff, h.batchSize)
+	dur := time.Since(start)
+
+	if err != nil {
+		h.logger.Warnw("Σ Sigma failed", "error", err, "took_ms", dur.Milliseconds())
+		return err
 	}
 
-	totalDistilled := 0
-	totalCreated := 0
-
-	totalSkipped := 0
-	for predicate, batch := range groups {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		// Skip groups with fewer than 2 attestations — a sigma that absorbs
-		// a single attestation adds no information, wastes a write, and
-		// deletes the original (net negative).
-		if len(batch) < 2 {
-			totalSkipped += len(batch)
-			continue
-		}
-
-		buildStart := time.Now()
-		distillAs := buildDistillAttestation(batch, predicate)
-		buildDur := time.Since(buildStart)
-
-		if h.dryRun {
-			h.logger.Infow("Dry run: would distill",
-				"predicate", predicate,
-				"count", len(batch),
-				"oldest", batch[0].Timestamp.Format(time.RFC3339),
-				"newest", batch[len(batch)-1].Timestamp.Format(time.RFC3339))
-			continue
-		}
-
-		// Insert sigma via normal store path (updates counters)
-		createStart := time.Now()
-		if err := h.atsStore.CreateAttestation(distillAs); err != nil {
-			h.logger.Warnw("Σ Failed to create sigma",
-				"predicate", predicate,
-				"count", len(batch),
-				"error", err)
-			continue
-		}
-		createDur := time.Since(createStart)
-		totalCreated++
-
-		// Delete originals — CASCADE handles junction tables,
-		// then decrement enforcement counters.
-		ids := make([]string, len(batch))
-		for i, a := range batch {
-			ids[i] = a.ID
-		}
-		deleteStart := time.Now()
-		deleted, err := h.deleteAndUpdateCounters(ctx, ids, batch)
-		deleteDur := time.Since(deleteStart)
-		if err != nil {
-			h.logger.Warnw("Failed to delete distilled attestations",
-				"predicate", predicate,
-				"error", err)
-			continue
-		}
-		totalDistilled += deleted
-
-		h.logger.Debugw("Σ Sigma group timing",
-			"predicate", predicate,
-			"batch_size", len(batch),
-			"build_ms", buildDur.Milliseconds(),
-			"create_ms", createDur.Milliseconds(),
-			"delete_ms", deleteDur.Milliseconds())
-	}
-
-	if h.dryRun {
-		h.logger.Infow("Σ Sigma dry run complete",
-			"groups", len(groups),
-			"candidates", len(candidates))
-	} else {
+	if distilled > 0 || sigmasCreated > 0 {
 		h.logger.Infow("Σ Sigma complete",
-			"distilled", totalDistilled,
-			"sigmas_created", totalCreated,
-			"groups", len(groups),
-			"skipped_singles", totalSkipped)
+			"distilled", distilled,
+			"sigmas_created", sigmasCreated,
+			"skipped_singles", skipped,
+			"took_ms", dur.Milliseconds())
 	}
 	return nil
 }
 
-// deleteAndUpdateCounters deletes attestations by ID in batches and decrements enforcement counters.
-func (h *distillHandler) deleteAndUpdateCounters(ctx context.Context, ids []string, batch []*types.As) (int, error) {
-	deleteStart := time.Now()
-	// Batch delete using IN clauses (chunks of 500 to stay within SQLite limits)
-	deleted := 0
-	const chunkSize = 500
-	for i := 0; i < len(ids); i += chunkSize {
-		end := i + chunkSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		chunk := ids[i:end]
-
-		placeholders := make([]string, len(chunk))
-		args := make([]interface{}, len(chunk))
-		for j, id := range chunk {
-			placeholders[j] = "?"
-			args[j] = id
-		}
-		query := "DELETE FROM attestations WHERE id IN (" + strings.Join(placeholders, ",") + ")"
-		result, err := h.db.ExecContext(ctx, query, args...)
-		if err != nil {
-			return deleted, errors.Wrapf(err, "batch delete %d attestations (chunk %d)", len(chunk), i/chunkSize)
-		}
-		n, _ := result.RowsAffected()
-		deleted += int(n)
-	}
-
-	deleteDur := time.Since(deleteStart)
-
-	// Rebuild enforcement counters for affected actors from actual data.
-	// Instead of decrementing one-by-one (3,584 queries for 896 actors),
-	// delete stale counter rows and repopulate from junction tables.
-	counterStart := time.Now()
-
-	// Collect unique actors from the deleted batch
-	actorSet := make(map[string]bool)
-	for _, as := range batch {
-		for _, actor := range as.Actors {
-			actorSet[actor] = true
-		}
-	}
-	actors := make([]string, 0, len(actorSet))
-	for a := range actorSet {
-		actors = append(actors, a)
-	}
-
-	// Process in chunks to stay within SQLite parameter limits
-	const actorChunkSize = 200
-	for i := 0; i < len(actors); i += actorChunkSize {
-		end := i + actorChunkSize
-		if end > len(actors) {
-			end = len(actors)
-		}
-		chunk := actors[i:end]
-
-		placeholders := make([]string, len(chunk))
-		args := make([]interface{}, len(chunk))
-		for j, actor := range chunk {
-			placeholders[j] = "?"
-			args[j] = actor
-		}
-		inClause := strings.Join(placeholders, ",")
-
-		// 1. Delete stale counter rows for these actors
-		h.db.ExecContext(ctx,
-			"DELETE FROM enforcement_actor_context WHERE actor IN ("+inClause+")", args...)
-
-		// 2. Rebuild from actual attestation data
-		h.db.ExecContext(ctx, `
-			INSERT OR REPLACE INTO enforcement_actor_context (actor, context, count)
-			SELECT aa.actor, ac.context, COUNT(DISTINCT aa.attestation_id)
-			FROM attestation_actors aa
-			JOIN attestation_contexts ac ON ac.attestation_id = aa.attestation_id
-			WHERE aa.actor IN (`+inClause+`)
-			GROUP BY aa.actor, ac.context
-		`, args...)
-
-		// 3. Rebuild actor_contexts counts
-		h.db.ExecContext(ctx,
-			"DELETE FROM enforcement_actor_contexts WHERE actor IN ("+inClause+")", args...)
-		h.db.ExecContext(ctx, `
-			INSERT OR REPLACE INTO enforcement_actor_contexts (actor, count)
-			SELECT actor, COUNT(*) FROM enforcement_actor_context
-			WHERE actor IN (`+inClause+`)
-			GROUP BY actor
-		`, args...)
-	}
-
-	counterDur := time.Since(counterStart)
-	h.logger.Debugw("deleteAndUpdateCounters timing",
-		"delete_ms", deleteDur.Milliseconds(),
-		"counter_rebuild_ms", counterDur.Milliseconds(),
-		"ids", len(ids),
-		"actors", len(actors))
-
-	return deleted, nil
-}
-
-// buildDistillAttestation creates a compressed summary from a batch of attestations
-// grouped by predicate. Subjects collapse into a count, actors/contexts into sets.
-func buildDistillAttestation(batch []*types.As, predicate string) *types.As {
-	now := time.Now()
-
-	subjectSet := make(map[string]bool)
-	actorSet := make(map[string]bool)
-	contextSet := make(map[string]bool)
-	var firstSeen, lastSeen time.Time
-
-	for _, as := range batch {
-		for _, s := range as.Subjects {
-			subjectSet[s] = true
-		}
-		for _, a := range as.Actors {
-			actorSet[a] = true
-		}
-		for _, c := range as.Contexts {
-			contextSet[c] = true
-		}
-		if firstSeen.IsZero() || as.Timestamp.Before(firstSeen) {
-			firstSeen = as.Timestamp
-		}
-		if as.Timestamp.After(lastSeen) {
-			lastSeen = as.Timestamp
-		}
-	}
-
-	// Contexts as set (capped at 50)
-	contexts := setToSlice(contextSet, 50)
-
-	// Actors: use canonical "distill" actor to avoid inflating entity_actors_limit.
-	// The original actor union is preserved as _actors_sample in attributes.
-	actorsSample := setToSlice(actorSet, 50)
-
-	// Strip already-merged attribute aggregates from prior sigmas before merging.
-	// Without this, re-distilled sigmas accumulate nested frequency maps unboundedly,
-	// eventually exceeding the 1MB JSON limit.
-	for _, as_ := range batch {
-		if as_.Source == "distill" && as_.Attributes != nil {
-			for k, v := range as_.Attributes {
-				if strings.HasPrefix(k, "_") {
-					continue // keep distill metadata
-				}
-				// Drop nested aggregate maps (num aggs, string freq maps)
-				if _, isMap := v.(map[string]interface{}); isMap {
-					delete(as_.Attributes, k)
-				}
-			}
-		}
-	}
-
-	// Merge attributes
-	merged := mergeAttributes(batch)
-	merged["_distill"] = true
-	merged["_version"] = version.VersionTag + " (" + version.CommitHash + ")"
-	merged["_rust_version"] = syscap.GetStorageVersion()
-	merged["_count"] = len(batch)
-
-	// Track original source — if all inputs share the same source, preserve it.
-	sourceSet := make(map[string]struct{})
-	for _, as_ := range batch {
-		if as_.Source != "" && as_.Source != "distill" {
-			sourceSet[as_.Source] = struct{}{}
-		}
-	}
-	if len(sourceSet) == 1 {
-		for s := range sourceSet {
-			merged["_source"] = s
-		}
-	} else if len(sourceSet) > 1 {
-		sources := make([]string, 0, len(sourceSet))
-		for s := range sourceSet {
-			sources = append(sources, s)
-		}
-		merged["_source"] = sources
-	}
-
-	// _total: transitive total of original observations this attestation represents.
-	// For raw attestations, each counts as 1. For prior distill attestations,
-	// use their _total (or fall back to _count for pre-_total distill attestations).
-	total := 0
-	for _, as_ := range batch {
-		if as_.Attributes != nil {
-			if t, ok := as_.Attributes["_total"].(float64); ok {
-				total += int(t)
-			} else if c, ok := as_.Attributes["_count"].(float64); ok {
-				total += int(c)
-			} else {
-				total += 1
-			}
-		} else {
-			total += 1
-		}
-	}
-	merged["_total"] = total
-
-	merged["_subjects_count"] = len(subjectSet)
-	merged["_first_seen"] = firstSeen.UTC().Format(time.RFC3339)
-	merged["_last_seen"] = lastSeen.UTC().Format(time.RFC3339)
-
-	// Preserve original actor set in attributes
-	merged["_actors_count"] = len(actorSet)
-	merged["_actors_sample"] = actorsSample
-
-	// Keep a sample of subjects (up to 10) for debuggability
-	if len(subjectSet) <= 10 {
-		subjects := make([]string, 0, len(subjectSet))
-		for s := range subjectSet {
-			subjects = append(subjects, s)
-		}
-		merged["_subjects_sample"] = subjects
-	} else {
-		sample := make([]string, 0, 10)
-		for s := range subjectSet {
-			sample = append(sample, s)
-			if len(sample) >= 10 {
-				break
-			}
-		}
-		merged["_subjects_sample"] = sample
-	}
-
-	// Build temporal histogram from attestation timestamps
-	merged["_histogram"] = buildHistogram(batch)
-
-	// Strip existing distill: prefixes before adding one. Without this,
-	// meta-distillation stacks prefixes infinitely: distill:distill:distill:...
-	// Each cycle adds one prefix, so after N cycles a predicate becomes
-	// "distill:" repeated N times. The strip loop collapses it to one.
-	basePredicate := predicate
-	for strings.HasPrefix(basePredicate, "distill:") {
-		basePredicate = basePredicate[len("distill:"):]
-	}
-	distillPredicate := "distill:" + basePredicate
-
-	return &types.As{
-		ID:         fmt.Sprintf("AS-distill-%d", now.UnixNano()),
-		Subjects:   []string{distillPredicate},
-		Predicates: []string{distillPredicate},
-		Contexts:   contexts,
-		Actors:     []string{"distill"},
-		Timestamp:  now,
-		CreatedAt:  now,
-		Source:     "distill",
-		Attributes: merged,
-	}
-}
-
-func setToSlice(set map[string]bool, cap int) []string {
-	result := make([]string, 0, len(set))
-	for s := range set {
-		result = append(result, s)
-		if len(result) >= cap {
-			break
-		}
-	}
-	return result
-}
-
-type distillNumAgg struct {
-	min, max, sum float64
-	count         int
-}
-
-type distillStrAgg struct {
-	frequencies map[string]int // value → observation count
-	unplaced    map[string]bool // values from old-format aggregates (no frequency data)
-	count       int
-}
-
-// mergeAttributes mechanically merges attributes from a batch of attestations.
-//   - Numbers: {min, max, sum, count}
-//   - Strings: {frequencies: {val: count, ...}, count} (frequencies capped at 50)
-//   - Constants (same value across all): kept as scalar
-//   - Already-aggregated (_distill): merge aggregates
-func mergeAttributes(batch []*types.As) map[string]interface{} {
-	if len(batch) == 0 {
-		return make(map[string]interface{})
-	}
-
-	nums := make(map[string]*distillNumAgg)
-	strs := make(map[string]*distillStrAgg)
-	constants := make(map[string]interface{})
-	seen := make(map[string]int) // how many attestations have this key
-
-	for _, as := range batch {
-		if as.Attributes == nil {
-			continue
-		}
-		for k, v := range as.Attributes {
-			// Skip distill metadata keys
-			if k == "_distill" || k == "_count" || k == "_total" || k == "_first_seen" || k == "_last_seen" || k == "_version" || k == "_rust_version" || k == "_subjects_count" || k == "_subjects_sample" || k == "_actors_count" || k == "_actors_sample" || k == "_histogram" {
-				continue
-			}
-
-			seen[k]++
-
-			switch val := v.(type) {
-			case float64:
-				if agg, ok := nums[k]; ok {
-					if val < agg.min {
-						agg.min = val
-					}
-					if val > agg.max {
-						agg.max = val
-					}
-					agg.sum += val
-					agg.count++
-				} else {
-					nums[k] = &distillNumAgg{min: val, max: val, sum: val, count: 1}
-				}
-			case string:
-				if agg, ok := strs[k]; ok {
-					agg.frequencies[val]++
-					agg.count++
-				} else {
-					strs[k] = &distillStrAgg{
-						frequencies: map[string]int{val: 1},
-						unplaced:    make(map[string]bool),
-						count:       1,
-					}
-				}
-			case map[string]interface{}:
-				// Already-aggregated from prior distill — merge aggregates
-				if hasAggKeys(val) {
-					if agg, ok := nums[k]; ok {
-						mergeNumAgg(agg, val)
-					} else {
-						nums[k] = numAggFromMap(val)
-					}
-				} else if isStrAgg(val) {
-					aCount := 0
-					if c, ok := val["count"].(float64); ok {
-						aCount = int(c)
-					}
-					if agg, ok := strs[k]; ok {
-						agg.count += aCount
-						mergeStrAgg(agg, val)
-					} else {
-						agg := &distillStrAgg{
-							frequencies: make(map[string]int),
-							unplaced:    make(map[string]bool),
-							count:       aCount,
-						}
-						mergeStrAgg(agg, val)
-						strs[k] = agg
-					}
-				}
-			default:
-				// Track for constant detection
-				if prev, ok := constants[k]; ok {
-					if fmt.Sprintf("%v", prev) != fmt.Sprintf("%v", v) {
-						constants[k] = nil // not constant
-					}
-				} else {
-					constants[k] = v
-				}
-			}
-		}
-	}
-
-	result := make(map[string]interface{})
-
-	for k, agg := range nums {
-		result[k] = map[string]interface{}{
-			"min":   agg.min,
-			"max":   agg.max,
-			"sum":   agg.sum,
-			"count": agg.count,
-		}
-	}
-
-	for k, agg := range strs {
-		if agg.count == len(batch) && len(agg.frequencies) == 1 && len(agg.unplaced) == 0 {
-			// Constant string — keep as scalar
-			for v := range agg.frequencies {
-				result[k] = v
-			}
-		} else {
-			// Cap frequencies at 50 entries, keep highest
-			freqMap := make(map[string]interface{})
-			if len(agg.frequencies) <= 50 {
-				for v, c := range agg.frequencies {
-					freqMap[v] = c
-				}
-			} else {
-				type freqEntry struct {
-					val   string
-					count int
-				}
-				entries := make([]freqEntry, 0, len(agg.frequencies))
-				for v, c := range agg.frequencies {
-					entries = append(entries, freqEntry{v, c})
-				}
-				// Sort by count descending — simple selection of top 50
-				for i := 0; i < 50 && i < len(entries); i++ {
-					maxIdx := i
-					for j := i + 1; j < len(entries); j++ {
-						if entries[j].count > entries[maxIdx].count {
-							maxIdx = j
-						}
-					}
-					entries[i], entries[maxIdx] = entries[maxIdx], entries[i]
-					freqMap[entries[i].val] = entries[i].count
-				}
-			}
-
-			out := map[string]interface{}{
-				"frequencies": freqMap,
-				"count":       agg.count,
-			}
-			if len(agg.unplaced) > 0 {
-				unplaced := make([]string, 0, len(agg.unplaced))
-				for v := range agg.unplaced {
-					unplaced = append(unplaced, v)
-				}
-				out["unplaced"] = unplaced
-			}
-			result[k] = out
-		}
-	}
-
-	// Constants that weren't captured by nums or strs
-	for k, v := range constants {
-		if _, ok := result[k]; ok {
-			continue
-		}
-		if v != nil {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
-func hasAggKeys(m map[string]interface{}) bool {
-	_, hasMin := m["min"]
-	_, hasMax := m["max"]
-	_, hasSum := m["sum"]
-	return hasMin && hasMax && hasSum
-}
-
-func numAggFromMap(m map[string]interface{}) *distillNumAgg {
-	agg := &distillNumAgg{}
-	if v, ok := m["min"].(float64); ok {
-		agg.min = v
-	}
-	if v, ok := m["max"].(float64); ok {
-		agg.max = v
-	}
-	if v, ok := m["sum"].(float64); ok {
-		agg.sum = v
-	}
-	if v, ok := m["count"].(float64); ok {
-		agg.count = int(v)
-	}
-	return agg
-}
-
-// isStrAgg checks if a map is a string aggregate ({frequencies, count} or legacy {values, count}).
-func isStrAgg(m map[string]interface{}) bool {
-	_, hasCount := m["count"]
-	_, hasFreqs := m["frequencies"]
-	_, hasValues := m["values"]
-	return hasCount && (hasFreqs || hasValues)
-}
-
-// mergeStrAgg merges a string aggregate map into an existing distillStrAgg.
-// New-format {frequencies: {val: count}} merges by summing frequencies.
-// Old-format {values: [...]} passes values as unplaced (no fabricated counts).
-func mergeStrAgg(agg *distillStrAgg, m map[string]interface{}) {
-	if freqs, ok := m["frequencies"].(map[string]interface{}); ok {
-		for key, val := range freqs {
-			if c, ok := val.(float64); ok {
-				agg.frequencies[key] += int(c)
-			}
-		}
-	} else if vals, ok := m["values"].([]interface{}); ok {
-		// Old format — values without frequencies
-		for _, v := range vals {
-			if s, ok := v.(string); ok {
-				if _, inFreqs := agg.frequencies[s]; !inFreqs {
-					agg.unplaced[s] = true
-				}
-			}
-		}
-	}
-	// Merge unplaced from prior new-format aggregates
-	if unplaced, ok := m["unplaced"].([]interface{}); ok {
-		for _, v := range unplaced {
-			if s, ok := v.(string); ok {
-				if _, inFreqs := agg.frequencies[s]; !inFreqs {
-					agg.unplaced[s] = true
-				}
-			}
-		}
-	}
-}
-
-func mergeNumAgg(agg *distillNumAgg, m map[string]interface{}) {
-	if v, ok := m["min"].(float64); ok && v < agg.min {
-		agg.min = v
-	}
-	if v, ok := m["max"].(float64); ok && v > agg.max {
-		agg.max = v
-	}
-	if v, ok := m["sum"].(float64); ok {
-		agg.sum += v
-	}
-	if v, ok := m["count"].(float64); ok {
-		agg.count += int(v)
-	}
-}
-
-const histogramKeyBudget = 200
-
-// buildHistogram creates a temporal histogram from attestation timestamps.
-// Raw attestations get bucketed into 10min keys. Existing distill attestations
-// with _histogram get their histograms merged. Legacy sigmas without _histogram
-// contribute nothing (their _total is still counted — sum(histogram) <= _total).
-func buildHistogram(batch []*types.As) map[string]int {
-	histogram := make(map[string]int)
-
-	for _, as := range batch {
-		if as.Attributes != nil {
-			if existing, ok := as.Attributes["_histogram"]; ok {
-				if histMap, ok := existing.(map[string]interface{}); ok {
-					for key, val := range histMap {
-						if count, ok := val.(float64); ok {
-							histogram[key] += int(count)
-						}
-					}
-					continue
-				}
-			}
-		}
-
-		// Skip distill attestations without histogram (legacy unplaced)
-		if as.Attributes != nil {
-			if _, ok := as.Attributes["_distill"]; ok {
-				continue
-			}
-		}
-
-		// Raw attestation — bucket its timestamp
-		key := timestampTo10minKey(as.Timestamp)
-		histogram[key]++
-	}
-
-	return coarsenHistogram(histogram)
-}
-
-// timestampTo10minKey converts a timestamp to a 10-minute bucket key.
-// Format: "2026-05-13T14:10" (truncated to 10min boundary).
-func timestampTo10minKey(t time.Time) string {
-	t = t.UTC()
-	minute := (t.Minute() / 10) * 10
-	return fmt.Sprintf("%sT%02d:%02d", t.Format("2006-01-02"), t.Hour(), minute)
-}
-
-// coarsenHistogram collapses the finest tier if key count exceeds budget.
-//
-// Tiers by key length:
-//   - 16 chars: 10min ("2026-05-13T14:10")
-//   - 13 chars: hourly ("2026-05-13T14")
-//   - 10 chars: daily  ("2026-05-13")
-//   - 8 chars:  weekly ("2026-W20")
-func coarsenHistogram(histogram map[string]int) map[string]int {
-	if len(histogram) <= histogramKeyBudget {
-		return histogram
-	}
-
-	// Find finest tier (longest key)
-	maxLen := 0
-	for key := range histogram {
-		if len(key) > maxLen {
-			maxLen = len(key)
-		}
-	}
-
-	coarsened := make(map[string]int)
-	for key, count := range histogram {
-		if len(key) == maxLen {
-			coarsened[coarsenKey(key)] += count
-		} else {
-			coarsened[key] += count
-		}
-	}
-
-	if len(coarsened) > histogramKeyBudget {
-		return coarsenHistogram(coarsened)
-	}
-	return coarsened
-}
-
-// coarsenKey collapses a histogram key to the next coarser tier.
-//
-//	"2026-05-13T14:10" (10min) → "2026-05-13T14" (hourly)
-//	"2026-05-13T14"    (hourly) → "2026-05-13"    (daily)
-//	"2026-05-13"       (daily)  → ISO week key     (weekly)
-func coarsenKey(key string) string {
-	switch len(key) {
-	case 16:
-		return key[:13] // 10min → hourly: drop ":MM"
-	case 13:
-		return key[:10] // hourly → daily: drop "THH"
-	case 10:
-		// daily → weekly
-		t, err := time.Parse("2006-01-02", key)
-		if err != nil {
-			return key
-		}
-		year, week := t.ISOWeek()
-		return fmt.Sprintf("%d-W%02d", year, week)
-	default:
-		return key
-	}
-}
-
-// setupDistillSchedule registers the distill handler and auto-creates
-// a Pulse schedule if distill.interval_seconds is set.
 func (s *QNTXServer) setupDistillSchedule(cfg *appcfg.Config) {
-	if cfg.Distill.IntervalSeconds == nil {
+	if cfg.Distill.IntervalSeconds == nil || *cfg.Distill.IntervalSeconds <= 0 {
 		return
 	}
-	interval := *cfg.Distill.IntervalSeconds
-	if interval <= 0 {
-		return
-	}
+	intervalSeconds := *cfg.Distill.IntervalSeconds
 
-	maxAgeHours := cfg.Distill.MaxAgeHours
-	if maxAgeHours <= 0 {
-		maxAgeHours = 720
+	maxAge := time.Duration(cfg.Distill.MaxAgeHours) * time.Hour
+	if maxAge <= 0 {
+		maxAge = 54 * time.Hour
 	}
 	batchSize := cfg.Distill.BatchSize
 	if batchSize <= 0 {
@@ -835,41 +74,25 @@ func (s *QNTXServer) setupDistillSchedule(cfg *appcfg.Config) {
 	}
 
 	handler := &distillHandler{
-		db:        s.db,
-		atsStore:  s.atsStore,
-		maxAge:    time.Duration(maxAgeHours) * time.Hour,
+		server:    s,
+		maxAge:    maxAge,
 		batchSize: batchSize,
-		dryRun:    cfg.Distill.DryRun,
 		logger:    s.logger.Named("distill"),
 	}
 
 	registry := s.daemon.Registry()
 	registry.Register(handler)
-	s.logger.Infow("Registered distill handler",
-		"max_age_hours", maxAgeHours,
-		"batch_size", batchSize,
-		"dry_run", cfg.Distill.DryRun)
 
 	schedStore := schedule.NewStore(s.db)
 
-	// Check for existing schedule to avoid duplicates on restart
+	// Check for existing schedule
 	existing, err := schedStore.ListAllScheduledJobs()
 	if err != nil {
-		s.logger.Errorw("Failed to list scheduled jobs for distill idempotency check",
-			"error", err)
+		s.logger.Errorw("Failed to list scheduled jobs for distill", "error", err)
 		return
 	}
 	for _, j := range existing {
 		if j.HandlerName == distillHandlerName && j.State == schedule.StateActive {
-			if j.IntervalSeconds != interval {
-				if err := schedStore.UpdateJobInterval(j.ID, interval); err != nil {
-					s.logger.Errorw("Failed to update distill schedule interval",
-						"job_id", j.ID, "error", err)
-				} else {
-					s.logger.Infow("Updated distill schedule interval",
-						"job_id", j.ID, "interval_seconds", interval)
-				}
-			}
 			return
 		}
 	}
@@ -878,19 +101,17 @@ func (s *QNTXServer) setupDistillSchedule(cfg *appcfg.Config) {
 	job := &schedule.Job{
 		ID:              fmt.Sprintf("SPJ_distill_%d", now.Unix()),
 		HandlerName:     distillHandlerName,
-		IntervalSeconds: interval,
+		IntervalSeconds: intervalSeconds,
 		State:           schedule.StateActive,
-		NextRunAt:       &now, // Run immediately on first startup
+		NextRunAt:       &now,
 	}
 
 	if err := schedStore.CreateJob(job); err != nil {
-		s.logger.Errorw("Failed to create distill schedule",
-			"interval_seconds", interval, "error", err)
+		s.logger.Errorw("Failed to create distill schedule", "error", err)
 		return
 	}
 	s.logger.Infow("Auto-created distill schedule",
-		"job_id", job.ID,
-		"interval_seconds", interval,
-		"max_age_hours", maxAgeHours,
+		"interval_seconds", intervalSeconds,
+		"max_age_hours", cfg.Distill.MaxAgeHours,
 		"batch_size", batchSize)
 }

--- a/server/distill_pulse_test.go
+++ b/server/distill_pulse_test.go
@@ -2,298 +2,89 @@ package server
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	qntxtest "github.com/teranos/QNTX/internal/testing"
 	"github.com/teranos/QNTX/pulse/async"
 	"go.uber.org/zap"
 )
 
-// insertTestAttestation inserts an attestation with RFC3339-formatted timestamp
-// matching production format. The sqlTestStore uses Go's time.Time serialization
-// which doesn't sort correctly against RFC3339 in SQLite string comparisons.
-func insertTestAttestation(t *testing.T, db *sql.DB, id string, subjects, predicates []string, actor, ctx string, ts time.Time, source string, attrs map[string]interface{}) {
-	t.Helper()
-	subJSON, _ := json.Marshal(subjects)
-	predJSON, _ := json.Marshal(predicates)
-	actJSON, _ := json.Marshal([]string{actor})
-	ctxJSON, _ := json.Marshal([]string{ctx})
-	attrJSON := []byte("{}")
-	if attrs != nil {
-		attrJSON, _ = json.Marshal(attrs)
-	}
-	_, err := db.Exec(
-		`INSERT INTO attestations (id, subjects, predicates, actors, contexts, timestamp, source, attributes)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, string(subJSON), string(predJSON), string(actJSON), string(ctxJSON),
-		ts.UTC().Format(time.RFC3339), source, string(attrJSON),
-	)
-	require.NoError(t, err, "Failed to insert test attestation %s", id)
+type mockDistiller struct {
+	distilled     int
+	sigmasCreated int
+	skipped       int
+	err           error
+	called        bool
+	cutoff        string
+	batchSize     int
 }
 
-func TestDistillHandler_BasicCycle(t *testing.T) {
-	store, db := qntxtest.CreateTestStore(t)
-	logger := zap.NewNop().Sugar()
+func (m *mockDistiller) AgeDistill(cutoffRFC3339 string, batchSize int) (int, int, int, error) {
+	m.called = true
+	m.cutoff = cutoffRFC3339
+	m.batchSize = batchSize
+	return m.distilled, m.sigmasCreated, m.skipped, m.err
+}
 
+func TestDistillHandler_CallsDistiller(t *testing.T) {
+	mock := &mockDistiller{
+		distilled:     10,
+		sigmasCreated: 1,
+		skipped:       2,
+	}
+
+	srv := &QNTXServer{ageDistiller: mock}
 	h := &distillHandler{
-		db:        db,
-		atsStore:  store,
+		server:    srv,
 		maxAge:    1 * time.Hour,
 		batchSize: 500,
-		logger:    logger,
-	}
-
-	oldTime := time.Now().UTC().Add(-2 * time.Hour)
-	for i := 0; i < 10; i++ {
-		insertTestAttestation(t, db,
-			fmt.Sprintf("OLD_%d", i),
-			[]string{fmt.Sprintf("subject_%d", i)},
-			[]string{"crawl-stage-changed"},
-			"crawler", "network",
-			oldTime.Add(time.Duration(i)*time.Minute),
-			"test",
-			map[string]interface{}{"stage": "connecting", "elapsed_ms": float64(i * 100)},
-		)
-	}
-
-	recentTime := time.Now().UTC().Add(1 * time.Hour)
-	for i := 0; i < 3; i++ {
-		insertTestAttestation(t, db,
-			fmt.Sprintf("RECENT_%d", i),
-			[]string{"recent_subject"},
-			[]string{"crawl-stage-changed"},
-			"crawler", "network",
-			recentTime.Add(time.Duration(i)*time.Minute),
-			"test", nil,
-		)
+		logger:    zap.NewNop().Sugar(),
 	}
 
 	err := h.Execute(context.Background(), &async.Job{})
 	require.NoError(t, err)
+	assert.True(t, mock.called)
+	assert.Equal(t, 500, mock.batchSize)
 
-	// Original old attestations should be deleted
-	for i := 0; i < 10; i++ {
-		assert.False(t, store.AttestationExists(fmt.Sprintf("OLD_%d", i)),
-			"Old attestation %d should be deleted", i)
-	}
-
-	// Recent attestations should survive
-	for i := 0; i < 3; i++ {
-		assert.True(t, store.AttestationExists(fmt.Sprintf("RECENT_%d", i)),
-			"Recent attestation %d should survive", i)
-	}
-
-	// One distill attestation should exist
-	var distillCount int
-	db.QueryRow("SELECT COUNT(*) FROM attestations WHERE source = 'distill'").Scan(&distillCount)
-	assert.Equal(t, 1, distillCount, "Should create exactly 1 distill attestation for 1 predicate group")
-
-	// Verify distill attestation metadata
-	var attrsJSON string
-	db.QueryRow("SELECT attributes FROM attestations WHERE source = 'distill'").Scan(&attrsJSON)
-
-	var attrs map[string]interface{}
-	require.NoError(t, json.Unmarshal([]byte(attrsJSON), &attrs))
-
-	assert.Equal(t, true, attrs["_distill"])
-	assert.Equal(t, float64(10), attrs["_count"])
-	assert.Equal(t, float64(10), attrs["_total"])  // 10 raw attestations, no prior distills
-	assert.Equal(t, float64(10), attrs["_subjects_count"])
-	assert.NotEmpty(t, attrs["_first_seen"])
-	assert.NotEmpty(t, attrs["_last_seen"])
-	assert.NotEmpty(t, attrs["_version"])
-	assert.NotEmpty(t, attrs["_rust_version"])
-
-	// Verify attribute merging: elapsed_ms should be aggregated
-	elapsed, ok := attrs["elapsed_ms"].(map[string]interface{})
-	require.True(t, ok, "elapsed_ms should be a numeric aggregate")
-	assert.Equal(t, float64(0), elapsed["min"])
-	assert.Equal(t, float64(900), elapsed["max"])
-	assert.Equal(t, float64(10), elapsed["count"])
+	// Cutoff should be approximately 1 hour ago in RFC3339
+	cutoff, parseErr := time.Parse(time.RFC3339, mock.cutoff)
+	require.NoError(t, parseErr)
+	assert.WithinDuration(t, time.Now().UTC().Add(-1*time.Hour), cutoff, 5*time.Second)
 }
 
-func TestDistillHandler_MultiplePredicateGroups(t *testing.T) {
-	store, db := qntxtest.CreateTestStore(t)
-	logger := zap.NewNop().Sugar()
-
+func TestDistillHandler_NilDistiller(t *testing.T) {
+	srv := &QNTXServer{} // ageDistiller is nil
 	h := &distillHandler{
-		db:        db,
-		atsStore:  store,
+		server:    srv,
 		maxAge:    1 * time.Hour,
 		batchSize: 500,
-		logger:    logger,
-	}
-
-	oldTime := time.Now().UTC().Add(-2 * time.Hour)
-
-	for i := 0; i < 5; i++ {
-		insertTestAttestation(t, db,
-			fmt.Sprintf("ANN_%d", i),
-			[]string{fmt.Sprintf("node_%d", i)},
-			[]string{"announced"},
-			"crawler", "network",
-			oldTime.Add(time.Duration(i)*time.Minute),
-			"test", nil,
-		)
-	}
-
-	for i := 0; i < 3; i++ {
-		insertTestAttestation(t, db,
-			fmt.Sprintf("PATH_%d", i),
-			[]string{fmt.Sprintf("path_%d", i)},
-			[]string{"path-found"},
-			"crawler", "network",
-			oldTime.Add(time.Duration(i)*time.Minute),
-			"test", nil,
-		)
+		logger:    zap.NewNop().Sugar(),
 	}
 
 	err := h.Execute(context.Background(), &async.Job{})
 	require.NoError(t, err)
-
-	var distillCount int
-	db.QueryRow("SELECT COUNT(*) FROM attestations WHERE source = 'distill'").Scan(&distillCount)
-	assert.Equal(t, 2, distillCount, "Should create 2 distill attestations (one per predicate)")
-
-	var remaining int
-	db.QueryRow("SELECT COUNT(*) FROM attestations WHERE source = 'test'").Scan(&remaining)
-	assert.Equal(t, 0, remaining, "All originals should be deleted")
 }
 
-func TestDistillHandler_MetaDistillation(t *testing.T) {
-	store, db := qntxtest.CreateTestStore(t)
-	logger := zap.NewNop().Sugar()
-
-	h := &distillHandler{
-		db:        db,
-		atsStore:  store,
-		maxAge:    1 * time.Hour,
-		batchSize: 500,
-		logger:    logger,
+func TestDistillHandler_PropagatesError(t *testing.T) {
+	mock := &mockDistiller{
+		err: assert.AnError,
 	}
 
-	oldTime := time.Now().UTC().Add(-2 * time.Hour)
-
-	// Insert an old distill attestation (from a previous distill cycle)
-	insertTestAttestation(t, db,
-		"AS-distill-old-1",
-		[]string{"distill:announced"},
-		[]string{"distill:announced"},
-		"crawler", "network",
-		oldTime, "distill",
-		map[string]interface{}{
-			"_distill":        true,
-			"_count":          float64(5),
-			"_first_seen":     oldTime.Add(-1 * time.Hour).UTC().Format(time.RFC3339),
-			"_last_seen":      oldTime.UTC().Format(time.RFC3339),
-			"_subjects_count": float64(5),
-		},
-	)
-
-	// Insert some regular old attestations with same predicate
-	for i := 0; i < 3; i++ {
-		insertTestAttestation(t, db,
-			fmt.Sprintf("REG_%d", i),
-			[]string{fmt.Sprintf("node_%d", i)},
-			[]string{"distill:announced"},
-			"crawler", "network",
-			oldTime.Add(time.Duration(i)*time.Minute),
-			"test", nil,
-		)
+	srv := &QNTXServer{ageDistiller: mock}
+	h := &distillHandler{
+		server:    srv,
+		maxAge:    2 * time.Hour,
+		batchSize: 100,
+		logger:    zap.NewNop().Sugar(),
 	}
 
 	err := h.Execute(context.Background(), &async.Job{})
-	require.NoError(t, err)
-
-	// Old distill attestation should be gone (meta-distilled)
-	assert.False(t, store.AttestationExists("AS-distill-old-1"))
-
-	// Regular attestations should be gone
-	for i := 0; i < 3; i++ {
-		assert.False(t, store.AttestationExists(fmt.Sprintf("REG_%d", i)))
-	}
-
-	// One new distill attestation should exist
-	var attrsJSON string
-	db.QueryRow("SELECT attributes FROM attestations WHERE source = 'distill'").Scan(&attrsJSON)
-
-	var attrs map[string]interface{}
-	require.NoError(t, json.Unmarshal([]byte(attrsJSON), &attrs))
-	assert.Equal(t, float64(4), attrs["_count"])  // batch size: 1 old distill + 3 regular
-	assert.Equal(t, float64(8), attrs["_total"])   // transitive: 5 (from old distill _count) + 3 regular
-
-	// Predicate should not stack distill: prefix
-	var predJSON string
-	db.QueryRow("SELECT predicates FROM attestations WHERE source = 'distill'").Scan(&predJSON)
-	assert.Contains(t, predJSON, "distill:announced")
-	assert.NotContains(t, predJSON, "distill:distill:")
+	assert.ErrorIs(t, err, assert.AnError)
 }
 
-func TestDistillHandler_DryRun(t *testing.T) {
-	store, db := qntxtest.CreateTestStore(t)
-	logger := zap.NewNop().Sugar()
-
-	h := &distillHandler{
-		db:        db,
-		atsStore:  store,
-		maxAge:    1 * time.Hour,
-		batchSize: 500,
-		dryRun:    true,
-		logger:    logger,
-	}
-
-	oldTime := time.Now().UTC().Add(-2 * time.Hour)
-	for i := 0; i < 5; i++ {
-		insertTestAttestation(t, db,
-			fmt.Sprintf("DRY_%d", i),
-			[]string{"sub"},
-			[]string{"test-pred"},
-			"actor", "ctx",
-			oldTime.Add(time.Duration(i)*time.Minute),
-			"test", nil,
-		)
-	}
-
-	err := h.Execute(context.Background(), &async.Job{})
-	require.NoError(t, err)
-
-	var count int
-	db.QueryRow("SELECT COUNT(*) FROM attestations").Scan(&count)
-	assert.Equal(t, 5, count, "Dry run should not delete anything")
-
-	var distillCount int
-	db.QueryRow("SELECT COUNT(*) FROM attestations WHERE source = 'distill'").Scan(&distillCount)
-	assert.Equal(t, 0, distillCount)
-}
-
-func TestDistillHandler_GhostRowCleanup(t *testing.T) {
-	_, db := qntxtest.CreateTestStore(t)
-	logger := zap.NewNop().Sugar()
-
-	db.Exec("INSERT INTO attestations (id, subjects, predicates, actors, contexts, timestamp, source, attributes) VALUES (NULL, '[]', '[]', '[]', '[]', '0', 'ghost', '{}')")
-	db.Exec("INSERT INTO attestations (id, subjects, predicates, actors, contexts, timestamp, source, attributes) VALUES ('', '[]', '[]', '[]', '[]', '0001-01-01', 'ghost', '{}')")
-
-	var ghostCount int
-	db.QueryRow("SELECT COUNT(*) FROM attestations WHERE id IS NULL OR id = '' OR timestamp < '0002'").Scan(&ghostCount)
-	require.Equal(t, 2, ghostCount, "Ghost rows should exist before cleanup")
-
-	h := &distillHandler{
-		db:        db,
-		atsStore:  nil,
-		maxAge:    1 * time.Hour,
-		batchSize: 500,
-		logger:    logger,
-	}
-
-	err := h.Execute(context.Background(), &async.Job{})
-	require.NoError(t, err)
-
-	db.QueryRow("SELECT COUNT(*) FROM attestations WHERE id IS NULL OR id = '' OR timestamp < '0002'").Scan(&ghostCount)
-	assert.Equal(t, 0, ghostCount, "Ghost rows should be cleaned up")
+func TestDistillHandler_Name(t *testing.T) {
+	h := &distillHandler{}
+	assert.Equal(t, "distill", h.Name())
 }

--- a/server/embeddings/handler.go
+++ b/server/embeddings/handler.go
@@ -45,6 +45,7 @@ type GroundWriteFunc func(dbPath string, as *types.As, logger *zap.SugaredLogger
 // Handler handles HTTP requests for the embedding service.
 type Handler struct {
 	DB           *sql.DB
+	ReadDB       *sql.DB         // read-only connection, no write lock contention
 	Store        *storage.EmbeddingStore
 	Service      Service
 	ATSStore     ats.AttestationStore
@@ -54,6 +55,14 @@ type Handler struct {
 	Invalidator  func()          // cluster cache invalidation callback
 	GroundDBPath string          // for cluster lifecycle attestations
 	GroundWrite  GroundWriteFunc // writes deferred news to Ground's DB
+}
+
+// readDB returns ReadDB if set, otherwise falls back to DB.
+func (h *Handler) readDB() *sql.DB {
+	if h.ReadDB != nil {
+		return h.ReadDB
+	}
+	return h.DB
 }
 
 // getAttestationByID retrieves a single attestation through the attestation store.

--- a/server/embeddings/handlers.go
+++ b/server/embeddings/handlers.go
@@ -557,12 +557,12 @@ func (h *Handler) HandleEmbeddingInfo(w http.ResponseWriter, r *http.Request) {
 		lag := &EmbeddingLag{}
 		var oldest, newest string
 		// Oldest embedded attestation — indexed scan on embeddings.created_at
-		err := h.DB.QueryRow(`SELECT MIN(created_at) FROM embeddings`).Scan(&oldest)
+		err := h.readDB().QueryRow(`SELECT MIN(created_at) FROM embeddings`).Scan(&oldest)
 		if err == nil && oldest != "" {
 			lag.OldestEmbedding = oldest
 		}
 		// Newest attestation — indexed scan on attestations.created_at
-		err = h.DB.QueryRow(`SELECT MAX(created_at) FROM attestations`).Scan(&newest)
+		err = h.readDB().QueryRow(`SELECT MAX(created_at) FROM attestations`).Scan(&newest)
 		if err == nil && newest != "" {
 			lag.NewestAttestation = newest
 		}
@@ -612,7 +612,7 @@ func (h *Handler) HandleUnembeddedPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	rows, err := h.DB.Query(`
+	rows, err := h.readDB().Query(`
 		SELECT a.id FROM attestations a
 		LEFT JOIN embeddings e ON e.source_type = 'attestation' AND e.source_id = a.id
 		WHERE e.id IS NULL

--- a/server/init.go
+++ b/server/init.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/teranos/QNTX/ai/tracker"
 	appcfg "github.com/teranos/QNTX/am"
+	qntxdb "github.com/teranos/QNTX/db"
 	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/signing"
 	"github.com/teranos/QNTX/ats/storage"
@@ -374,8 +375,16 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 	// Initialize embedding service for semantic search (optional)
 	server.groundDBPath = deps.config.GroundDBPath
 	server.SetupEmbeddingService()
+
+	// Open a read-only connection for embedding reads — avoids write lock
+	// contention from _txlock=immediate on the primary connection.
+	readOnlyDB, err := qntxdb.OpenReadOnly(dbPath, serverLogger)
+	if err != nil {
+		serverLogger.Warnw("Failed to open read-only DB for embeddings, falling back to primary", "error", err)
+	}
 	server.embeddingsHandler = &serverembeddings.Handler{
 		DB:           db,
+		ReadDB:       readOnlyDB,
 		Store:        server.embeddingStore,
 		Service:      server.embeddingService,
 		ATSStore:     atsStore,

--- a/server/init.go
+++ b/server/init.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/teranos/QNTX/ai/tracker"
 	appcfg "github.com/teranos/QNTX/am"
-	qntxdb "github.com/teranos/QNTX/db"
 	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/signing"
 	"github.com/teranos/QNTX/ats/storage"
@@ -376,15 +375,13 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 	server.groundDBPath = deps.config.GroundDBPath
 	server.SetupEmbeddingService()
 
-	// Open a read-only connection for embedding reads — avoids write lock
-	// contention from _txlock=immediate on the primary connection.
-	readOnlyDB, err := qntxdb.OpenReadOnly(dbPath, serverLogger)
-	if err != nil {
-		serverLogger.Warnw("Failed to open read-only DB for embeddings, falling back to primary", "error", err)
-	}
+	// Use the primary rustsqlite connection for reads — the Rust driver
+	// separates reads/writes internally (muRead/muWrite), no need for a
+	// separate mattn read-only connection (which caused SIGBUS crashes from
+	// concurrent CGO calls via different drivers on the same file).
 	server.embeddingsHandler = &serverembeddings.Handler{
 		DB:           db,
-		ReadDB:       readOnlyDB,
+		ReadDB:       db,
 		Store:        server.embeddingStore,
 		Service:      server.embeddingService,
 		ATSStore:     atsStore,
@@ -403,6 +400,7 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 		}
 	}
 	server.setupDistillSchedule(deps.config)
+	server.setupCheckpointSchedule(deps.config)
 	server.setupEmbeddingReclusterSchedule(deps.config)
 	server.setupEmbeddingReprojectSchedule(deps.config)
 	server.setupClusterLabelSchedule(deps.config)

--- a/server/lifecycle.go
+++ b/server/lifecycle.go
@@ -221,6 +221,9 @@ func (s *QNTXServer) Stop() error {
 	if s.watcherDB != nil {
 		s.watcherDB.Close()
 	}
+	if s.embeddingsHandler != nil && s.embeddingsHandler.ReadDB != nil {
+		s.embeddingsHandler.ReadDB.Close()
+	}
 
 	// Clear service providers before killing plugins — observers check HasProvider()
 	// and will skip routing once providers are cleared.

--- a/server/routing.go
+++ b/server/routing.go
@@ -87,6 +87,7 @@ func (s *QNTXServer) setupHTTPRoutes() {
 	http.HandleFunc("/api/config", wrap(s.HandleConfig))
 	http.HandleFunc("/api/dev", wrap(s.HandleDevMode))                                              // Dev mode status
 	http.HandleFunc("/api/debug", wrap(s.HandleDebug))                                              // Browser console debugging (dev mode only)
+	http.HandleFunc("/api/crash-test", wrap(s.HandleCrashTest))                                     // Flight recorder crash test (dev mode only)
 	http.HandleFunc("/api/prose", wrap(s.HandleProse))                                              // Prose content tree
 	http.HandleFunc("/api/prose/", wrap(s.HandleProseContent))                                      // Individual prose files
 	http.HandleFunc("/api/pulse/executions/", wrap(s.HandlePulseExecution))                         // Individual execution (GET) and logs (GET /logs)

--- a/server/server.go
+++ b/server/server.go
@@ -108,6 +108,7 @@ type QNTXServer struct {
 	watcherDB                   *sql.DB                // Separate DB connection for watcher engine (avoids RustStore contention)
 	walCheckpointer             WALCheckpointer        // Rust-side WAL checkpoint (closes read conns, checkpoints, reopens)
 	ageDistiller                AgeDistiller           // Rust-side age distillation (fold old attestations into sigmas)
+	writeLockInspector          WriteLockInspector     // Rust-side write lock holder tracking
 	onReady                     func()                 // Called once when server is fully ready (routes, DB, listeners)
 
 	// Cached database stats — refreshed every 30s in the background.
@@ -123,6 +124,11 @@ func (s *QNTXServer) SetWALCheckpointer(c WALCheckpointer) {
 // SetAgeDistiller sets the Rust-side age distiller (fold old attestations into sigmas).
 func (s *QNTXServer) SetAgeDistiller(d AgeDistiller) {
 	s.ageDistiller = d
+}
+
+// SetWriteLockInspector sets the write lock inspector for diagnostics.
+func (s *QNTXServer) SetWriteLockInspector(w WriteLockInspector) {
+	s.writeLockInspector = w
 }
 
 

--- a/server/server.go
+++ b/server/server.go
@@ -106,12 +106,25 @@ type QNTXServer struct {
 	embeddingStats              schedule.EmbeddingStats // drained by ticker for periodic summary
 	groundDBPath                string
 	watcherDB                   *sql.DB                // Separate DB connection for watcher engine (avoids RustStore contention)
+	walCheckpointer             WALCheckpointer        // Rust-side WAL checkpoint (closes read conns, checkpoints, reopens)
+	ageDistiller                AgeDistiller           // Rust-side age distillation (fold old attestations into sigmas)
 	onReady                     func()                 // Called once when server is fully ready (routes, DB, listeners)
 
 	// Cached database stats — refreshed every 30s in the background.
 	// Glyph opens return instantly from cache instead of blocking on 4+ queries.
 	dbStatsCache atomic.Pointer[cachedDBStats]
 }
+
+// SetWALCheckpointer sets the Rust-side WAL checkpointer (closes read conns, checkpoints, reopens).
+func (s *QNTXServer) SetWALCheckpointer(c WALCheckpointer) {
+	s.walCheckpointer = c
+}
+
+// SetAgeDistiller sets the Rust-side age distiller (fold old attestations into sigmas).
+func (s *QNTXServer) SetAgeDistiller(d AgeDistiller) {
+	s.ageDistiller = d
+}
+
 
 // handleClientRegister handles a new client connection
 func (s *QNTXServer) handleClientRegister(client *Client) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -711,7 +711,7 @@ func TestGetDaemon(t *testing.T) {
 	// Verify registry has only built-in handlers (e.g. distill if configured)
 	handlers := registry.Names()
 	for _, h := range handlers {
-		if h != "distill" {
+		if h != "distill" && h != "wal-checkpoint" {
 			t.Errorf("Unexpected handler registered: %s", h)
 		}
 	}

--- a/server/watcher_handlers.go
+++ b/server/watcher_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/teranos/QNTX/ats/storage"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/ats/watcher"
+	"github.com/teranos/QNTX/db/rustdriver"
 	"github.com/teranos/QNTX/errors"
 	grpcplugin "github.com/teranos/QNTX/plugin/grpc"
 	serverembeddings "github.com/teranos/QNTX/server/embeddings"
@@ -528,6 +529,7 @@ func (s *QNTXServer) initWatcherEngine() error {
 	}
 	watcherDB.SetMaxOpenConns(4)
 	s.watcherDB = watcherDB
+	rustdriver.SetCaller("watcher-db")
 
 	// Pass atsStore as AttestationReader so watcher queries go through Rust's connection,
 	// eliminating dual-driver access to the attestations table.

--- a/server/watcher_handlers.go
+++ b/server/watcher_handlers.go
@@ -664,7 +664,7 @@ func (s *QNTXServer) runDilationLoop() {
 	}
 
 	logDilation := func(d, memPct, cpuPct float64, tag string) {
-		s.logger.Infof("\n%s", formatDist(d, memPct, cpuPct, tag))
+		s.logger.Debugf("\n%s", formatDist(d, memPct, cpuPct, tag))
 		resetDist()
 	}
 

--- a/web/ts/db-glyph.ts
+++ b/web/ts/db-glyph.ts
@@ -236,8 +236,8 @@ function renderDbStats(): void {
     }
 
     // -- Performance --
-    if (dbStats.performance) {
-        renderPerformanceSection(sectionPerformance, dbStats.performance);
+    if (dbStats.performance || dbStats.live) {
+        renderPerformanceSection(sectionPerformance, dbStats.performance, dbStats.live);
     } else {
         sectionPerformance.innerHTML = '';
     }
@@ -496,8 +496,76 @@ function formatMs(ms: number): string {
     return `${(ms / 1000).toFixed(1)}s`;
 }
 
-function renderPerformanceSection(container: HTMLElement, perf: PerfData): void {
-    if (!perf.current || perf.current.length === 0) return;
+interface LiveStatus {
+    write_lock?: { holder: string; held_ms: number };
+    wal_bytes?: number;
+    db_bytes?: number;
+    dilation?: number;
+    mem_pct?: number;
+    cpu_pct?: number;
+}
+
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}K`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GB`;
+}
+
+function renderLiveStatus(live: LiveStatus): string {
+    const lines: string[] = [];
+
+    // Write lock
+    const wl = live.write_lock;
+    if (wl) {
+        const heldSec = wl.held_ms / 1000;
+        const color = heldSec > 30 ? '#ef4444' : heldSec > 5 ? '#f59e0b' : '#4ade80';
+        lines.push(`<div style="display: flex; align-items: center; gap: 6px; font-size: 10px;">
+            <span style="width: 6px; height: 6px; border-radius: 50%; background: ${color};"></span>
+            <span style="color: #e2e8f0;">write: <b>${wl.holder}</b> ${formatMs(wl.held_ms)}</span>
+        </div>`);
+    } else {
+        lines.push(`<div style="display: flex; align-items: center; gap: 6px; font-size: 10px;">
+            <span style="width: 6px; height: 6px; border-radius: 50%; background: #4ade80;"></span>
+            <span style="color: #64748b;">write: idle</span>
+        </div>`);
+    }
+
+    // Dilation + pressure
+    if (live.dilation != null) {
+        const d = live.dilation;
+        const color = d >= 1.0 ? '#4ade80' : d >= 0.5 ? '#f59e0b' : '#ef4444';
+        const mem = live.mem_pct != null ? `${live.mem_pct.toFixed(0)}% mem` : '';
+        const cpu = live.cpu_pct != null ? `${live.cpu_pct.toFixed(0)}% cpu` : '';
+        const pressure = [mem, cpu].filter(Boolean).join(' · ');
+        lines.push(`<div style="font-size: 10px; color: #94a3b8;">
+            dilation <span style="color: ${color};">${d.toFixed(2)}x</span>${pressure ? ` · ${pressure}` : ''}
+        </div>`);
+    }
+
+    // DB + WAL size
+    const sizes: string[] = [];
+    if (live.db_bytes != null) sizes.push(`db ${formatBytes(live.db_bytes)}`);
+    if (live.wal_bytes != null) sizes.push(`wal ${formatBytes(live.wal_bytes)}`);
+    if (sizes.length > 0) {
+        lines.push(`<div style="font-size: 10px; color: #64748b;">${sizes.join(' · ')}</div>`);
+    }
+
+    return lines.join('');
+}
+
+function renderPerformanceSection(container: HTMLElement, perf: PerfData | null, live?: LiveStatus): void {
+    let liveHTML = '';
+    if (live) {
+        liveHTML = `<div style="margin-bottom: 8px;">${renderLiveStatus(live)}</div>`;
+    }
+
+    if (!perf || !perf.current || perf.current.length === 0) {
+        if (liveHTML) {
+            container.innerHTML = `<div style="padding: 8px 0; border-bottom: 1px solid var(--border-color, #333);">${liveHTML}</div>`;
+        }
+        return;
+    }
 
     const maxVal = Math.max(...perf.current.map(e => e.max));
     if (maxVal === 0) return;
@@ -539,6 +607,7 @@ function renderPerformanceSection(container: HTMLElement, perf: PerfData): void 
 
     container.innerHTML = `
         <div style="padding: 8px 0; border-bottom: 1px solid var(--border-color, #333);">
+            ${liveHTML}
             <span class="glyph-label" style="font-size: 11px;">Performance (5m windows):</span>
             <div style="margin-top: 4px;">${rows}</div>
         </div>

--- a/web/ts/embeddings-glyph.ts
+++ b/web/ts/embeddings-glyph.ts
@@ -24,6 +24,8 @@ let embeddingsInfo: {
 } | null = null;
 let embeddingsReembedding = false;
 let embeddingsClustering = false;
+let embeddingsResultMsg = '';
+let embeddingsClusterResultMsg = '';
 let embeddingsProjecting = false;
 type ProjectionPoint = { id: string; source_id: string; method: string; model: string; x: number; y: number; z?: number; cluster_id: number };
 let projectionsData: Record<string, ProjectionPoint[]> = {};
@@ -592,7 +594,7 @@ function renderEmbeddings(): void {
                         ${embeddingsReembedding ? 'disabled' : ''}>
                         ${embeddingsReembedding ? 'Embedding...' : `Embed ${Math.min(1000, unembedded)} oldest of ${unembedded} unembedded`}
                     </button>
-                    <div class="emb-result" style="margin-top:6px;font-size:12px;opacity:0.7"></div>
+                    <div class="emb-result" style="margin-top:6px;font-size:12px;opacity:0.7">${embeddingsResultMsg}</div>
                 </div>
             `;
             sectionReembed.querySelector('.emb-reembed-btn')?.addEventListener('click', reembedAll);
@@ -671,7 +673,7 @@ function renderEmbeddings(): void {
                             ${embeddingsClustering ? 'Clustering...' : 'Recompute'}
                         </button>
                     </div>
-                    <div class="emb-cluster-result" style="margin-top:6px;font-size:12px;opacity:0.7"></div>
+                    <div class="emb-cluster-result" style="margin-top:6px;font-size:12px;opacity:0.7">${embeddingsClusterResultMsg}</div>
                 </div>
             `;
             sectionCluster.querySelector('.emb-cluster-btn')?.addEventListener('click', () => recluster());
@@ -1205,32 +1207,34 @@ async function reembedAll(): Promise<void> {
     if (embeddingsReembedding || !embeddingsInfo?.available) return;
 
     embeddingsReembedding = true;
+    embeddingsResultMsg = '';
     renderEmbeddings();
-
-    const resultEl = embeddingsElement?.querySelector('.emb-result');
 
     try {
         // Fetch a page of unembedded IDs from the paginated endpoint
         const pageResp = await apiFetch('/api/embeddings/unembedded?limit=1000');
         const page = await pageResp.json() as { ids: string[]; count: number };
-        if (page.ids.length === 0) return;
+        if (page.ids.length === 0) {
+            embeddingsResultMsg = 'No unembedded attestations';
+            return;
+        }
 
         const resp = await apiFetch('/api/embeddings/batch', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ attestation_ids: page.ids })
         });
-        const result = await resp.json();
-
-        if (resultEl) {
-            resultEl.textContent = `${result.processed} embedded, ${result.failed} failed (${result.time_ms.toFixed(0)}ms)`;
+        if (!resp.ok) {
+            const errBody = await resp.text();
+            embeddingsResultMsg = `Error ${resp.status}: ${errBody}`;
+            return;
         }
+        const result = await resp.json();
+        embeddingsResultMsg = `${result.processed} embedded, ${result.failed} failed (${result.time_ms.toFixed(0)}ms)`;
 
         await fetchEmbeddingsInfo();
     } catch (err) {
-        if (resultEl) {
-            resultEl.textContent = `Error: ${err}`;
-        }
+        embeddingsResultMsg = `Error: ${err}`;
     } finally {
         embeddingsReembedding = false;
         renderEmbeddings();
@@ -1241,9 +1245,8 @@ async function recluster(model?: string): Promise<void> {
     if (embeddingsClustering || !embeddingsInfo?.available) return;
 
     embeddingsClustering = true;
+    embeddingsClusterResultMsg = '';
     renderEmbeddings();
-
-    const resultEl = embeddingsElement?.querySelector('.emb-cluster-result');
 
     try {
         const minClusterSize = Number((embeddingsElement?.querySelector('.emb-param-min-cluster-size') as HTMLInputElement)?.value) || 5;
@@ -1257,17 +1260,17 @@ async function recluster(model?: string): Promise<void> {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ min_cluster_size: minClusterSize, cluster_threshold: clusterThreshold, cluster_match_threshold: clusterMatchThreshold })
         });
-        const result = await resp.json();
-
-        if (resultEl) {
-            resultEl.textContent = `${result.summary.n_clusters} clusters, ${result.summary.n_noise} noise (${result.time_ms.toFixed(0)}ms)`;
+        if (!resp.ok) {
+            const errBody = await resp.text();
+            embeddingsClusterResultMsg = `Error ${resp.status}: ${errBody}`;
+            return;
         }
+        const result = await resp.json();
+        embeddingsClusterResultMsg = `${result.summary.n_clusters} clusters, ${result.summary.n_noise} noise (${result.time_ms.toFixed(0)}ms)`;
 
         await fetchEmbeddingsInfo();
     } catch (err) {
-        if (resultEl) {
-            resultEl.textContent = `Error: ${err}`;
-        }
+        embeddingsClusterResultMsg = `Error: ${err}`;
     } finally {
         embeddingsClustering = false;
         renderEmbeddings();

--- a/web/ts/generated/proto/plugin/grpc/protocol/atsstore.ts
+++ b/web/ts/generated/proto/plugin/grpc/protocol/atsstore.ts
@@ -97,6 +97,18 @@ export interface GenerateAttestationResponse {
   attestation: Attestation | undefined;
 }
 
+export interface BatchGenerateAttestationRequest {
+  auth_token: string;
+  commands: AttestationCommand[];
+}
+
+export interface BatchGenerateAttestationResponse {
+  success: boolean;
+  error: string;
+  /** Number of attestations successfully created */
+  created: number;
+}
+
 export interface GetAttestationsRequest {
   auth_token: string;
   filter: AttestationFilter | undefined;


### PR DESCRIPTION
## Summary

- **Chunked batch writes**: `BatchCreateAttestations` splits large batches into 500-item chunks, each holding the write mutex independently. Drops write queue contention from 21 waiters/10s avg to 2-11 waiters under sustained Levi load.
- **Sigma convergence**: Sigmas are always eligible for re-distillation (exempt from `max_age_hours`). Single-attestation groups are skipped to prevent 1:1 copy waste. Prior sigma aggregate maps are stripped before re-merging to prevent unbounded JSON growth toward the 1MB limit.
- **Preserve original source**: Sigma carries `_source` attribute with the original attestation source (e.g. "levi") since `source='distill'` is load-bearing for queries.
- **Batch gRPC endpoint**: New `BatchCreateAttestations` RPC for bulk attestation creation.
- **ADR-020 updated**: Documents sigma always-eligible semantics, single skip rule, attribute stripping, temporal histogram, and re-distillation behavior.
- **Activity log cleanup**: Replaced random `(top: ...)` samples with eviction percentage in ticker summary.

## Test plan

- [x] `make test` passes
- [x] Overnight stability test: 7+ hours under full crawl load (121/128 crawlers, sigmas cycling every 6 min)
- [x] Sigma count bounded by unique predicates, not attestation volume
- [x] No 1MB JSON limit breaches after attribute stripping