### PR TITLE
Chart glyph, top-direction meld, single-edge glow

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,40 @@
+# HANDOVER — chart-glyph branch
+
+## Status
+
+PR #813 open. Branch has chart glyph on canvas with dummy D3 data, top-direction meld support (detection + glow proven), single-edge directional shadows. Tests pass (663).
+
+## Blocker
+
+**Composition jump on top meld.** When chart melds above ax, ax shifts down. Root cause: `performMeld` in `packages/glyphs/meld/meld-composition.ts` positions the composition at the initiator's canvas position, but `applyColumnLayout` places the initiator at a non-zero internal offset for `top` direction (row 2 instead of row 1). Three compensation attempts failed — the math is simple (`origY - internalOffset`) but something diverges at runtime. Next step: add `console.log` in `performMeld` to dump `origY`, `internalY`, `scale`, final `composition.style.top`. See `docs/glyphs/top-meld-jump.md`.
+
+## Roadmap (sequenced)
+
+1. **Jump bug** — `packages/glyphs/meld/meld-composition.ts` lines ~209 and ~349
+2. **Wire chart to ax data** — replace dummy data with watcher pipeline (ax->py pattern in `web/ts/components/glyph/glyph-followup.ts`)
+3. **WASD attribute cycling** — keydown on selected chart, W/S cycles y-axis attribute, re-renders live, axis label is feedback
+4. **Comma/period chosen attributes** — comma promotes previewing to chosen (persistent line), period demotes, state in glyph `content` field
+5. **Arrow keys viz type** — Up/Down cycles line/area/bar/scatter, orthogonal to WASD
+6. **A/D time window** — adjusts x-axis range (hour/day/week/month), changes watcher query
+7. **Sigma as data source** — add sigma `top` port in meldability.ts, same watcher mechanism
+8. **Outgoing ports** — chosen attributes as chart output, add ports to `MELDABILITY['canvas-chart-glyph']`
+
+## What's proven
+
+- Chart glyph renders, spawns from tray, headerless fold bar, resize-aware D3
+- `canvas-chart-glyph` in `ALL_GLYPH_CLASSES`, ax has `top` port targeting chart
+- Top direction glow: single-edge shadows on correct edges
+- Top direction detection: test passes, meld triggers on mouse release
+- Left-to-right meld glow improved (single-edge, no bleed)
+
+## Key files
+
+- `web/ts/components/glyph/canvas-chart-glyph.ts` — chart glyph renderer
+- `web/ts/components/glyph/glyph-registry.ts` — spawn menu registration
+- `packages/glyphs/meld/meldability.ts` — port rules
+- `packages/glyphs/meld/meld-feedback.ts` — directional shadows
+- `packages/glyphs/meld/meld-composition.ts` — jump bug lives here
+- `packages/glyphs/meld/meld-detect.ts` — top direction proximity check
+- `packages/glyphs/edge-graph.ts` — `computeGridPositions` grid normalization
+- `docs/glyphs/chart.md` — vision (keyboard nav, attribute states, modes)
+- `docs/glyphs/top-meld-jump.md` — jump bug analysis

--- a/docs/glyphs/chart.md
+++ b/docs/glyphs/chart.md
@@ -1,0 +1,64 @@
+# Chart Glyph
+
+The chart glyph visualizes attestation data. It melds above a data-producing glyph (ax query, sigma) — the data source sits below, the visualization sits above. You edit the query below, the chart above reacts.
+
+## Meld Position
+
+The chart melds **above** its data source via a `top` composition edge. The data source (ax glyph, sigma glyph) fires through a watcher, the chart re-renders on each update. This reuses the existing watcher pipeline — the chart is a consumer, not a new data flow concept.
+
+## Keyboard Navigation
+
+The chart is navigated entirely by keyboard when selected. No config panels, no dropdowns.
+
+### Attribute Selection (WASD)
+
+- **W** — cycle y-axis attribute backward
+- **S** — cycle y-axis attribute forward
+- **A/D** — context-dependent (see Modes)
+
+Each keypress updates the chart live. The currently cycling attribute is the **preview** — always visible alongside any **chosen** attributes.
+
+### Attribute States
+
+- **Chosen** — persistent, always rendered, visually prominent axis label
+- **Previewing** — the attribute WASD is currently on, visible but floating, dimmer label, changes with each keypress
+- **Hidden** — everything else
+
+Multiple attributes can be chosen. Each chosen attribute adds a line (or series) to the visualization. The chart always renders all chosen attributes plus the one being previewed.
+
+- **,** (comma) — promote the previewed attribute to chosen
+- **.** (period) — demote the last chosen attribute back to hidden
+
+### Visualization Type (Arrows)
+
+- **Up** — cycle visualization type forward (line, area, bar, scatter)
+- **Down** — cycle visualization type backward
+
+### Modes
+
+The chart has two implicit modes determined by what's selected:
+
+**Time-series** (default) — x-axis is `created_at`. This is the natural mode for attestations as events.
+- A/D adjusts the time window (hour, day, week, month)
+- W/S cycles through attestation attributes for the y-axis
+
+**Correlation** — x-axis is an attestation attribute. Active when two non-time attributes are chosen.
+- A/D cycles the x-axis attribute
+- W/S cycles the y-axis attribute
+- The visualization naturally becomes a scatter plot
+
+The mode switch is implicit — it follows from what you've chosen, no toggle needed.
+
+## Axis Labels as State
+
+The axis label is the feedback mechanism. It shows the current attribute name and updates as you cycle. Chosen attributes render with full weight; the previewing attribute renders dimmer. You glance at the axes and see immediately what's pinned and what's floating.
+
+## Data Flow
+
+The chart reads its data through the existing watcher pipeline. The ax glyph below defines a filter, the watcher monitors for matching attestations, and the chart renders what comes through. This is the same mechanism that drives ax-to-py melds — the chart is just a different action at the end of the pipe.
+
+For sigmas, the watcher fires as aggregations update. The chart animates as new attestations flow in.
+
+## Internal Glyph
+
+The chart glyph is a core glyph, not a plugin — it needs tight integration with the composition/meld system and D3 is already bundled.

--- a/docs/glyphs/top-meld-jump.md
+++ b/docs/glyphs/top-meld-jump.md
@@ -1,0 +1,50 @@
+# Top Direction Meld: Composition Jump Bug
+
+## Problem
+
+When melding a chart glyph above an ax glyph (`top` direction), the composition jumps — the ax glyph shifts down from its original position after the meld completes. Detection and glow work correctly; the bug is in composition positioning.
+
+## Root Cause
+
+`performMeld` in `packages/glyphs/meld/meld-composition.ts` positions the composition at the initiator's (ax's) original canvas position:
+
+```typescript
+composition.style.left = initiatorElement.style.left;
+composition.style.top = initiatorElement.style.top;
+```
+
+Then `applyColumnLayout` computes a grid from the edge DAG. For `right` and `bottom` edges, the initiator is always at grid position (1,1) with internal offset (0, 0) — it stays at the composition origin, matching its original canvas position. No jump.
+
+For `top` edges, the initiator lands at row 2 (row 1 is the target above). `computeGridPositions` normalizes so min row = 1, pushing the initiator to `style.top = targetHeight`. The initiator's canvas position becomes `composition.top + targetHeight` instead of `composition.top + 0`. It shifts down by exactly the target's measured height.
+
+The same issue exists in `extendComposition` when adding a `top` edge to an existing composition — existing glyphs shift to later rows.
+
+## What Was Tried
+
+### Attempt 1: parseInt compensation
+After `applyColumnLayout`, read initiator's internal offset via `parseInt(initiatorElement.style.top)`, subtract from composition position. Result: still jumps, "not as much." `parseInt` truncates fractional pixels from `getBoundingClientRect / scale` measurements.
+
+### Attempt 2: getBoundingClientRect screen-coordinate compensation
+Snapshot initiator's screen position before reparenting, compare after layout, convert delta to canvas coordinates via `/ scale`. Result: still jumps. The delta computation is correct in theory but the composition is at (0,0) during layout (position not yet set), which may affect the screen rect comparison after the composition is repositioned.
+
+### Attempt 3: parseFloat canvas-coordinate compensation
+Read initiator's original `style.left/top` with `parseFloat` before clearing, read internal offset after layout with `parseFloat`, subtract. Simpler than attempt 2 — stays in canvas coordinate space, no scale conversion needed. Not yet tested at runtime.
+
+## Why It's Hard
+
+The values involved (`origY`, `internalY`, `scale`) are all individually correct in unit tests. The test for `checkDirectionalProximity` with `top` direction passes. The bug manifests only at runtime where:
+
+- Canvas zoom/pan transforms affect `getBoundingClientRect` measurements
+- `applyColumnLayout` measures via `getBoundingClientRect / scale` but sets `style.top` directly
+- The composition position, element reparenting, and forced reflow interact in sequence
+- `right`/`bottom` never exposed this because the initiator always lands at offset 0
+
+## Files
+
+- `packages/glyphs/meld/meld-composition.ts` — `performMeld` (line ~209) and `extendComposition` (line ~349): composition positioning after layout
+- `packages/glyphs/edge-graph.ts` — `computeGridPositions`: grid normalization that pushes initiator to row 2 for `top` edges
+- `packages/glyphs/meld/meld-composition.ts` — `applyColumnLayout`: element measurement and pixel offset computation
+
+## Next Step
+
+Add `console.log` to `performMeld` dumping `origY`, `internalY`, `scale`, `composition.style.top` before and after compensation. Compare against the visible jump in pixels. The math is straightforward — the bug is a value being wrong at runtime, and we need to see which one.

--- a/packages/glyphs/meld/meld-feedback.ts
+++ b/packages/glyphs/meld/meld-feedback.ts
@@ -26,26 +26,38 @@ export function applyMeldFeedback(
     }
 
     const intensity = 1 - (distance / PROXIMITY_THRESHOLD);
-    const isVertical = direction === 'bottom' || direction === 'top';
 
-    // Shadow offsets: glow toward the meld edge
-    const strongOffset = isVertical ? '0 10px' : '10px 0';
-    const strongOffsetReverse = isVertical ? '0 -10px' : '-10px 0';
-    const mildOffset = isVertical ? '0 5px' : '5px 0';
-    const mildOffsetReverse = isVertical ? '0 -5px' : '-5px 0';
+    // Single-edge box-shadows using negative spread to confine glow to one side.
+    // Format: offset-x offset-y blur spread color
+    // Negative spread shrinks the shadow so it only bleeds from the offset edge.
+    //   [initiator shadow, target shadow]
+    const edgeShadow = (ox: string, oy: string, blur: number, spread: number, alpha: number): [string, string] => {
+        const c = `rgba(255, 69, 0, ${alpha})`;
+        // Initiator: glow toward target. Target: glow toward initiator (negated offset).
+        return [
+            `${ox} ${oy} ${blur}px ${spread}px ${c}`,
+            `${ox.startsWith('-') ? ox.slice(1) : '-' + ox} ${oy.startsWith('-') ? oy.slice(1) : '-' + oy} ${blur}px ${spread}px ${c}`,
+        ];
+    };
 
-    // Apply glow based on distance
+    // Offset/spread per direction — initiator's meld edge
+    const cfg: Record<EdgeDirection, [string, string]> = {
+        right:  ['8px', '0'],
+        bottom: ['0', '8px'],
+        top:    ['0', '-8px'],
+    };
+    const [ox, oy] = cfg[direction];
+
     if (distance < MELD_THRESHOLD) {
-        // Ready to meld - strong glow
-        initiatorElement.style.boxShadow = `${strongOffset} 20px rgba(255, 69, 0, ${intensity * 0.6})`;
-        targetElement.style.boxShadow = `${strongOffsetReverse} 20px rgba(255, 69, 0, ${intensity * 0.6})`;
+        const [iShadow, tShadow] = edgeShadow(ox, oy, 12, -4, intensity * 0.6);
+        initiatorElement.style.boxShadow = iShadow;
+        targetElement.style.boxShadow = tShadow;
         initiatorElement.classList.add('meld-ready');
         targetElement.classList.add('meld-target');
     } else {
-        // Approaching - mild glow
-        const glowIntensity = intensity * 0.3;
-        initiatorElement.style.boxShadow = `${mildOffset} 10px rgba(255, 140, 0, ${glowIntensity})`;
-        targetElement.style.boxShadow = `${mildOffsetReverse} 10px rgba(255, 140, 0, ${glowIntensity})`;
+        const [iShadow, tShadow] = edgeShadow(ox, oy, 8, -4, intensity * 0.3);
+        initiatorElement.style.boxShadow = iShadow;
+        targetElement.style.boxShadow = tShadow;
     }
 }
 

--- a/packages/glyphs/meld/meldability.ts
+++ b/packages/glyphs/meld/meldability.ts
@@ -7,7 +7,7 @@
  * Each glyph has directional ports that define valid connections:
  * - right: horizontal data flow (ax → py → prompt, py → py)
  * - bottom: result/output attachment (py ↓ result, prompt ↓ result)
- * - top: (reserved for future upward connections)
+ * - top: upward attachment (ax ↑ chart — visualization above data source)
  */
 
 import type { EdgeDirection } from '../composition';
@@ -27,7 +27,7 @@ const ALL_GLYPH_CLASSES = [
     'canvas-ax-glyph', 'canvas-se-glyph', 'canvas-py-glyph',
     'canvas-prompt-glyph', 'canvas-doc-glyph', 'canvas-note-glyph',
     'canvas-result-glyph', 'canvas-subcanvas-glyph',
-    'canvas-plugin-glyph',
+    'canvas-plugin-glyph', 'canvas-chart-glyph',
 ] as const;
 
 /**
@@ -36,7 +36,8 @@ const ALL_GLYPH_CLASSES = [
  */
 export const MELDABILITY: Record<string, readonly PortRule[]> = {
     'canvas-ax-glyph': [
-        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph', 'canvas-subcanvas-glyph'] }
+        { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph', 'canvas-subcanvas-glyph'] },
+        { direction: 'top', targets: ['canvas-chart-glyph'] }
     ],
     'canvas-se-glyph': [
         { direction: 'right', targets: ['canvas-prompt-glyph', 'canvas-py-glyph', 'canvas-se-glyph', 'canvas-subcanvas-glyph'] }
@@ -61,6 +62,7 @@ export const MELDABILITY: Record<string, readonly PortRule[]> = {
     'canvas-plugin-glyph': [
         { direction: 'bottom', targets: ['canvas-result-glyph', 'canvas-subcanvas-glyph'] }
     ],
+    'canvas-chart-glyph': [],
     'canvas-subcanvas-glyph': [
         { direction: 'right', targets: ALL_GLYPH_CLASSES },
         { direction: 'bottom', targets: ALL_GLYPH_CLASSES },

--- a/web/ts/components/glyph/canvas-chart-glyph.ts
+++ b/web/ts/components/glyph/canvas-chart-glyph.ts
@@ -1,0 +1,168 @@
+/**
+ * Chart Glyph — attestation data visualization on canvas.
+ *
+ * Renders a D3 chart. Will meld above data-producing glyphs (ax, sigma)
+ * and visualize whatever flows through the composition edge.
+ *
+ * Phase 1: standalone with dummy data, proves the glyph lives on canvas.
+ */
+
+import type { Glyph } from '@qntx/glyphs';
+import { canvasPlaced, wireExpandToWindow, preventDrag } from '@qntx/glyphs';
+import * as d3 from 'd3';
+import { el } from '../../html-utils';
+
+const CHART_SYMBOL = 'chart';
+
+export { CHART_SYMBOL };
+
+export async function createChartGlyph(glyph: Glyph): Promise<HTMLElement> {
+    const { element } = canvasPlaced({
+        glyph,
+        className: 'canvas-chart-glyph',
+        defaults: {
+            x: glyph.x ?? 200,
+            y: glyph.y ?? 200,
+            width: glyph.width ?? 420,
+            height: glyph.height ?? 280,
+        },
+        resizable: true,
+        logLabel: 'ChartGlyph',
+    });
+
+    // Minimal fold bar (like note glyph) — buttons appear on hover
+    const foldBar = el('div', {
+        class: 'glyph-title-bar chart-fold-bar',
+        style: {
+            height: '20px', minHeight: '20px', padding: '0 4px',
+            background: 'transparent', borderBottom: '1px solid rgba(100,116,139,0.2)',
+            cursor: 'move', display: 'flex', alignItems: 'center',
+            justifyContent: 'flex-end', gap: '2px',
+        },
+    });
+
+    const expandBtn = el('button', { text: '\u2B06' });
+    expandBtn.title = 'Expand to window';
+    expandBtn.style.cssText = 'width:20px;height:18px;font-size:11px;padding:0;background:transparent;border:none;color:#64748b;cursor:pointer;opacity:0;transition:opacity 0.15s ease;display:flex;align-items:center;justify-content:center;';
+    preventDrag(expandBtn);
+
+    foldBar.addEventListener('mouseenter', () => { expandBtn.style.opacity = '1'; });
+    foldBar.addEventListener('mouseleave', () => { expandBtn.style.opacity = '0'; });
+
+    foldBar.appendChild(expandBtn);
+    element.appendChild(foldBar);
+
+    // Chart container — fills remaining space
+    const chartContainer = el('div', {
+        class: 'glyph-content-area',
+        style: { flex: '1', overflow: 'hidden' },
+    });
+    element.appendChild(chartContainer);
+
+    // Render chart
+    renderChart(chartContainer);
+
+    // Re-render on resize
+    const observer = new ResizeObserver(() => {
+        renderChart(chartContainer);
+    });
+    observer.observe(chartContainer);
+
+    // Wire expand-to-window
+    wireExpandToWindow({
+        element,
+        expandBtn,
+        glyphId: glyph.id,
+        title: 'Chart',
+        symbol: CHART_SYMBOL,
+        renderContent: () => {
+            const content = el('div', { style: { flex: '1' } });
+            renderChart(content);
+            return content;
+        },
+        logLabel: 'ChartGlyph',
+    });
+
+    return element;
+}
+
+/** Render a D3 line chart with dummy data into container */
+function renderChart(container: HTMLElement): void {
+    container.innerHTML = '';
+
+    const rect = container.getBoundingClientRect();
+    const width = Math.max(rect.width, 120);
+    const height = Math.max(rect.height, 80);
+    const margin = { top: 8, right: 12, bottom: 24, left: 36 };
+    const innerW = width - margin.left - margin.right;
+    const innerH = height - margin.top - margin.bottom;
+
+    // Dummy time-series data
+    const now = Date.now();
+    const day = 86400000;
+    const data = Array.from({ length: 14 }, (_, i) => ({
+        date: new Date(now - (13 - i) * day),
+        value: Math.floor(Math.random() * 40 + 10 + i * 2),
+    }));
+
+    const svg = d3.select(container)
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height);
+
+    const g = svg.append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+    const x = d3.scaleTime()
+        .domain(d3.extent(data, d => d.date) as [Date, Date])
+        .range([0, innerW]);
+
+    const y = d3.scaleLinear()
+        .domain([0, (d3.max(data, d => d.value) || 0) * 1.1])
+        .range([innerH, 0]);
+
+    // Area
+    const area = d3.area<typeof data[0]>()
+        .x(d => x(d.date))
+        .y0(innerH)
+        .y1(d => y(d.value))
+        .curve(d3.curveMonotoneX);
+
+    g.append('path')
+        .datum(data)
+        .attr('fill', '#4ade80')
+        .attr('fill-opacity', 0.15)
+        .attr('d', area);
+
+    // Line
+    const line = d3.line<typeof data[0]>()
+        .x(d => x(d.date))
+        .y(d => y(d.value))
+        .curve(d3.curveMonotoneX);
+
+    g.append('path')
+        .datum(data)
+        .attr('fill', 'none')
+        .attr('stroke', '#4ade80')
+        .attr('stroke-width', 1.5)
+        .attr('d', line);
+
+    // X axis
+    g.append('g')
+        .attr('transform', `translate(0,${innerH})`)
+        .call(d3.axisBottom(x).ticks(5).tickFormat(d3.timeFormat('%m/%d') as any))
+        .selectAll('text')
+        .style('fill', '#64748b')
+        .style('font-size', '10px');
+
+    // Y axis
+    g.append('g')
+        .call(d3.axisLeft(y).ticks(4))
+        .selectAll('text')
+        .style('fill', '#64748b')
+        .style('font-size', '10px');
+
+    // Style axis lines
+    g.selectAll('path, line')
+        .style('stroke', '#334155');
+}

--- a/web/ts/components/glyph/glyph-registry.ts
+++ b/web/ts/components/glyph/glyph-registry.ts
@@ -20,6 +20,7 @@ import { createSubcanvasGlyph } from './subcanvas-glyph';
 import { createAttestationGlyph } from './attestation-glyph';
 import { createSigmaGlyph } from './sigma-glyph';
 import { createResultGlyph } from './result-glyph';
+import { createChartGlyph, CHART_SYMBOL } from './canvas-chart-glyph';
 
 export interface GlyphTypeEntry {
     /** Symbol identifier (e.g., AX, 'py', SO, Prose) */
@@ -54,6 +55,7 @@ const GLYPH_TYPES: GlyphTypeEntry[] = [
     { symbol: AS,       className: 'canvas-attestation-glyph', title: 'Attestation', label: 'AS',        render: createAttestationGlyph },
     { symbol: Sigma,    className: 'canvas-sigma-glyph',       title: 'Sigma',       label: 'Sigma',     render: createSigmaGlyph },
     { symbol: 'stream', className: 'canvas-stream-glyph',      title: 'Stream',      label: 'Stream',    render: (g) => createResultGlyph(g) },
+    { symbol: CHART_SYMBOL, className: 'canvas-chart-glyph',  title: 'Chart',       label: 'Chart',     render: createChartGlyph, spawnMenuOrder: 7 },
 ];
 
 const _bySymbol = new Map(GLYPH_TYPES.map(e => [e.symbol, e]));

--- a/web/ts/components/glyph/meld/meld-detect.test.ts
+++ b/web/ts/components/glyph/meld/meld-detect.test.ts
@@ -185,6 +185,36 @@ describe('Subcanvas top/bottom disambiguation', () => {
     });
 });
 
+describe('Top direction meld detection', () => {
+    test('chart dragged above ax — reverse top meld detected', () => {
+        const canvas = document.createElement('div');
+        document.body.appendChild(canvas);
+
+        const axElement = document.createElement('div');
+        axElement.className = 'canvas-ax-glyph';
+        axElement.setAttribute('data-glyph-id', 'ax1');
+        canvas.appendChild(axElement);
+
+        const chartElement = document.createElement('div');
+        chartElement.className = 'canvas-chart-glyph';
+        chartElement.setAttribute('data-glyph-id', 'chart1');
+        canvas.appendChild(chartElement);
+
+        // ax below, chart above with 20px gap — well within PROXIMITY_THRESHOLD
+        mockRect(axElement, { left: 100, top: 300, width: 400, height: 200 });
+        mockRect(chartElement, { left: 100, top: 80, width: 400, height: 200 });
+
+        const result = findMeldTarget(chartElement);
+
+        expect(result.target).toBe(axElement);
+        expect(result.direction).toBe('top');
+        expect(result.reversed).toBe(true);
+        expect(result.distance).toBeLessThan(PROXIMITY_THRESHOLD);
+
+        document.body.innerHTML = '';
+    });
+});
+
 describe('findMeldTarget detects composition targets', () => {
     test('standalone prompt finds py inside composition via reverse detection', () => {
         uiState.setCanvasCompositions([]);

--- a/web/ts/components/glyph/meld/meldability.test.ts
+++ b/web/ts/components/glyph/meld/meldability.test.ts
@@ -133,12 +133,13 @@ describe('Port-aware MELDABILITY registry', () => {
             expect(targets).toContain('canvas-result-glyph');
         });
 
-        test('ax can target prompt, py, and subcanvas', () => {
+        test('ax can target prompt, py, subcanvas, and chart', () => {
             const targets = getCompatibleTargets('canvas-ax-glyph');
             expect(targets).toContain('canvas-prompt-glyph');
             expect(targets).toContain('canvas-py-glyph');
             expect(targets).toContain('canvas-subcanvas-glyph');
-            expect(targets.length).toBe(3);
+            expect(targets).toContain('canvas-chart-glyph');
+            expect(targets.length).toBe(4);
         });
 
         test('se can target prompt, py, se, and subcanvas', () => {


### PR DESCRIPTION
## Summary

- Chart glyph: headerless D3 area+line chart on canvas, spawnable from tray, fold bar with hover-reveal expand, resize-aware
- Meld: ax gets `top` port targeting chart, single-edge box-shadows replace bleed-all-sides glow for all directions
- Top direction detection tested and proven (glow, meld trigger)

## Known issue

Top meld triggers correctly but composition jumps after layout — `performMeld` doesn't compensate for the initiator's non-zero grid offset when direction is `top`. Documented in `docs/glyphs/top-meld-jump.md`.

## Test plan

- [x] 663 tests pass
- [x] Chart spawns from tray
- [x] Fold bar expand button appears on hover
- [x] Left-to-right meld glow works (single-edge)
- [x] Top meld glow works (correct edges light up)
- [x] Top meld triggers on release
- [ ] Composition jump after top meld (known, documented)