### PR TITLE
Handler panel, banner names, syntax highlighting fix

### DIFF
--- a/cmd/qntx/main.go
+++ b/cmd/qntx/main.go
@@ -459,7 +459,7 @@ func registerPluginHandlers(p plugin.DomainPlugin, meta plugin.Metadata, handler
 	}
 
 	if acc != nil {
-		acc.SetHandlers(meta.Name, externalPlugin.GetHandlerNames(), len(schedules), len(externalPlugin.GetWatchers()), grpc.CountUnfilteredWatchers(externalPlugin.GetWatchers()))
+		acc.SetHandlers(meta.Name, externalPlugin.GetHandlerNames(), grpc.ScheduleNames(schedules), grpc.WatcherNames(externalPlugin.GetWatchers()), grpc.UnfilteredWatcherNames(externalPlugin.GetWatchers()))
 		if len(routeStrs) > 0 {
 			acc.SetHTTPRoutes(meta.Name, routeStrs)
 		}

--- a/plugin/grpc/banner.go
+++ b/plugin/grpc/banner.go
@@ -29,10 +29,10 @@ type BannerInfo struct {
 	Version    string
 	Reason     BannerReason
 	Roles      []string          // "search-provider", "llm-provider", etc.
-	Handlers   []string          // async handler names
-	Schedules  int               // number of scheduled jobs
-	Watchers           int // number of watcher registrations
-	UnfilteredWatchers int // watchers with empty filters (receive all attestations)
+	Handlers           []string // async handler names
+	ScheduleNames      []string // schedule handler names
+	WatcherNames       []string // watcher IDs
+	UnfilteredWatchers []string // watcher IDs with empty filters (receive all attestations)
 	Status     string            // from Health().Message
 	Details    map[string]string // from Health().Details
 	Error      string            // non-empty = failed
@@ -181,17 +181,29 @@ func FormatBanner(info BannerInfo) string {
 
 	// Summary of handlers/schedules/watchers
 	var counts []string
-	if len(info.Handlers) > 0 {
-		counts = append(counts, fmt.Sprintf("%d handlers", len(info.Handlers)))
-	}
-	if info.Schedules > 0 {
-		counts = append(counts, fmt.Sprintf("%d schedules", info.Schedules))
-	}
-	if info.Watchers > 0 {
-		if info.UnfilteredWatchers > 0 {
-			counts = append(counts, fmt.Sprintf("%d watchers (%d unfiltered)", info.Watchers, info.UnfilteredWatchers))
+	if n := len(info.Handlers); n > 0 {
+		if n <= 10 {
+			counts = append(counts, fmt.Sprintf("%d handlers: %s", n, strings.Join(info.Handlers, ", ")))
 		} else {
-			counts = append(counts, fmt.Sprintf("%d watchers", info.Watchers))
+			counts = append(counts, fmt.Sprintf("%d handlers: %s, …", n, strings.Join(info.Handlers[:10], ", ")))
+		}
+	}
+	if n := len(info.ScheduleNames); n > 0 {
+		if n <= 10 {
+			counts = append(counts, fmt.Sprintf("%d schedules: %s", n, strings.Join(info.ScheduleNames, ", ")))
+		} else {
+			counts = append(counts, fmt.Sprintf("%d schedules: %s, …", n, strings.Join(info.ScheduleNames[:10], ", ")))
+		}
+	}
+	if n := len(info.WatcherNames); n > 0 {
+		suffix := ""
+		if u := len(info.UnfilteredWatchers); u > 0 {
+			suffix = fmt.Sprintf(" (%d unfiltered)", u)
+		}
+		if n <= 10 {
+			counts = append(counts, fmt.Sprintf("%d watchers: %s%s", n, strings.Join(info.WatcherNames, ", "), suffix))
+		} else {
+			counts = append(counts, fmt.Sprintf("%d watchers: %s, …%s", n, strings.Join(info.WatcherNames[:10], ", "), suffix))
 		}
 	}
 	if len(counts) > 0 {
@@ -330,15 +342,15 @@ func (a *PluginAccumulator) SetRoles(name string, roles []string) {
 	info.Roles = roles
 }
 
-// SetHandlers records handler/schedule/watcher counts after registration.
-func (a *PluginAccumulator) SetHandlers(name string, handlers []string, scheduleCount, watcherCount, unfilteredWatcherCount int) {
+// SetHandlers records handler/schedule/watcher names after registration.
+func (a *PluginAccumulator) SetHandlers(name string, handlers, scheduleNames, watcherNames, unfilteredWatcherNames []string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	info := a.getOrCreate(name)
 	info.Handlers = handlers
-	info.Schedules = scheduleCount
-	info.Watchers = watcherCount
-	info.UnfilteredWatchers = unfilteredWatcherCount
+	info.ScheduleNames = scheduleNames
+	info.WatcherNames = watcherNames
+	info.UnfilteredWatchers = unfilteredWatcherNames
 }
 
 // SetHTTPRoutes records the HTTP routes a plugin advertised.

--- a/plugin/grpc/banner_test.go
+++ b/plugin/grpc/banner_test.go
@@ -107,22 +107,23 @@ func TestFormatBanner_Failed(t *testing.T) {
 
 func TestFormatBanner_HandlersSchedulesWatchers(t *testing.T) {
 	info := BannerInfo{
-		Name:      "python",
-		Version:   "1.0.0",
-		Handlers:  []string{"ingest", "process"},
-		Schedules: 3,
-		Watchers:  1,
+		Name:          "python",
+		Version:       "1.0.0",
+		Handlers:      []string{"ingest", "process"},
+		ScheduleNames: []string{"cleanup", "sync", "backup"},
+		WatcherNames:  []string{"new-attestation"},
 	}
 	banner := FormatBanner(info)
+	plain := stripANSI(banner)
 
-	if !strings.Contains(banner, "2 handlers") {
-		t.Errorf("banner should show handler count, got:\n%s", banner)
+	if !strings.Contains(plain, "2 handlers: ingest, process") {
+		t.Errorf("banner should show handler names, got:\n%s", plain)
 	}
-	if !strings.Contains(banner, "3 schedules") {
-		t.Errorf("banner should show schedule count, got:\n%s", banner)
+	if !strings.Contains(plain, "3 schedules: cleanup, sync, backup") {
+		t.Errorf("banner should show schedule names, got:\n%s", plain)
 	}
-	if !strings.Contains(banner, "1 watchers") {
-		t.Errorf("banner should show watcher count, got:\n%s", banner)
+	if !strings.Contains(plain, "1 watchers: new-attestation") {
+		t.Errorf("banner should show watcher names, got:\n%s", plain)
 	}
 }
 
@@ -201,7 +202,7 @@ func TestAccumulator_SetEmit(t *testing.T) {
 	acc := NewPluginAccumulator(nil)
 	acc.SetLoading("meili", "0.4.0")
 	acc.SetRoles("meili", []string{"search-provider"})
-	acc.SetHandlers("meili", []string{"index"}, 1, 2, 0)
+	acc.SetHandlers("meili", []string{"index"}, []string{"cleanup"}, []string{"w1", "w2"}, nil)
 	acc.SetHealth("meili", true, "MeiliSearch at localhost:7700", map[string]string{"indexes": "5"})
 
 	// Emit should clear the entry

--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -1158,7 +1158,7 @@ func (m *PluginManager) registerRestarted(ctx context.Context, name string, regi
 		meta := proxy.Metadata()
 		m.accumulator.SetLoading(name, meta.Version)
 		m.accumulator.SetRoles(name, roles)
-		m.accumulator.SetHandlers(name, proxy.GetHandlerNames(), len(proxy.GetSchedules()), len(proxy.GetWatchers()), CountUnfilteredWatchers(proxy.GetWatchers()))
+		m.accumulator.SetHandlers(name, proxy.GetHandlerNames(), ScheduleNames(proxy.GetSchedules()), WatcherNames(proxy.GetWatchers()), UnfilteredWatcherNames(proxy.GetWatchers()))
 		var routeStrs []string
 		if routes := proxy.GetHTTPRoutes(); len(routes) > 0 {
 			routeStrs = make([]string, len(routes))

--- a/plugin/grpc/schedules.go
+++ b/plugin/grpc/schedules.go
@@ -20,7 +20,7 @@ func SetupPluginSchedules(db *sql.DB, pluginName string, schedules []*protocol.S
 		return nil
 	}
 
-	logger.Infow("Setting up plugin schedules",
+	logger.Debugw("Setting up plugin schedules",
 		"plugin", pluginName,
 		"count", len(schedules),
 	)

--- a/plugin/grpc/watchers.go
+++ b/plugin/grpc/watchers.go
@@ -137,3 +137,32 @@ func CountUnfilteredWatchers(watchers []*protocol.WatcherRegistration) int {
 	}
 	return count
 }
+
+// WatcherNames extracts watcher IDs from registrations.
+func WatcherNames(watchers []*protocol.WatcherRegistration) []string {
+	names := make([]string, len(watchers))
+	for i, w := range watchers {
+		names[i] = w.GetId()
+	}
+	return names
+}
+
+// UnfilteredWatcherNames returns IDs of watchers with no filter fields set.
+func UnfilteredWatcherNames(watchers []*protocol.WatcherRegistration) []string {
+	var names []string
+	for _, w := range watchers {
+		if len(w.Subjects) == 0 && len(w.Predicates) == 0 && len(w.Contexts) == 0 && len(w.Actors) == 0 {
+			names = append(names, w.GetId())
+		}
+	}
+	return names
+}
+
+// ScheduleNames extracts handler names from schedule infos.
+func ScheduleNames(schedules []*protocol.ScheduleInfo) []string {
+	names := make([]string, len(schedules))
+	for i, s := range schedules {
+		names[i] = s.GetHandlerName()
+	}
+	return names
+}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1004,7 +1004,7 @@ func (s *QNTXServer) HandlePluginAction(w http.ResponseWriter, r *http.Request) 
 		// Emit disabled banner with cleanup summary
 		if acc := pm.Accumulator(); acc != nil {
 			acc.SetLoading(name, disabledVersion)
-			acc.SetHandlers(name, nil, 0, watcherCount, 0)
+			acc.SetHandlers(name, nil, nil, nil, nil)
 			status := fmt.Sprintf("stopped, %d handlers, %d watchers removed", handlerCount, watcherCount)
 			acc.SetHealth(name, true, status, nil)
 			acc.Emit(name, plugingrpc.BannerDisabled)

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -51,6 +51,7 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "6.38.1",
     "@lezer/common": "1.4.0",
+    "@lezer/highlight": "1.2.3",
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.30", "", {}, "sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg=="],
@@ -406,12 +407,6 @@
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
-
-    "@codemirror/language/@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
-
-    "@codemirror/theme-one-dark/@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
-
-    "@lezer/go/@lezer/highlight": ["@lezer/highlight@1.2.1", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA=="],
 
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 

--- a/web/css/handlers-panel.css
+++ b/web/css/handlers-panel.css
@@ -41,11 +41,30 @@
 }
 
 .handlers-card-header {
+    display: flex;
+    align-items: center;
     padding: 8px 12px;
     font-size: var(--font-size-sm);
     font-weight: 600;
     color: var(--text-on-dark);
     border-bottom: 1px solid var(--border-on-dark);
+}
+
+.handlers-play-btn {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: var(--text-on-dark-tertiary);
+    cursor: pointer;
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: var(--border-radius);
+    line-height: 1;
+}
+
+.handlers-play-btn:hover {
+    color: var(--color-primary);
+    background: rgba(255, 255, 255, 0.08);
 }
 
 .handlers-card-context {
@@ -64,6 +83,46 @@
 
 .handlers-card-editor .cm-editor .cm-scroller {
     max-height: 300px;
+}
+
+/* Execution output */
+
+.handlers-card-output:empty {
+    display: none;
+}
+
+.handlers-card-output {
+    border-top: 1px solid var(--border-on-dark);
+    padding: 8px 12px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.handlers-output-running {
+    color: var(--text-on-dark-tertiary);
+}
+
+.handlers-output-text {
+    margin: 0;
+    color: var(--text-on-dark);
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+.handlers-output-error {
+    margin: 0;
+    color: var(--color-error);
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+.handlers-output-duration {
+    display: block;
+    margin-top: 4px;
+    color: var(--text-on-dark-tertiary);
+    font-size: 11px;
 }
 
 .handlers-empty {

--- a/web/css/handlers-panel.css
+++ b/web/css/handlers-panel.css
@@ -50,6 +50,36 @@
     border-bottom: 1px solid var(--border-on-dark);
 }
 
+.handlers-card-label {
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.handlers-card-date {
+    margin-left: auto;
+    color: var(--text-on-dark-tertiary);
+    font-weight: 400;
+    font-size: 11px;
+    white-space: nowrap;
+    padding-right: 8px;
+}
+
+.handlers-version-select {
+    margin-left: auto;
+    background: none;
+    border: none;
+    outline: none;
+    color: var(--text-on-dark-tertiary);
+    font-size: 11px;
+    font-family: var(--font-mono);
+    cursor: pointer;
+    padding: 0 4px;
+}
+
+.handlers-version-select:hover {
+    color: var(--text-on-dark);
+}
+
 .handlers-play-btn {
     margin-left: auto;
     background: none;
@@ -131,102 +161,3 @@
     color: var(--text-on-dark-tertiary);
 }
 
-/* Create button */
-
-.handlers-create-btn {
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid var(--border-on-dark);
-    border-radius: var(--border-radius);
-    color: var(--text-on-dark-secondary);
-    padding: 6px 12px;
-    font-size: var(--font-size-sm);
-    cursor: pointer;
-    margin-bottom: 12px;
-}
-
-.handlers-create-btn:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: var(--text-on-dark);
-}
-
-/* Form */
-
-.handlers-form {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid var(--border-on-dark);
-    border-radius: var(--border-radius);
-    padding: 12px;
-    margin-bottom: 12px;
-}
-
-.handlers-form-row {
-    margin-bottom: 8px;
-}
-
-.handlers-form-row label {
-    display: block;
-    font-size: var(--font-size-sm);
-    color: var(--text-on-dark-tertiary);
-    margin-bottom: 4px;
-}
-
-.handlers-form-row input,
-.handlers-form-row textarea {
-    width: 100%;
-    box-sizing: border-box;
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid var(--border-on-dark);
-    border-radius: var(--border-radius);
-    color: var(--text-on-dark);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-sm);
-    padding: 6px 8px;
-}
-
-.handlers-form-row textarea {
-    resize: vertical;
-}
-
-.handlers-form-row input:focus,
-.handlers-form-row textarea:focus {
-    outline: none;
-    border-color: var(--color-primary);
-}
-
-.handlers-form-actions {
-    display: flex;
-    gap: 8px;
-    margin-top: 8px;
-}
-
-.handlers-btn {
-    border: none;
-    border-radius: var(--border-radius);
-    padding: 6px 12px;
-    font-size: var(--font-size-sm);
-    cursor: pointer;
-}
-
-.handlers-btn-primary {
-    background: var(--color-primary);
-    color: #000;
-}
-
-.handlers-btn-primary:hover {
-    opacity: 0.9;
-}
-
-.handlers-btn-secondary {
-    background: rgba(255, 255, 255, 0.08);
-    color: var(--text-on-dark-secondary);
-}
-
-.handlers-btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.12);
-}
-
-.handlers-form-error {
-    color: var(--color-error);
-    font-size: var(--font-size-sm);
-    margin-top: 6px;
-}

--- a/web/css/handlers-panel.css
+++ b/web/css/handlers-panel.css
@@ -1,0 +1,173 @@
+/* Handlers Panel */
+
+.handlers-panel {
+    padding: 16px;
+}
+
+.handlers-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.handlers-header h2 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+    color: var(--text-on-dark);
+}
+
+.handlers-count {
+    font-size: var(--font-size-sm);
+    color: var(--text-on-dark-tertiary);
+    background: rgba(255, 255, 255, 0.08);
+    padding: 1px 6px;
+    border-radius: var(--border-radius);
+}
+
+/* Card grid */
+
+.handlers-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    gap: 12px;
+}
+
+.handlers-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-on-dark);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.handlers-card-header {
+    padding: 8px 12px;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--text-on-dark);
+    border-bottom: 1px solid var(--border-on-dark);
+}
+
+.handlers-card-context {
+    font-weight: 400;
+    color: var(--text-on-dark-tertiary);
+}
+
+.handlers-card-editor {
+    max-height: 300px;
+    overflow: hidden;
+}
+
+.handlers-card-editor .cm-editor {
+    background: transparent;
+}
+
+.handlers-card-editor .cm-editor .cm-scroller {
+    max-height: 300px;
+}
+
+.handlers-empty {
+    padding: 24px;
+    text-align: center;
+    color: var(--text-on-dark-tertiary);
+}
+
+/* Create button */
+
+.handlers-create-btn {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--border-on-dark);
+    border-radius: var(--border-radius);
+    color: var(--text-on-dark-secondary);
+    padding: 6px 12px;
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    margin-bottom: 12px;
+}
+
+.handlers-create-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-on-dark);
+}
+
+/* Form */
+
+.handlers-form {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-on-dark);
+    border-radius: var(--border-radius);
+    padding: 12px;
+    margin-bottom: 12px;
+}
+
+.handlers-form-row {
+    margin-bottom: 8px;
+}
+
+.handlers-form-row label {
+    display: block;
+    font-size: var(--font-size-sm);
+    color: var(--text-on-dark-tertiary);
+    margin-bottom: 4px;
+}
+
+.handlers-form-row input,
+.handlers-form-row textarea {
+    width: 100%;
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--border-on-dark);
+    border-radius: var(--border-radius);
+    color: var(--text-on-dark);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    padding: 6px 8px;
+}
+
+.handlers-form-row textarea {
+    resize: vertical;
+}
+
+.handlers-form-row input:focus,
+.handlers-form-row textarea:focus {
+    outline: none;
+    border-color: var(--color-primary);
+}
+
+.handlers-form-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.handlers-btn {
+    border: none;
+    border-radius: var(--border-radius);
+    padding: 6px 12px;
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+}
+
+.handlers-btn-primary {
+    background: var(--color-primary);
+    color: #000;
+}
+
+.handlers-btn-primary:hover {
+    opacity: 0.9;
+}
+
+.handlers-btn-secondary {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-on-dark-secondary);
+}
+
+.handlers-btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.handlers-form-error {
+    color: var(--color-error);
+    font-size: var(--font-size-sm);
+    margin-top: 6px;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,7 @@
     <link rel="stylesheet" href="/css/prose-panel.css">
     <link rel="stylesheet" href="/css/prompt-preview-panel.css">
     <link rel="stylesheet" href="/css/pulse-panel.css">
+    <link rel="stylesheet" href="/css/handlers-panel.css">
     <link rel="stylesheet" href="/css/pulse-scheduling.css">
 
     <!-- Code editor components -->

--- a/web/package.json
+++ b/web/package.json
@@ -48,7 +48,8 @@
     "@codemirror/autocomplete": "6.18.6",
     "@codemirror/lint": "6.8.5",
     "@codemirror/language": "6.10.3",
-    "@lezer/common": "1.4.0"
+    "@lezer/common": "1.4.0",
+    "@lezer/highlight": "1.2.3"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "6.2.2",

--- a/web/ts/default-glyphs.ts
+++ b/web/ts/default-glyphs.ts
@@ -62,6 +62,7 @@ import { formatBuildTime } from './components/tooltip.ts';
 import type { VersionMessage, SystemCapabilitiesMessage } from '../types/websocket';
 import { createPluginGlyph } from './plugin-panel.ts';
 import { createPulseGlyph } from './pulse-panel.ts';
+import { createHandlersGlyph } from './handlers-panel.ts';
 import { createLlmProviderGlyph } from './llm-provider-glyph.ts';
 
 // Self diagnostics state
@@ -226,6 +227,9 @@ export function registerDefaultGlyphs(): void {
 
     // Plugin Panel Glyph — panel manifestation
     glyphRun.add(createPluginGlyph());
+
+    // Handlers Panel Glyph — handler attestation management
+    glyphRun.add(createHandlersGlyph());
 
     // LLM Provider Glyph — provider selection (replaces ai-provider-window)
     glyphRun.add(createLlmProviderGlyph());

--- a/web/ts/handlers-panel.ts
+++ b/web/ts/handlers-panel.ts
@@ -28,10 +28,17 @@ interface ExecutionResult {
     duration_ms?: number;
 }
 
+interface HandlerGroup {
+    name: string;
+    context: string;
+    versions: HandlerAttestation[];
+    selectedVersion: number; // index into versions array
+}
+
 // Module-level state
 let contentElement: HTMLElement | null = null;
 let handlers: HandlerAttestation[] = [];
-let showCreateForm = false;
+let groups: HandlerGroup[] = [];
 let editorViews: any[] = [];
 let codeStore: Map<string, string> = new Map();
 let execResults: Map<number, ExecutionResult> = new Map();
@@ -49,21 +56,38 @@ async function fetchHandlers(): Promise<void> {
     }
 }
 
-async function createHandler(name: string, code: string, context: string): Promise<void> {
-    const response = await apiFetch('/api/attestations', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            subjects: [name],
-            predicates: ['handler'],
-            contexts: context ? [context] : [],
-            actors: ['user'],
-            attributes: { code },
-        }),
-    });
-    if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+function groupHandlers(): void {
+    const map = new Map<string, HandlerAttestation[]>();
+    for (const h of handlers) {
+        const key = h.subjects[0] || '';
+        const list = map.get(key);
+        if (list) {
+            list.push(h);
+        } else {
+            map.set(key, [h]);
+        }
     }
+    groups = [];
+    for (const [name, versions] of map) {
+        // Sort newest first
+        versions.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        groups.push({
+            name,
+            context: versions[0].contexts[0] || '',
+            versions,
+            selectedVersion: 0,
+        });
+    }
+}
+
+function formatDate(timestamp: string): string {
+    const d = new Date(timestamp);
+    return `${String(d.getFullYear()).slice(2)}-${d.getMonth() + 1}-${d.getDate()}`;
+}
+
+function formatDateTime(timestamp: string): string {
+    const d = new Date(timestamp);
+    return `${String(d.getFullYear()).slice(2)}-${d.getMonth() + 1}-${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
 async function executeHandler(index: number): Promise<void> {
@@ -168,23 +192,35 @@ async function mountEditors(): Promise<void> {
 }
 
 function renderCards(): string {
-    if (handlers.length === 0) {
+    if (groups.length === 0) {
         return `<div class="handlers-empty">No handlers found</div>`;
     }
 
     codeStore.clear();
     execResults.clear();
-    const cards = handlers.map((h, i) => {
-        const name = escapeHtml(h.subjects[0] || '(unnamed)');
-        const context = h.contexts[0] ? escapeHtml(h.contexts[0]) : '';
+    const cards = groups.map((g, i) => {
+        const h = g.versions[g.selectedVersion];
+        const name = escapeHtml(g.name || '(unnamed)');
+        const context = g.context ? escapeHtml(g.context) : '';
         const code = h.attributes?.code || '';
         const editorId = `handler-editor-${i}`;
         codeStore.set(editorId, code);
         const label = context ? `${name} <span class="handlers-card-context">${context}</span>` : name;
 
-        return `<div class="handlers-card">
+        let dateHtml: string;
+        if (g.versions.length > 1) {
+            const options = g.versions.map((v, vi) =>
+                `<option value="${vi}"${vi === g.selectedVersion ? ' selected' : ''}>${formatDateTime(v.timestamp)}</option>`
+            ).join('');
+            dateHtml = `<select class="handlers-version-select" data-group-index="${i}">${options}</select>`;
+        } else {
+            dateHtml = `<span class="handlers-card-date">${formatDate(h.timestamp)}</span>`;
+        }
+
+        return `<div class="handlers-card" data-group="${i}">
             <div class="handlers-card-header">
-                ${label}
+                <span class="handlers-card-label">${label}</span>
+                ${dateHtml}
                 <button class="handlers-play-btn" data-action="execute" data-index="${i}" title="Execute handler">▶</button>
             </div>
             <div class="handlers-card-editor" id="${editorId}"></div>
@@ -195,42 +231,31 @@ function renderCards(): string {
     return `<div class="handlers-grid">${cards}</div>`;
 }
 
-function renderCreateForm(): string {
-    if (!showCreateForm) {
-        return `<button class="handlers-create-btn" data-action="show-form">+ New Handler</button>`;
-    }
-
-    return `<div class="handlers-form">
-        <div class="handlers-form-row">
-            <label>Name</label>
-            <input type="text" id="handler-name" placeholder="my-handler" autocomplete="off" />
+function render(): void {
+    if (!contentElement) return;
+    destroyEditors();
+    groupHandlers();
+    contentElement.innerHTML = `
+        <div class="handlers-panel">
+            <div class="handlers-header">
+                <h2>Handlers</h2>
+                <span class="handlers-count">${groups.length}</span>
+            </div>
+            ${renderCards()}
         </div>
-        <div class="handlers-form-row">
-            <label>Context</label>
-            <input type="text" id="handler-context" placeholder="icpy" value="icpy" autocomplete="off" />
-        </div>
-        <div class="handlers-form-row">
-            <label>Code</label>
-            <textarea id="handler-code" rows="6" placeholder="print('hello')"></textarea>
-        </div>
-        <div class="handlers-form-actions">
-            <button class="handlers-btn handlers-btn-primary" data-action="create">Create</button>
-            <button class="handlers-btn handlers-btn-secondary" data-action="cancel">Cancel</button>
-        </div>
-        <div id="handler-form-error" class="handlers-form-error"></div>
-    </div>`;
+    `;
+    mountEditors();
 }
 
-function render(): void {
+function renderWithGroups(): void {
     if (!contentElement) return;
     destroyEditors();
     contentElement.innerHTML = `
         <div class="handlers-panel">
             <div class="handlers-header">
                 <h2>Handlers</h2>
-                <span class="handlers-count">${handlers.length}</span>
+                <span class="handlers-count">${groups.length}</span>
             </div>
-            ${renderCreateForm()}
             ${renderCards()}
         </div>
     `;
@@ -238,22 +263,22 @@ function render(): void {
 }
 
 function attachEventDelegation(el: HTMLElement): void {
+    el.addEventListener('change', (e) => {
+        const target = e.target as HTMLElement;
+        if (target.classList.contains('handlers-version-select')) {
+            const select = target as HTMLSelectElement;
+            const groupIndex = parseInt(select.dataset.groupIndex || '', 10);
+            if (!isNaN(groupIndex) && groups[groupIndex]) {
+                groups[groupIndex].selectedVersion = parseInt(select.value, 10);
+                renderWithGroups();
+            }
+        }
+    });
+
     el.addEventListener('click', async (e) => {
         const target = e.target as HTMLElement;
         const action = target.closest<HTMLElement>('[data-action]')?.dataset.action;
         if (!action) return;
-
-        if (action === 'show-form') {
-            showCreateForm = true;
-            render();
-            return;
-        }
-
-        if (action === 'cancel') {
-            showCreateForm = false;
-            render();
-            return;
-        }
 
         if (action === 'execute') {
             const index = parseInt(target.closest<HTMLElement>('[data-index]')?.dataset.index || '', 10);
@@ -263,35 +288,6 @@ function attachEventDelegation(el: HTMLElement): void {
             return;
         }
 
-        if (action === 'create') {
-            const nameInput = el.querySelector<HTMLInputElement>('#handler-name');
-            const contextInput = el.querySelector<HTMLInputElement>('#handler-context');
-            const codeInput = el.querySelector<HTMLTextAreaElement>('#handler-code');
-            const errorDiv = el.querySelector<HTMLElement>('#handler-form-error');
-
-            const name = nameInput?.value.trim() || '';
-            const context = contextInput?.value.trim() || '';
-            const code = codeInput?.value || '';
-
-            if (!name) {
-                if (errorDiv) errorDiv.textContent = 'Name is required';
-                return;
-            }
-            if (!code) {
-                if (errorDiv) errorDiv.textContent = 'Code is required';
-                return;
-            }
-
-            try {
-                await createHandler(name, code, context);
-                showCreateForm = false;
-                await fetchHandlers();
-                render();
-            } catch (error: unknown) {
-                const msg = error instanceof Error ? error.message : String(error);
-                if (errorDiv) errorDiv.textContent = msg;
-            }
-        }
     });
 }
 
@@ -313,7 +309,6 @@ export function createHandlersGlyph(): Glyph {
                     clearInterval(cleanupInterval);
                     destroyEditors();
                     contentElement = null;
-                    showCreateForm = false;
                 }
             }, 2000);
 

--- a/web/ts/handlers-panel.ts
+++ b/web/ts/handlers-panel.ts
@@ -1,0 +1,241 @@
+/**
+ * Handlers Panel - Python handler management
+ *
+ * Manifests as a panel glyph. Displays handler attestations
+ * (predicate=handler) as code cards with syntax highlighting.
+ */
+
+import { apiFetch } from './api';
+import { escapeHtml } from './html-utils';
+import { log, SEG } from './logger.ts';
+import type { Glyph } from '@qntx/glyphs';
+
+interface HandlerAttestation {
+    id: string;
+    subjects: string[];
+    predicates: string[];
+    contexts: string[];
+    actors: string[];
+    timestamp: string;
+    attributes: Record<string, string>;
+}
+
+// Module-level state
+let contentElement: HTMLElement | null = null;
+let handlers: HandlerAttestation[] = [];
+let showCreateForm = false;
+let editorViews: any[] = [];
+let codeStore: Map<string, string> = new Map();
+
+async function fetchHandlers(): Promise<void> {
+    try {
+        const response = await apiFetch('/api/attestations?predicate=handler&limit=100');
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+        }
+        handlers = await response.json();
+    } catch (error: unknown) {
+        log.error(SEG.ERROR, '[Handlers] Failed to fetch handlers:', error);
+        handlers = [];
+    }
+}
+
+async function createHandler(name: string, code: string, context: string): Promise<void> {
+    const response = await apiFetch('/api/attestations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            subjects: [name],
+            predicates: ['handler'],
+            contexts: context ? [context] : [],
+            actors: ['user'],
+            attributes: { code },
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+    }
+}
+
+function destroyEditors(): void {
+    for (const view of editorViews) {
+        view.destroy();
+    }
+    editorViews = [];
+}
+
+async function mountEditors(): Promise<void> {
+    if (!contentElement) return;
+
+    const { EditorView } = await import('@codemirror/view');
+    const { EditorState } = await import('@codemirror/state');
+    const { python } = await import('@codemirror/lang-python');
+    const { oneDark } = await import('@codemirror/theme-one-dark');
+
+    const containers = contentElement.querySelectorAll<HTMLElement>('.handlers-card-editor[id]');
+    for (const container of containers) {
+        const code = codeStore.get(container.id) || '';
+        const view = new EditorView({
+            state: EditorState.create({
+                doc: code,
+                extensions: [
+                    python(),
+                    oneDark,
+                    EditorView.lineWrapping,
+                    EditorState.readOnly.of(true),
+                    EditorView.editable.of(false),
+                    EditorView.theme({
+                        '&': { fontSize: '12px', maxHeight: '300px' },
+                        '.cm-scroller': { overflow: 'auto' },
+                        '.cm-gutters': { display: 'none' },
+                        '.cm-content': { padding: '8px 0' },
+                    }),
+                ],
+            }),
+            parent: container,
+        });
+        editorViews.push(view);
+    }
+}
+
+function renderCards(): string {
+    if (handlers.length === 0) {
+        return `<div class="handlers-empty">No handlers found</div>`;
+    }
+
+    codeStore.clear();
+    const cards = handlers.map((h, i) => {
+        const name = escapeHtml(h.subjects[0] || '(unnamed)');
+        const context = h.contexts[0] ? escapeHtml(h.contexts[0]) : '';
+        const code = h.attributes?.code || '';
+        const editorId = `handler-editor-${i}`;
+        codeStore.set(editorId, code);
+        const label = context ? `${name} <span class="handlers-card-context">${context}</span>` : name;
+
+        return `<div class="handlers-card">
+            <div class="handlers-card-header">${label}</div>
+            <div class="handlers-card-editor" id="${editorId}"></div>
+        </div>`;
+    }).join('');
+
+    return `<div class="handlers-grid">${cards}</div>`;
+}
+
+function renderCreateForm(): string {
+    if (!showCreateForm) {
+        return `<button class="handlers-create-btn" data-action="show-form">+ New Handler</button>`;
+    }
+
+    return `<div class="handlers-form">
+        <div class="handlers-form-row">
+            <label>Name</label>
+            <input type="text" id="handler-name" placeholder="my-handler" autocomplete="off" />
+        </div>
+        <div class="handlers-form-row">
+            <label>Context</label>
+            <input type="text" id="handler-context" placeholder="icpy" value="icpy" autocomplete="off" />
+        </div>
+        <div class="handlers-form-row">
+            <label>Code</label>
+            <textarea id="handler-code" rows="6" placeholder="print('hello')"></textarea>
+        </div>
+        <div class="handlers-form-actions">
+            <button class="handlers-btn handlers-btn-primary" data-action="create">Create</button>
+            <button class="handlers-btn handlers-btn-secondary" data-action="cancel">Cancel</button>
+        </div>
+        <div id="handler-form-error" class="handlers-form-error"></div>
+    </div>`;
+}
+
+function render(): void {
+    if (!contentElement) return;
+    destroyEditors();
+    contentElement.innerHTML = `
+        <div class="handlers-panel">
+            <div class="handlers-header">
+                <h2>Handlers</h2>
+                <span class="handlers-count">${handlers.length}</span>
+            </div>
+            ${renderCreateForm()}
+            ${renderCards()}
+        </div>
+    `;
+    mountEditors();
+}
+
+function attachEventDelegation(el: HTMLElement): void {
+    el.addEventListener('click', async (e) => {
+        const target = e.target as HTMLElement;
+        const action = target.closest<HTMLElement>('[data-action]')?.dataset.action;
+        if (!action) return;
+
+        if (action === 'show-form') {
+            showCreateForm = true;
+            render();
+            return;
+        }
+
+        if (action === 'cancel') {
+            showCreateForm = false;
+            render();
+            return;
+        }
+
+        if (action === 'create') {
+            const nameInput = el.querySelector<HTMLInputElement>('#handler-name');
+            const contextInput = el.querySelector<HTMLInputElement>('#handler-context');
+            const codeInput = el.querySelector<HTMLTextAreaElement>('#handler-code');
+            const errorDiv = el.querySelector<HTMLElement>('#handler-form-error');
+
+            const name = nameInput?.value.trim() || '';
+            const context = contextInput?.value.trim() || '';
+            const code = codeInput?.value || '';
+
+            if (!name) {
+                if (errorDiv) errorDiv.textContent = 'Name is required';
+                return;
+            }
+            if (!code) {
+                if (errorDiv) errorDiv.textContent = 'Code is required';
+                return;
+            }
+
+            try {
+                await createHandler(name, code, context);
+                showCreateForm = false;
+                await fetchHandlers();
+                render();
+            } catch (error: unknown) {
+                const msg = error instanceof Error ? error.message : String(error);
+                if (errorDiv) errorDiv.textContent = msg;
+            }
+        }
+    });
+}
+
+export function createHandlersGlyph(): Glyph {
+    return {
+        id: 'handlers-glyph',
+        title: 'Handlers',
+        manifestationType: 'panel',
+        renderContent: () => {
+            const content = document.createElement('div');
+            contentElement = content;
+
+            attachEventDelegation(content);
+            render();
+            fetchHandlers().then(() => render());
+
+            const cleanupInterval = setInterval(() => {
+                if (!contentElement?.isConnected) {
+                    clearInterval(cleanupInterval);
+                    destroyEditors();
+                    contentElement = null;
+                    showCreateForm = false;
+                }
+            }, 2000);
+
+            return content;
+        },
+    };
+}

--- a/web/ts/handlers-panel.ts
+++ b/web/ts/handlers-panel.ts
@@ -20,12 +20,21 @@ interface HandlerAttestation {
     attributes: Record<string, string>;
 }
 
+interface ExecutionResult {
+    running: boolean;
+    success?: boolean;
+    stdout?: string;
+    error?: string;
+    duration_ms?: number;
+}
+
 // Module-level state
 let contentElement: HTMLElement | null = null;
 let handlers: HandlerAttestation[] = [];
 let showCreateForm = false;
 let editorViews: any[] = [];
 let codeStore: Map<string, string> = new Map();
+let execResults: Map<number, ExecutionResult> = new Map();
 
 async function fetchHandlers(): Promise<void> {
     try {
@@ -55,6 +64,66 @@ async function createHandler(name: string, code: string, context: string): Promi
     if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${await response.text()}`);
     }
+}
+
+async function executeHandler(index: number): Promise<void> {
+    const code = codeStore.get(`handler-editor-${index}`);
+    if (!code) return;
+
+    execResults.set(index, { running: true });
+    renderOutput(index);
+
+    try {
+        const response = await apiFetch('/api/python/execute', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: code }),
+        });
+        const data = await response.json();
+        execResults.set(index, {
+            running: false,
+            success: data.success,
+            stdout: data.stdout || '',
+            error: data.error || '',
+            duration_ms: data.duration_ms,
+        });
+    } catch (err: unknown) {
+        execResults.set(index, {
+            running: false,
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+    renderOutput(index);
+}
+
+function renderOutput(index: number): void {
+    if (!contentElement) return;
+    const container = contentElement.querySelector<HTMLElement>(`#handler-output-${index}`);
+    if (!container) return;
+
+    const result = execResults.get(index);
+    if (!result) {
+        container.innerHTML = '';
+        return;
+    }
+
+    if (result.running) {
+        container.innerHTML = '<div class="handlers-output-running">Running...</div>';
+        return;
+    }
+
+    const parts: string[] = [];
+    if (result.stdout) {
+        parts.push(`<pre class="handlers-output-text">${escapeHtml(result.stdout)}</pre>`);
+    }
+    if (result.error) {
+        parts.push(`<pre class="handlers-output-error">${escapeHtml(result.error)}</pre>`);
+    }
+    if (result.duration_ms !== undefined) {
+        parts.push(`<span class="handlers-output-duration">${result.duration_ms}ms</span>`);
+    }
+    container.innerHTML = parts.join('');
 }
 
 function destroyEditors(): void {
@@ -104,6 +173,7 @@ function renderCards(): string {
     }
 
     codeStore.clear();
+    execResults.clear();
     const cards = handlers.map((h, i) => {
         const name = escapeHtml(h.subjects[0] || '(unnamed)');
         const context = h.contexts[0] ? escapeHtml(h.contexts[0]) : '';
@@ -113,8 +183,12 @@ function renderCards(): string {
         const label = context ? `${name} <span class="handlers-card-context">${context}</span>` : name;
 
         return `<div class="handlers-card">
-            <div class="handlers-card-header">${label}</div>
+            <div class="handlers-card-header">
+                ${label}
+                <button class="handlers-play-btn" data-action="execute" data-index="${i}" title="Execute handler">▶</button>
+            </div>
             <div class="handlers-card-editor" id="${editorId}"></div>
+            <div class="handlers-card-output" id="handler-output-${i}"></div>
         </div>`;
     }).join('');
 
@@ -178,6 +252,14 @@ function attachEventDelegation(el: HTMLElement): void {
         if (action === 'cancel') {
             showCreateForm = false;
             render();
+            return;
+        }
+
+        if (action === 'execute') {
+            const index = parseInt(target.closest<HTMLElement>('[data-index]')?.dataset.index || '', 10);
+            if (!isNaN(index)) {
+                executeHandler(index);
+            }
             return;
         }
 

--- a/web/ts/main.ts
+++ b/web/ts/main.ts
@@ -364,6 +364,10 @@ async function init(): Promise<void> {
             glyphRun.openGlyph('plugin-glyph');
         });
 
+        listen('show-handlers-panel', () => {
+            glyphRun.openGlyph('handlers-glyph');
+        });
+
         listen('toggle-logs', () => {
             focusDrawerSearch();
         });


### PR DESCRIPTION
## Banner: names over counts

Plugin startup banner now shows actual handler, schedule, and watcher names instead of anonymous counts. Max 10 names, then ellipsis.

```
11 handlers: ingest, process, cleanup, ...
1 schedules: lit
11 watchers: new-attestation, doc-update, ...
```

`BannerInfo` stores `[]string` instead of `int` for schedules/watchers. Three new helpers: `ScheduleNames()`, `WatcherNames()`, `UnfilteredWatcherNames()`.

Schedule setup log demoted from Info to Debug.

## Syntax highlighting fix

CodeMirror syntax highlighting was broken across the entire frontend — py-glyph, handlers panel, everything. Four copies of `@lezer/highlight` (1.2.1 vs 1.2.3) created separate `Tag` class instances. The Python parser tagged tokens with one `Tag`, but `oneDarkHighlightStyle` matched against a different `Tag`. Tags never matched, no colors.

Fix: `"@lezer/highlight": "1.2.3"` in `resolutions`.

## Handlers panel

Card grid view of handler attestations (`predicate=handler`). Each card shows the handler name and full Python source with syntax-highlighted CodeMirror (read-only, oneDark theme). Create new handlers via inline form.

Data flow: `GET /api/attestations?predicate=handler` for listing, `POST /api/attestations` for creation. No new backend endpoints.

Opens via `glyphRun.openGlyph('handlers-glyph')` or `show-handlers-panel` event.