### PR TITLE
Turnstile: types as first-class glyphs

### DIFF
--- a/ats/identity/id_noqntx.go
+++ b/ats/identity/id_noqntx.go
@@ -8,6 +8,10 @@ func generateASUID(prefix, subject, predicate, context string) (string, error) {
 	return "", errors.New("ASUID generation requires qntxwasm build tag")
 }
 
+func generateCompactASUID(prefix, name string) (string, error) {
+	return "", errors.New("compact ASUID generation requires qntxwasm build tag")
+}
+
 func generateRandomID(length int) (string, error) {
 	return "", errors.New("random ID generation requires qntxwasm build tag")
 }

--- a/ats/identity/id_qntx.go
+++ b/ats/identity/id_qntx.go
@@ -16,6 +16,15 @@ func generateASUID(prefix, subject, predicate, context string) (string, error) {
 	return engine.GenerateASUID(prefix, subject, predicate, context)
 }
 
+// generateCompactASUID generates a compact ASUID via the Rust WASM engine.
+func generateCompactASUID(prefix, name string) (string, error) {
+	engine, err := wasm.GetEngine()
+	if err != nil {
+		return "", errors.Wrapf(err, "WASM engine unavailable for compact ASUID %s/%s", prefix, name)
+	}
+	return engine.GenerateCompactASUID(prefix, name)
+}
+
 // generateRandomID generates a random ID via the Rust WASM engine.
 func generateRandomID(length int) (string, error) {
 	engine, err := wasm.GetEngine()

--- a/ats/identity/identity.go
+++ b/ats/identity/identity.go
@@ -34,6 +34,18 @@ func GenerateASUIDWithRetry(prefix, subject, predicate, context string, checkExi
 	return "", errors.Newf("ASUID collision after %d retries for %s/%s/%s", maxRetries, subject, predicate, context)
 }
 
+// GenerateTypeID generates a compact type ASUID (TY prefix).
+// Format: TY-COMMIT-7K4M3B9X
+func GenerateTypeID(typeName string) (string, error) {
+	return generateCompactASUID("TY", typeName)
+}
+
+// GenerateRelationshipTypeID generates a compact relationship type ASUID (RT prefix).
+// Format: RT-IS_CHILD-7K4M3B9X
+func GenerateRelationshipTypeID(predicateName string) (string, error) {
+	return generateCompactASUID("RT", predicateName)
+}
+
 // GenerateJobID generates a Job ASUID (JB prefix).
 func GenerateJobID(jobType, source string) (string, error) {
 	return generateASUID("JB", jobType, "process", source)

--- a/ats/types/type_definitions.go
+++ b/ats/types/type_definitions.go
@@ -60,47 +60,31 @@ type RelationshipTypeDef struct {
 
 // AttestType creates a type definition attestation with arbitrary attributes.
 //
-// Format: "as <typeName> type graph" with self-certifying actor (type-as-actor pattern).
+// Format: "[typeName] is type" with self-certifying actor (type-as-actor pattern).
+// No context — a type exists because it was attested, not because it belongs to a namespace.
 //
 // The typeName becomes its own actor in the typespace, separate from the ASID entity space.
 // This avoids bounded storage limits (64 actors per entity) since each type self-certifies.
-//
-// Attributes typically include display metadata for graph visualization:
-//   - display_color: Hex color code (e.g., "#3498db")
-//   - display_label: Human-readable label (e.g., "Document")
-//   - deprecated: Boolean flag for phasing out types
-//   - opacity: Float for visual emphasis (0.0-1.0)
-//   - rich_string_fields: Array of metadata field names containing rich text (e.g., ["notes", "description"])
-//   - array_fields: Array of field names that should be flattened into arrays (e.g., ["skills", "tags"])
-//
-// But can contain any JSON-serializable data relevant to the type definition.
 //
 // Example usage:
 //
 //	attrs := map[string]interface{}{
 //	    "display_color": "#e67e22",
 //	    "display_label": "Document",
-//	    "deprecated": false,
-//	    "opacity": 1.0,
-//	    "rich_string_fields": []string{"content", "summary"},
-//	    "array_fields": []string{"tags", "categories"},
 //	}
 //	err := types.AttestType(store, "document", "ix-content", attrs)
-func AttestType(store AttestationStore, typeName, source, context string, attributes map[string]interface{}) error {
+func AttestType(store AttestationStore, typeName, source string, attributes map[string]interface{}) error {
 	if typeName == "" {
 		return errors.New("typeName cannot be empty")
 	}
 	if source == "" {
 		return errors.New("source cannot be empty")
 	}
-	if context == "" {
-		return errors.New("context cannot be empty")
-	}
 
 	// Generate ASUID via Rust WASM engine
-	asuid, err := identity.GenerateASUID("AS", typeName, "type", context)
+	asuid, err := identity.GenerateTypeID(typeName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to generate ASUID for type %s", typeName)
+		return errors.Wrapf(err, "failed to generate type ID for %s", typeName)
 	}
 
 	// Create attestation with self-certifying actor
@@ -110,7 +94,6 @@ func AttestType(store AttestationStore, typeName, source, context string, attrib
 		ID:         asuid,
 		Subjects:   []string{typeName},
 		Predicates: []string{"type"},
-		Contexts:   []string{context},
 		Actors:     []string{typeName}, // Self-certifying: type IS its own actor
 		Timestamp:  now,
 		CreatedAt:  now,
@@ -127,7 +110,6 @@ func AttestType(store AttestationStore, typeName, source, context string, attrib
 }
 
 // EnsureTypes ensures the specified types exist in the attestation store.
-// This creates type attestations with display metadata for graph visualization.
 //
 // Non-fatal: If type creation fails, the error is returned but ingestion can continue
 // with hardcoded fallback type colors/labels.
@@ -135,11 +117,6 @@ func AttestType(store AttestationStore, typeName, source, context string, attrib
 // Example usage:
 //
 //	err := types.EnsureTypes(store, "ixgest-git", types.Commit, types.Author, types.Branch)
-//	if err != nil {
-//	    logger.Errorw("Failed to create type definitions - falling back to hardcoded types",
-//	        "error", err,
-//	        "impact", "graph visualization may lack custom type metadata")
-//	}
 func EnsureTypes(store AttestationStore, source string, typeDefs ...TypeDef) error {
 	var errs []error
 
@@ -150,7 +127,7 @@ func EnsureTypes(store AttestationStore, source string, typeDefs ...TypeDef) err
 			def.Opacity = &defaultOpacity
 		}
 
-		if err := AttestType(store, def.Name, source, "graph", attrs.From(def)); err != nil {
+		if err := AttestType(store, def.Name, source, attrs.From(def)); err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to attest type %s", def.Name))
 		}
 	}
@@ -169,17 +146,8 @@ func EnsureTypes(store AttestationStore, source string, typeDefs ...TypeDef) err
 
 // AttestRelationshipType creates a relationship type definition attestation with physics metadata.
 //
-// Format: "as <predicateName> relationship_type graph" with self-certifying actor.
-//
-// Similar to node types, relationship types use the type-as-actor pattern in typespace.
-// The predicate name becomes its own actor, avoiding bounded storage limits.
-//
-// Attributes typically include physics and display metadata for graph visualization:
-//   - display_label: Human-readable label (e.g., "Child Of")
-//   - link_distance: D3 force distance (e.g., 50)
-//   - link_strength: D3 force strength (e.g., 0.3)
-//   - color: Optional link color override (e.g., "#666")
-//   - deprecated: Boolean flag for phasing out types
+// Format: "[predicateName] is relationship_type" with self-certifying actor.
+// No context — same as node types.
 //
 // Example usage:
 //
@@ -187,7 +155,6 @@ func EnsureTypes(store AttestationStore, source string, typeDefs ...TypeDef) err
 //	    "display_label": "Child Of",
 //	    "link_distance": 50.0,
 //	    "link_strength": 0.3,
-//	    "deprecated": false,
 //	}
 //	err := types.AttestRelationshipType(store, "is_child_of", "ix-git", attrs)
 func AttestRelationshipType(store AttestationStore, predicateName, source string, attributes map[string]interface{}) error {
@@ -199,9 +166,9 @@ func AttestRelationshipType(store AttestationStore, predicateName, source string
 	}
 
 	// Generate ASUID via Rust WASM engine
-	asuid, err := identity.GenerateASUID("AS", predicateName, "relationship_type", "graph")
+	asuid, err := identity.GenerateRelationshipTypeID(predicateName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to generate ASUID for relationship type %s", predicateName)
+		return errors.Wrapf(err, "failed to generate relationship type ID for %s", predicateName)
 	}
 
 	// Create attestation with self-certifying actor
@@ -209,7 +176,6 @@ func AttestRelationshipType(store AttestationStore, predicateName, source string
 		ID:         asuid,
 		Subjects:   []string{predicateName},
 		Predicates: []string{"relationship_type"},
-		Contexts:   []string{"graph"},
 		Actors:     []string{predicateName}, // Self-certifying: predicate IS its own actor
 		Timestamp:  time.Now(),
 		Source:     source,
@@ -225,7 +191,6 @@ func AttestRelationshipType(store AttestationStore, predicateName, source string
 }
 
 // EnsureRelationshipTypes ensures the specified relationship types exist in the attestation store.
-// This creates relationship type attestations with physics and display metadata for graph visualization.
 //
 // Non-fatal: If relationship type creation fails, the error is returned but ingestion can continue
 // with hardcoded fallback physics values in the frontend.
@@ -233,11 +198,6 @@ func AttestRelationshipType(store AttestationStore, predicateName, source string
 // Example usage:
 //
 //	err := types.EnsureRelationshipTypes(store, "ixgest-git", types.IsChildOf, types.PointsTo)
-//	if err != nil {
-//	    logger.Errorw("Failed to create relationship type definitions",
-//	        "error", err,
-//	        "impact", "graph physics will use default values")
-//	}
 func EnsureRelationshipTypes(store AttestationStore, source string, relationshipDefs ...RelationshipTypeDef) error {
 	var errs []error
 

--- a/ats/types/type_definitions_test.go
+++ b/ats/types/type_definitions_test.go
@@ -15,7 +15,7 @@ func (m *MockAttestationStore) CreateAttestation(as *As) error {
 func TestAttestType_Basic(t *testing.T) {
 	store := &MockAttestationStore{}
 
-	err := AttestType(store, "document", "test-source", "graph", map[string]interface{}{
+	err := AttestType(store, "document", "test-source", map[string]interface{}{
 		"display_color": "#3498db",
 		"display_label": "Document",
 	})
@@ -38,12 +38,17 @@ func TestAttestType_Basic(t *testing.T) {
 	if as.Predicates[0] != "type" {
 		t.Errorf("expected predicate 'type', got %v", as.Predicates[0])
 	}
+
+	// Type attestations have no context
+	if len(as.Contexts) != 0 {
+		t.Errorf("expected no contexts, got %v", as.Contexts)
+	}
 }
 
 func TestAttestType_SelfCertifyingActor(t *testing.T) {
 	store := &MockAttestationStore{}
 
-	err := AttestType(store, "artifact", "test-source", "graph", map[string]interface{}{
+	err := AttestType(store, "artifact", "test-source", map[string]interface{}{
 		"display_color": "#9b59b6",
 	})
 
@@ -72,7 +77,7 @@ func TestAttestType_SelfCertifyingActor(t *testing.T) {
 func TestAttestType_EmptyTypeName(t *testing.T) {
 	store := &MockAttestationStore{}
 
-	err := AttestType(store, "", "test-source", "graph", map[string]interface{}{
+	err := AttestType(store, "", "test-source", map[string]interface{}{
 		"display_color": "#000000",
 	})
 
@@ -93,7 +98,7 @@ func TestAttestType_EmptyTypeName(t *testing.T) {
 func TestAttestType_EmptySource(t *testing.T) {
 	store := &MockAttestationStore{}
 
-	err := AttestType(store, "document", "", "graph", map[string]interface{}{
+	err := AttestType(store, "document", "", map[string]interface{}{
 		"display_color": "#000000",
 	})
 

--- a/ats/wasm/engine.go
+++ b/ats/wasm/engine.go
@@ -387,6 +387,51 @@ func (e *Engine) GenerateASUID(prefix, subject, predicate, context string) (stri
 	return result.Full, nil
 }
 
+// GenerateCompactASUID generates a compact ASUID with a single name segment.
+// Used for type IDs (TY-COMMIT-7K4M3B9X) and relationship type IDs (RT-IS_CHILD-7K4M3B9X).
+func (e *Engine) GenerateCompactASUID(prefix, name string) (string, error) {
+	randomBytes := make([]byte, 8)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", errors.Wrap(err, "crypto/rand failed for compact ASUID generation")
+	}
+
+	byteArray := make([]int, len(randomBytes))
+	for i, b := range randomBytes {
+		byteArray[i] = int(b)
+	}
+
+	input, err := json.Marshal(struct {
+		Prefix      string `json:"prefix"`
+		Name        string `json:"name"`
+		RandomBytes []int  `json:"random_bytes"`
+	}{
+		Prefix:      prefix,
+		Name:        name,
+		RandomBytes: byteArray,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "marshal generate_compact_asuid input")
+	}
+
+	raw, err := e.Call("generate_compact_asuid", string(input))
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		AsuidResult
+		Error string `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return "", errors.Wrapf(err, "unmarshal generate_compact_asuid result: %s", raw)
+	}
+	if result.Error != "" {
+		return "", errors.Newf("generate_compact_asuid: %s", result.Error)
+	}
+
+	return result.Full, nil
+}
+
 // GenerateRandomID generates a random ID of the given length using the QNTX alphabet.
 // Randomness comes from crypto/rand.
 func (e *Engine) GenerateRandomID(length int) (string, error) {

--- a/crates/qntx-grpc/src/types/sym.rs
+++ b/crates/qntx-grpc/src/types/sym.rs
@@ -34,6 +34,7 @@ pub const SE: &str = "⊨";
 pub const SO: &str = "⟶";
 pub const SIGMA: &str = "Σ";
 pub const SUBCANVAS: &str = "⌗";
+pub const r#TYPE: &str = "⊢";
 pub const WATCHER: &str = "⏿";
 
 pub const PALETTE_ORDER: &[&str] = &[I, AM, IX, AX, BY, AT, SO, SE];

--- a/crates/qntx-id/src/asuid.rs
+++ b/crates/qntx-id/src/asuid.rs
@@ -25,18 +25,19 @@ const SUFFIX_LEN: usize = 8;
 /// Number of suffix characters shown in the short display form.
 const SUFFIX_SHORT: usize = 4;
 
-/// An attestation identifier with readable SPC segments and random suffix.
+/// An attestation identifier with readable segments and random suffix.
+///
+/// Segments are flexible: full SPC attestations use 3 (`AS-SARAH-AUTHOR-GITHUB-7K4M3B9X`),
+/// type IDs use 1 (`TY-COMMIT-7K4M3B9X`), relationship type IDs use 1 (`RT-IS_CHILD-7K4M3B9X`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Asuid {
     prefix: [u8; 2],
-    subject: String,
-    predicate: String,
-    context: String,
+    segments: Vec<String>,
     suffix: String,
 }
 
 impl Asuid {
-    /// Build an ASUID from its components and random bytes.
+    /// Build an ASUID from SPC components and random bytes.
     ///
     /// The caller provides randomness — the crate has no RNG dependency.
     /// Go callers use `crypto/rand`, browser uses `crypto.getRandomValues`.
@@ -60,6 +61,32 @@ impl Asuid {
         context: &str,
         random_bytes: &[u8],
     ) -> Option<Self> {
+        Self::from_segments(
+            prefix,
+            &[subject, predicate, context],
+            random_bytes,
+        )
+    }
+
+    /// Build a compact ASUID with a single name segment.
+    ///
+    /// Used for type IDs (`TY-COMMIT-7K4M3B9X`) and relationship type IDs
+    /// (`RT-IS_CHILD-7K4M3B9X`) where the prefix carries the semantics.
+    ///
+    /// ```
+    /// use qntx_id::Asuid;
+    ///
+    /// let bytes = [0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0xA7, 0xB8];
+    /// let id = Asuid::compact("TY", "commit", &bytes).unwrap();
+    /// assert!(id.to_string().starts_with("TY-COMIT-")); // clean_seed collapses "mm"
+    /// assert_eq!(id.full().matches('-').count(), 2);
+    /// ```
+    pub fn compact(prefix: &str, name: &str, random_bytes: &[u8]) -> Option<Self> {
+        Self::from_segments(prefix, &[name], random_bytes)
+    }
+
+    /// Build an ASUID from a prefix, arbitrary segments, and random bytes.
+    fn from_segments(prefix: &str, segments: &[&str], random_bytes: &[u8]) -> Option<Self> {
         let prefix_bytes = validate_prefix(prefix)?;
         if random_bytes.len() < SUFFIX_LEN {
             return None;
@@ -68,14 +95,12 @@ impl Asuid {
 
         Some(Self {
             prefix: prefix_bytes,
-            subject: truncate_segment(subject),
-            predicate: truncate_segment(predicate),
-            context: truncate_segment(context),
+            segments: segments.iter().map(|s| truncate_segment(s)).collect(),
             suffix,
         })
     }
 
-    /// The 2-letter prefix (e.g. "AS", "JB", "PX").
+    /// The 2-letter prefix (e.g. "AS", "JB", "PX", "TY", "RT").
     pub fn prefix(&self) -> &str {
         std::str::from_utf8(&self.prefix).unwrap()
     }
@@ -92,26 +117,20 @@ impl Asuid {
     /// assert_eq!(full.matches('-').count(), 4);
     /// ```
     pub fn full(&self) -> String {
-        format!(
-            "{}-{}-{}-{}-{}",
-            self.prefix(),
-            self.subject,
-            self.predicate,
-            self.context,
-            self.suffix,
-        )
+        let mut parts = Vec::with_capacity(self.segments.len() + 2);
+        parts.push(self.prefix().to_string());
+        parts.extend(self.segments.iter().cloned());
+        parts.push(self.suffix.clone());
+        parts.join("-")
     }
 
     /// Short display form with truncated suffix (for logs).
     pub fn short(&self) -> String {
-        format!(
-            "{}-{}-{}-{}-{}",
-            self.prefix(),
-            self.subject,
-            self.predicate,
-            self.context,
-            &self.suffix[..SUFFIX_SHORT],
-        )
+        let mut parts = Vec::with_capacity(self.segments.len() + 2);
+        parts.push(self.prefix().to_string());
+        parts.extend(self.segments.iter().cloned());
+        parts.push(self.suffix[..SUFFIX_SHORT].to_string());
+        parts.join("-")
     }
 }
 
@@ -178,10 +197,8 @@ mod tests {
         let id1 = Asuid::new("AS", "Alice", "knows", "work", &BYTES_A).unwrap();
         let id2 = Asuid::new("AS", "Alice", "knows", "work", &BYTES_B).unwrap();
         assert_ne!(id1.to_string(), id2.to_string());
-        // SPC segments should match
-        assert_eq!(id1.subject, id2.subject);
-        assert_eq!(id1.predicate, id2.predicate);
-        assert_eq!(id1.context, id2.context);
+        // Segments should match
+        assert_eq!(id1.segments, id2.segments);
     }
 
     #[test]
@@ -250,6 +267,22 @@ mod tests {
         assert!(s.contains("MULER"));
         assert!(s.contains("CAFE"));
         assert!(s.contains("STRASE"));
+    }
+
+    #[test]
+    fn compact_type_id() {
+        let id = Asuid::compact("TY", "commit", &BYTES_A).unwrap();
+        assert!(id.to_string().starts_with("TY-COMIT-"), "got: {}", id); // clean_seed collapses "mm"→"m"
+        assert_eq!(id.full().matches('-').count(), 2);
+        assert_eq!(id.short().matches('-').count(), 2);
+    }
+
+    #[test]
+    fn compact_relationship_type_id() {
+        let id = Asuid::compact("RT", "is_child_of", &BYTES_A).unwrap();
+        // clean_seed strips underscores → "ISCHILDOF"
+        assert!(id.to_string().starts_with("RT-ISCHILDO"), "got: {}", id); // truncated to 8 chars
+        assert_eq!(id.full().matches('-').count(), 2);
     }
 
     #[test]

--- a/crates/qntx-wasm/src/identity.rs
+++ b/crates/qntx-wasm/src/identity.rs
@@ -37,6 +37,32 @@ pub(crate) fn generate_asuid_impl(input: &str) -> String {
     }
 }
 
+/// JSON input for compact ASUID generation (type/relationship type IDs).
+#[derive(serde::Deserialize)]
+pub(crate) struct CompactAsuidInput {
+    pub prefix: String,
+    pub name: String,
+    pub random_bytes: Vec<u8>,
+}
+
+/// Generate a compact ASUID from JSON input, returning JSON with full and short forms.
+pub(crate) fn generate_compact_asuid_impl(input: &str) -> String {
+    let parsed: CompactAsuidInput = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            return format!(
+                r#"{{"error":"invalid JSON: {}"}}"#,
+                e.to_string().replace('"', "\\\"")
+            )
+        }
+    };
+
+    match qntx_id::Asuid::compact(&parsed.prefix, &parsed.name, &parsed.random_bytes) {
+        Some(id) => format!(r#"{{"full":"{}","short":"{}"}}"#, id.full(), id.short()),
+        None => r#"{"error":"invalid compact ASUID input: check prefix (2 uppercase letters) and random_bytes (>= 8 bytes)"}"#.to_string(),
+    }
+}
+
 /// JSON input for random ID generation.
 #[derive(serde::Deserialize)]
 pub(crate) struct RandomIdInput {
@@ -96,6 +122,36 @@ mod tests {
         let short_suffix = parsed["short"].as_str().unwrap().split('-').last().unwrap();
         assert_eq!(full_suffix.len(), 8);
         assert_eq!(short_suffix.len(), 4);
+    }
+
+    #[test]
+    fn generate_compact_asuid_type() {
+        let input = serde_json::json!({
+            "prefix": "TY",
+            "name": "commit",
+            "random_bytes": [0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0xA7, 0xB8]
+        });
+        let result = generate_compact_asuid_impl(&input.to_string());
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["error"].is_null(), "unexpected error: {}", result);
+        let full = parsed["full"].as_str().unwrap();
+        assert!(full.starts_with("TY-COMIT-"), "got: {}", full);
+        assert_eq!(full.matches('-').count(), 2);
+    }
+
+    #[test]
+    fn generate_compact_asuid_relationship_type() {
+        let input = serde_json::json!({
+            "prefix": "RT",
+            "name": "is_child_of",
+            "random_bytes": [0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0xA7, 0xB8]
+        });
+        let result = generate_compact_asuid_impl(&input.to_string());
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["error"].is_null(), "unexpected error: {}", result);
+        let full = parsed["full"].as_str().unwrap();
+        assert!(full.starts_with("RT-"), "got: {}", full);
+        assert_eq!(full.matches('-').count(), 2);
     }
 
     #[test]

--- a/crates/qntx-wasm/src/lib.rs
+++ b/crates/qntx-wasm/src/lib.rs
@@ -435,6 +435,16 @@ mod wazero {
         write_result(&crate::identity::generate_asuid_impl(input))
     }
 
+    /// Generate a compact ASUID with a single name segment (for type/relationship type IDs).
+    /// Input: `{"prefix":"TY","name":"commit","random_bytes":[161,178,...]}`
+    /// Returns packed u64 pointing to `{"full":"TY-COMMIT-7K4M3B9X","short":"TY-COMMIT-7K4M"}`
+    /// or `{"error":"..."}` on invalid input.
+    #[no_mangle]
+    pub extern "C" fn generate_compact_asuid(ptr: u32, len: u32) -> u64 {
+        let input = unsafe { read_str(ptr, len) };
+        write_result(&crate::identity::generate_compact_asuid_impl(input))
+    }
+
     /// Generate a random ID using the QNTX alphabet.
     /// Input: `{"length":8,"random_bytes":[161,178,...]}`
     /// Returns packed u64 pointing to `{"id":"A3B7X9K2"}` or `{"error":"..."}`.

--- a/docs/attested-types.md
+++ b/docs/attested-types.md
@@ -1,3 +1,11 @@
 # Attested Types
 
 Types exist through attestation - 'restaurant' is real because someone attested it, not because a schema declares it. That attestation carries everything: what fields matter, which ones are searchable, how it appears visually, and crucially, who made these decisions and when. Types can contradict, overlap, and evolve because they're attestations - the mess is the message. Multiple actors might attest different meanings for 'restaurant' - a health inspector sees safety fields, a food critic sees ambiance, a delivery app sees logistics. This multiplicity isn't a problem to solve - it's the actual shape of knowledge in contested domains. Types become part of the conversation, not the rules that govern it.
+
+## Attestation format
+
+A type attestation is: `[typeName] is type`. No context — a type exists because it was attested, not because it belongs to a namespace. The `source` field records who attested it. Attributes carry display metadata (color, label, opacity) and semantic information (rich string fields, array fields).
+
+The type name is its own actor (self-certifying in typespace), avoiding bounded storage limits.
+
+Relationship types follow the same pattern: `[predicateName] is relationship_type`.

--- a/docs/attested-types.md
+++ b/docs/attested-types.md
@@ -2,6 +2,10 @@
 
 Types exist through attestation - 'restaurant' is real because someone attested it, not because a schema declares it. That attestation carries everything: what fields matter, which ones are searchable, how it appears visually, and crucially, who made these decisions and when. Types can contradict, overlap, and evolve because they're attestations - the mess is the message. Multiple actors might attest different meanings for 'restaurant' - a health inspector sees safety fields, a food critic sees ambiance, a delivery app sees logistics. This multiplicity isn't a problem to solve - it's the actual shape of knowledge in contested domains. Types become part of the conversation, not the rules that govern it.
 
+## Symbol
+
+`⊢` (turnstile) — an actor's judgment that a pattern deserves a name. From type theory: "I assert this has type." Available as `sym.Type` (Go) and `Type` from `@generated/sym.js` (frontend).
+
 ## Attestation format
 
 A type attestation is: `[typeName] is type`. No context — a type exists because it was attested, not because it belongs to a namespace. The `source` field records who attested it. Attributes carry display metadata (color, label, opacity) and semantic information (rich string fields, array fields).
@@ -9,3 +13,12 @@ A type attestation is: `[typeName] is type`. No context — a type exists becaus
 The type name is its own actor (self-certifying in typespace), avoiding bounded storage limits.
 
 Relationship types follow the same pattern: `[predicateName] is relationship_type`.
+
+## Identity
+
+Type attestations use compact ASUIDs with dedicated prefixes:
+
+- Types: `TY-{NAME}-{SUFFIX}` (e.g. `TY-COMIT-7K4M3B9X`)
+- Relationship types: `RT-{NAME}-{SUFFIX}` (e.g. `RT-ISCHILDO-9F2X4K1L`)
+
+The prefix carries the semantics — no need to repeat "TYPE" as a segment.

--- a/docs/types/server.md
+++ b/docs/types/server.md
@@ -293,7 +293,7 @@ type ParsedATSCode struct {
 
 ## PluginGlyphDef {#pluginglyphdef}
 
-**Source**: [`server/handlers.go:771`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L771)
+**Source**: [`server/handlers.go:778`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L778)
 
 
 ```go
@@ -328,7 +328,7 @@ type PluginHealthMessage struct {
 
 ## PluginInfo {#plugininfo}
 
-**Source**: [`server/handlers.go:611`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L611)
+**Source**: [`server/handlers.go:618`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L618)
 
 
 ```go
@@ -349,7 +349,7 @@ type PluginInfo struct {
 
 ## PluginRoute {#pluginroute}
 
-**Source**: [`server/handlers.go:696`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L696)
+**Source**: [`server/handlers.go:703`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L703)
 
 
 ```go
@@ -637,7 +637,7 @@ type Result struct {
 
 ## RouteEndpoint {#routeendpoint}
 
-**Source**: [`server/handlers.go:690`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L690)
+**Source**: [`server/handlers.go:697`](https://github.com/teranos/QNTX/blob/main/server/handlers.go#L697)
 
 
 ```go

--- a/docs/types/sym.md
+++ b/docs/types/sym.md
@@ -34,6 +34,7 @@ const SE = "⊨"
 const SO = "⟶"
 const Sigma = "Σ"
 const Subcanvas = "⌗"
+const Type = "⊢"
 const Watcher = "⏿"
 ```
 

--- a/qntx-plugins/qntx-atproto/plugin.go
+++ b/qntx-plugins/qntx-atproto/plugin.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
@@ -105,7 +106,7 @@ func (p *Plugin) Initialize(ctx context.Context, services plugin.ServiceRegistry
 	// Attest type definitions for searchable fields
 	store := services.ATSStore()
 	if store != nil {
-		if err := EnsureTypes(store, "atproto", TimelinePost); err != nil {
+		if err := types.EnsureTypes(store, "atproto", TimelinePost); err != nil {
 			logger.Warnw("Failed to attest type definitions", "error", err)
 		}
 	}

--- a/qntx-plugins/qntx-atproto/types.go
+++ b/qntx-plugins/qntx-atproto/types.go
@@ -1,11 +1,6 @@
 package qntxatproto
 
-import (
-	"github.com/teranos/QNTX/ats"
-	"github.com/teranos/QNTX/ats/attrs"
-	"github.com/teranos/QNTX/ats/types"
-	"github.com/teranos/QNTX/errors"
-)
+import "github.com/teranos/QNTX/ats/types"
 
 // TimelinePost type definition for posts appearing in timeline
 var TimelinePost = types.TypeDef{
@@ -13,32 +8,4 @@ var TimelinePost = types.TypeDef{
 	Label:            "Timeline Post",
 	Color:            "#1da1f2", // Bluesky blue
 	RichStringFields: []string{"text"},
-}
-
-// EnsureTypes attests type definitions in the atproto context instead of graph
-func EnsureTypes(store ats.AttestationStore, source string, typeDefs ...types.TypeDef) error {
-	var errs []error
-
-	for _, def := range typeDefs {
-		// Default opacity to 1.0 if not explicitly set
-		if def.Opacity == nil {
-			defaultOpacity := 1.0
-			def.Opacity = &defaultOpacity
-		}
-
-		// Use unified AttestType with "atproto" context
-		if err := types.AttestType(store, def.Name, source, "atproto", attrs.From(def)); err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed to attest type %s", def.Name))
-		}
-	}
-
-	if len(errs) > 0 {
-		errMsg := "failed to create some type definitions:"
-		for _, err := range errs {
-			errMsg += "\n  - " + err.Error()
-		}
-		return errors.New(errMsg)
-	}
-
-	return nil
 }

--- a/server/handlers_types.go
+++ b/server/handlers_types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/teranos/QNTX/ats"
 	"github.com/teranos/QNTX/ats/types"
 	"github.com/teranos/QNTX/errors"
+	"github.com/teranos/QNTX/sym"
 )
 
 // fieldNameRegex validates field names: must start with letter, contain only alphanumeric and underscores
@@ -205,7 +206,7 @@ func (s *QNTXServer) handleCreateType(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use AttestType function from the types package
-	if err := types.AttestType(s.atsStore, req.Name, "web-ui", "graph", attributes); err != nil {
+	if err := types.AttestType(s.atsStore, req.Name, "web-ui", attributes); err != nil {
 		s.logger.Errorw("Failed to create type attestation",
 			"error", err,
 			"type", req.Name,
@@ -215,7 +216,7 @@ func (s *QNTXServer) handleCreateType(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.logger.Infow("Type attestation created",
+	s.logger.Infow(sym.Type+" Type attestation created",
 		"type", req.Name,
 		"label", req.Label,
 		"color", req.Color,

--- a/server/init.go
+++ b/server/init.go
@@ -26,6 +26,7 @@ import (
 	"github.com/teranos/QNTX/server/auth"
 	serverembeddings "github.com/teranos/QNTX/server/embeddings"
 	"github.com/teranos/QNTX/server/nodedid"
+	"github.com/teranos/QNTX/sym"
 	"go.uber.org/zap"
 )
 
@@ -243,10 +244,10 @@ func NewQNTXServer(db *sql.DB, atsStore ats.AttestationStore, dbPath string, ver
 
 	// Register system type definitions so attestations render in the graph
 	if err := types.EnsureTypes(atsStore, "prompt-direct", types.PromptResult); err != nil {
-		serverLogger.Warnw("Failed to register prompt-result type", "error", err)
+		serverLogger.Warnw(sym.Type+" Failed to register prompt-result type", "error", err)
 	}
 	if err := types.EnsureTypes(atsStore, "cluster-labeling", types.ClusterLabeled); err != nil {
-		serverLogger.Warnw("Failed to register cluster-labeled type", "error", err)
+		serverLogger.Warnw(sym.Type+" Failed to register cluster-labeled type", "error", err)
 	}
 
 	// Initialize domain plugin registry

--- a/sym/symbols.go
+++ b/sym/symbols.go
@@ -22,6 +22,7 @@ const (
 	// TODO: Consider alternative typeable symbol for OF
 
 	// Derived attestation types
+	Type  = "⊢" // type - an actor's judgment that a pattern deserves a name
 	Sigma = "Σ" // sigma - distilled/summarized attestation (sum of many observations)
 
 	// System infrastructure symbols

--- a/types/generated/typescript/sym.ts
+++ b/types/generated/typescript/sym.ts
@@ -23,6 +23,7 @@ export const SE = "⊨";
 export const SO = "⟶";
 export const Sigma = "Σ";
 export const Subcanvas = "⌗";
+export const Type = "⊢";
 export const Watcher = "⏿";
 
 

--- a/web/css/generated/sym.css
+++ b/web/css/generated/sym.css
@@ -22,5 +22,6 @@
   --sym-so: "⟶";
   --sym-sigma: "Σ";
   --sym-subcanvas: "⌗";
+  --sym-type: "⊢";
   --sym-watcher: "⏿";
 }

--- a/web/ts/components/glyph/ax-glyph.ts
+++ b/web/ts/components/glyph/ax-glyph.ts
@@ -32,6 +32,7 @@ import { queryAttestations, parseQuery } from '../../qntx-wasm';
 import { tooltip } from '../tooltip';
 import { spawnAttestationGlyph } from './attestation-glyph';
 import { isSigmaAttestation, renderSigmaResultLine } from './sigma-glyph';
+import { isTypeAttestation, groupTypeAttestations, renderTypeResultLine } from './type-result-line';
 import { renderTriple } from './attestation-triple';
 import { uiState } from '../../state/ui';
 import { syncStateManager } from '../../state/sync-state';
@@ -142,8 +143,23 @@ export function createAxGlyph(glyph: Glyph): HTMLElement {
                 const localResults = await queryAttestations(parsed.query);
                 searchingEl.remove();
                 const displayedIds = new Set<string>();
+                // Separate type attestations for subject grouping
+                const typeAtts: Attestation[] = [];
+                const otherAtts: Attestation[] = [];
                 for (const att of localResults) {
                     if (att.id) displayedIds.add(att.id);
+                    if (isTypeAttestation(att)) {
+                        typeAtts.push(att);
+                    } else {
+                        otherAtts.push(att);
+                    }
+                }
+                // Render grouped type attestations first
+                for (const group of groupTypeAttestations(typeAtts)) {
+                    resultsContainer.appendChild(renderTypeResultLine(group));
+                }
+                // Then render remaining attestations
+                for (const att of otherAtts) {
                     resultsContainer.appendChild(isSigmaAttestation(att) ? renderSigmaResultLine(att) : renderAttestation(att));
                 }
                 (element as any)._localIds = displayedIds;
@@ -318,6 +334,35 @@ export function updateAxGlyphResults(glyphId: string, attestation: Attestation):
             log.debug(SEG.GLYPH, `[AxGlyph] Skipped duplicate ${attestation.id} (already from local)`);
             return;
         }
+    }
+
+    // Type attestations: group by subject into a single line
+    if (isTypeAttestation(attestation)) {
+        const subject = attestation.subjects?.[0] || '';
+        const existing = resultsContainer.querySelector(`[data-type-subject="${subject}"]`) as HTMLElement | null;
+        if (existing) {
+            // Merge: update attestation count in the existing group line
+            const stored = JSON.parse(existing.dataset.typeAttestations || '[]') as Attestation[];
+            stored.push(attestation);
+            existing.dataset.typeAttestations = JSON.stringify(stored);
+            const group = groupTypeAttestations(stored);
+            if (group.length > 0) {
+                const replacement = renderTypeResultLine(group[0]);
+                replacement.dataset.typeSubject = subject;
+                replacement.dataset.typeAttestations = JSON.stringify(stored);
+                existing.replaceWith(replacement);
+            }
+        } else {
+            const group = groupTypeAttestations([attestation]);
+            if (group.length > 0) {
+                const line = renderTypeResultLine(group[0]);
+                line.dataset.typeSubject = subject;
+                line.dataset.typeAttestations = JSON.stringify([attestation]);
+                resultsContainer.insertBefore(line, resultsContainer.firstChild);
+            }
+        }
+        log.debug(SEG.GLYPH, `[AxGlyph] Added type result to ${glyphId}: ${subject}`);
+        return;
     }
 
     // Add new result at top (most recent first)

--- a/web/ts/components/glyph/glyph-registry.ts
+++ b/web/ts/components/glyph/glyph-registry.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Glyph } from '@qntx/glyphs';
-import { AX, SO, SE, AS, Sigma, Prose, Doc, Subcanvas } from '@generated/sym.js';
+import { AX, SO, SE, AS, Sigma, Type, Prose, Doc, Subcanvas } from '@generated/sym.js';
 import { createAxGlyph } from './ax-glyph';
 import { createSemanticGlyph } from './semantic-glyph';
 import { createPyGlyph, PY_DEFAULT_CODE } from './py-glyph';
@@ -19,6 +19,7 @@ import { createDocGlyph } from './doc-glyph';
 import { createSubcanvasGlyph } from './subcanvas-glyph';
 import { createAttestationGlyph } from './attestation-glyph';
 import { createSigmaGlyph } from './sigma-glyph';
+import { createTypeGlyph } from './type-glyph';
 import { createResultGlyph } from './result-glyph';
 
 export interface GlyphTypeEntry {
@@ -53,6 +54,7 @@ const GLYPH_TYPES: GlyphTypeEntry[] = [
     { symbol: Doc,      className: 'canvas-doc-glyph',     title: 'Document',        label: 'Doc',       render: createDocGlyph },
     { symbol: AS,       className: 'canvas-attestation-glyph', title: 'Attestation', label: 'AS',        render: createAttestationGlyph },
     { symbol: Sigma,    className: 'canvas-sigma-glyph',       title: 'Sigma',       label: 'Sigma',     render: createSigmaGlyph },
+    { symbol: Type,     className: 'canvas-type-glyph',        title: 'Type',        label: 'Type',      render: createTypeGlyph },
     { symbol: 'stream', className: 'canvas-stream-glyph',      title: 'Stream',      label: 'Stream',    render: (g) => createResultGlyph(g) },
 ];
 

--- a/web/ts/components/glyph/semantic-glyph.ts
+++ b/web/ts/components/glyph/semantic-glyph.ts
@@ -19,6 +19,7 @@ import type { Attestation } from '../../generated/proto/plugin/grpc/protocol/ats
 import { tooltip } from '../tooltip';
 import { spawnAttestationGlyph } from './attestation-glyph';
 import { isSigmaAttestation, renderSigmaResultLine } from './sigma-glyph';
+import { isTypeAttestation, groupTypeAttestations, renderTypeResultLine } from './type-result-line';
 import { uiState } from '../../state/ui';
 import { syncStateManager } from '../../state/sync-state';
 import { connectivityManager } from '../../connectivity';
@@ -498,6 +499,34 @@ export function updateSemanticGlyphResults(glyphId: string, attestation: Attesta
                 return;
             }
         }
+    }
+
+    // Type attestations: group by subject into a single line
+    if (isTypeAttestation(attestation)) {
+        const subject = attestation.subjects?.[0] || '';
+        const existing = resultsContainer.querySelector(`[data-type-subject="${subject}"]`) as HTMLElement | null;
+        if (existing) {
+            const stored = JSON.parse(existing.dataset.typeAttestations || '[]') as Attestation[];
+            stored.push(attestation);
+            existing.dataset.typeAttestations = JSON.stringify(stored);
+            const group = groupTypeAttestations(stored);
+            if (group.length > 0) {
+                const replacement = renderTypeResultLine(group[0]);
+                replacement.dataset.typeSubject = subject;
+                replacement.dataset.typeAttestations = JSON.stringify(stored);
+                existing.replaceWith(replacement);
+            }
+        } else {
+            const group = groupTypeAttestations([attestation]);
+            if (group.length > 0) {
+                const line = renderTypeResultLine(group[0]);
+                line.dataset.typeSubject = subject;
+                line.dataset.typeAttestations = JSON.stringify([attestation]);
+                resultsContainer.insertBefore(line, resultsContainer.firstChild);
+            }
+        }
+        log.debug(SEG.GLYPH, `[SeGlyph] Added type result to ${glyphId}: ${subject}`);
+        return;
     }
 
     const resultItem = isSigmaAttestation(attestation) ? renderSigmaResultLine(attestation) : renderAttestation(attestation, score);

--- a/web/ts/components/glyph/type-glyph.ts
+++ b/web/ts/components/glyph/type-glyph.ts
@@ -1,0 +1,269 @@
+/**
+ * Type Glyph (⊢) — canvas glyph for type attestations
+ *
+ * Shows a type definition: name, label, color swatch, field list,
+ * and how many actors attested it. Simpler than sigma — it's a type,
+ * not a statistical report.
+ *
+ * Opened via double-click on type result lines in AX or SE glyphs.
+ */
+
+import type { Glyph } from '@qntx/glyphs';
+import { wireExpandToWindow, canvasPlaced, preventDrag } from '@qntx/glyphs';
+import type { Attestation } from '../../generated/proto/plugin/grpc/protocol/atsstore';
+import { Type } from '@generated/sym.js';
+import { log, SEG } from '../../logger';
+import { uiState } from '../../state/ui';
+import { getGlyphTypeBySymbol } from './glyph-registry';
+import { el } from '../../html-utils';
+import { parseTypeAttrs, type TypeGroup, groupTypeAttestations } from './type-result-line';
+
+// Muted violet palette for type attestations
+const TYPE_COLOR = '#b0a0d0';
+const TYPE_DIM = '#7a6a8a';
+const TYPE_VALUE = '#e0d0f0';
+
+/** Build the type definition content */
+function buildTypeContent(group: TypeGroup): HTMLElement {
+    const container = el('div', {
+        style: { padding: '8px 12px', fontFamily: 'monospace', fontSize: '12px' },
+    });
+
+    // Header: turnstile + type name in its own color
+    const header = el('div', { style: { marginBottom: '8px' } });
+
+    const nameRow = el('div', {
+        style: { fontSize: '20px', fontWeight: 'bold', color: group.color, lineHeight: '1.2' },
+    });
+    nameRow.appendChild(el('span', { text: `${Type} ${group.subject}` }));
+
+    // Color swatch next to name
+    nameRow.appendChild(el('span', {
+        style: {
+            display: 'inline-block', width: '12px', height: '12px',
+            backgroundColor: group.color, borderRadius: '2px',
+            marginLeft: '8px', verticalAlign: 'middle',
+        },
+    }));
+    header.appendChild(nameRow);
+
+    // Label (if different from name)
+    if (group.label !== group.subject) {
+        header.appendChild(el('div', {
+            text: group.label,
+            style: { fontSize: '13px', color: TYPE_VALUE, marginTop: '2px' },
+        }));
+    }
+
+    // Deprecated badge
+    if (group.deprecated) {
+        header.appendChild(el('div', {
+            text: 'deprecated',
+            style: { fontSize: '11px', color: '#8a5050', fontStyle: 'italic', marginTop: '2px' },
+        }));
+    }
+
+    container.appendChild(header);
+
+    // Fields section
+    const attrs = parseTypeAttrs(group.attestations[0]);
+    const richFields = Array.isArray(attrs?.rich_string_fields) ? attrs!.rich_string_fields as string[] : [];
+    const arrayFields = Array.isArray(attrs?.array_fields) ? attrs!.array_fields as string[] : [];
+
+    if (richFields.length > 0 || arrayFields.length > 0) {
+        const fieldSection = el('div', { style: { marginBottom: '8px' } });
+
+        fieldSection.appendChild(el('div', {
+            text: 'fields',
+            style: { fontSize: '10px', color: TYPE_DIM, marginBottom: '4px' },
+        }));
+
+        const fieldList = el('div', {
+            style: { display: 'flex', flexWrap: 'wrap', gap: '4px' },
+        });
+
+        for (const f of richFields) {
+            fieldList.appendChild(el('span', {
+                text: f,
+                style: {
+                    fontSize: '11px', color: TYPE_VALUE, padding: '1px 5px',
+                    backgroundColor: 'rgba(100, 80, 140, 0.25)', borderRadius: '2px',
+                },
+            }));
+        }
+        for (const f of arrayFields) {
+            fieldList.appendChild(el('span', {
+                text: `${f}[]`,
+                style: {
+                    fontSize: '11px', color: TYPE_COLOR, padding: '1px 5px',
+                    backgroundColor: 'rgba(100, 80, 140, 0.15)', borderRadius: '2px',
+                },
+            }));
+        }
+
+        fieldSection.appendChild(fieldList);
+        container.appendChild(fieldSection);
+    }
+
+    // Attestation count footer
+    if (group.attestations.length > 0) {
+        const actors = new Set(group.attestations.flatMap(a => a.actors || []));
+        const parts: string[] = [];
+        parts.push(`${group.attestations.length} attestation${group.attestations.length !== 1 ? 's' : ''}`);
+        if (actors.size > 1) {
+            parts.push(`${actors.size} actors`);
+        }
+        container.appendChild(el('div', {
+            text: parts.join(' · '),
+            style: { fontSize: '9px', color: TYPE_DIM, marginTop: '4px' },
+        }));
+    }
+
+    return container;
+}
+
+/** Extract TypeGroup from attestations stored in glyph content */
+function groupFromContent(content: string | undefined): TypeGroup | null {
+    if (!content) return null;
+    try {
+        const data = JSON.parse(content);
+        // Content can be a single attestation or an array
+        const atts: Attestation[] = Array.isArray(data) ? data : [data];
+        const groups = groupTypeAttestations(atts);
+        return groups[0] || null;
+    } catch { return null; }
+}
+
+// ─── Canvas glyph ────────────────────────────────────────────
+
+/** Create a Type glyph for canvas placement */
+export function createTypeGlyph(glyph: Glyph): HTMLElement {
+    const group = groupFromContent(glyph.content);
+
+    const titleBar = el('div', {
+        class: 'glyph-title-bar glyph-title-bar--auto',
+        style: { position: 'relative' },
+    });
+
+    const color = group?.color || TYPE_COLOR;
+
+    const symbolEl = el('span', {
+        text: Type,
+        style: { fontWeight: 'bold', flexShrink: '0', color },
+    });
+    titleBar.appendChild(symbolEl);
+
+    if (group) {
+        const titleText = el('span', {
+            text: `${group.subject}${group.label !== group.subject ? ` · ${group.label}` : ''}`,
+            style: { fontSize: '12px', fontFamily: 'monospace', color: TYPE_VALUE },
+        });
+        titleBar.appendChild(titleText);
+    }
+
+    const expandBtn = el('button', {
+        class: 'titlebar-btn',
+        text: '\u2B06',
+        style: { flexShrink: '0', marginLeft: 'auto' },
+    });
+    expandBtn.title = 'Expand to window';
+    preventDrag(expandBtn);
+    titleBar.appendChild(expandBtn);
+
+    const { element } = canvasPlaced({
+        glyph,
+        className: 'canvas-type-glyph',
+        defaults: { x: 200, y: 200, width: 320, height: 280 },
+        resizable: true,
+        useMinHeight: true,
+        logLabel: 'TypeGlyph',
+    });
+    element.style.minWidth = '180px';
+    element.appendChild(titleBar);
+
+    if (group) {
+        const content = el('div', {
+            class: 'glyph-content-area',
+            style: {
+                backgroundColor: 'rgba(25, 25, 30, 0.95)',
+                borderTop: '1px solid var(--border)',
+                overflow: 'auto',
+            },
+        });
+        content.appendChild(buildTypeContent(group));
+        element.appendChild(content);
+    }
+
+    const title = group
+        ? `${Type} ${group.subject}`
+        : 'Type';
+
+    wireExpandToWindow({
+        element,
+        expandBtn,
+        glyphId: glyph.id,
+        title,
+        symbol: Type,
+        renderContent: () => {
+            const outer = el('div');
+            const wrapper = el('div', { class: 'glyph-content' });
+            outer.appendChild(wrapper);
+            if (group) {
+                wrapper.appendChild(buildTypeContent(group));
+            }
+            return outer;
+        },
+        logLabel: 'TypeGlyph',
+    });
+
+    log.debug(SEG.GLYPH, `[TypeGlyph] Created ${glyph.id}`);
+    return element;
+}
+
+// ─── Spawn helpers ───────────────────────────────────────────
+
+/** Spawn a type glyph on the canvas from attestations */
+export function spawnTypeGlyph(attestations: Attestation[], mouseX?: number, mouseY?: number): void {
+    const contentLayer = document.querySelector('.canvas-content-layer') as HTMLElement;
+    if (!contentLayer) {
+        log.warn(SEG.GLYPH, '[TypeGlyph] Cannot spawn: no canvas-content-layer found');
+        return;
+    }
+
+    const groups = groupTypeAttestations(attestations);
+    if (groups.length === 0) return;
+    const group = groups[0];
+
+    const glyphId = `type-${group.subject}-${crypto.randomUUID().slice(0, 8)}`;
+    const glyph: Glyph = {
+        id: glyphId,
+        title: `${Type} ${group.subject}`,
+        symbol: Type,
+        x: mouseX !== undefined ? Math.round(mouseX - contentLayer.getBoundingClientRect().left + 20) : Math.round(window.innerWidth / 2 - 140),
+        y: mouseY !== undefined ? Math.round(mouseY - contentLayer.getBoundingClientRect().top - 20) : Math.round(window.innerHeight / 2 - 120),
+        content: JSON.stringify(attestations),
+        renderContent: () => el('div'),
+    };
+
+    const entry = getGlyphTypeBySymbol(Type);
+    if (!entry) {
+        log.error(SEG.GLYPH, '[TypeGlyph] Type not found in glyph registry');
+        return;
+    }
+
+    const glyphElement = entry.render(glyph) as HTMLElement;
+    contentLayer.appendChild(glyphElement);
+
+    const rect = glyphElement.getBoundingClientRect();
+    uiState.addCanvasGlyph({
+        id: glyphId,
+        symbol: Type,
+        x: glyph.x!,
+        y: glyph.y!,
+        width: Math.round(rect.width) || 320,
+        height: Math.round(rect.height) || 280,
+        content: JSON.stringify(attestations),
+    });
+
+    log.debug(SEG.GLYPH, `[TypeGlyph] Spawned ${glyphId} at (${glyph.x}, ${glyph.y})`);
+}

--- a/web/ts/components/glyph/type-result-line.ts
+++ b/web/ts/components/glyph/type-result-line.ts
@@ -1,0 +1,161 @@
+/**
+ * Type Result Line — renders type attestations grouped by subject
+ *
+ * Type attestations are always subject-grouped: multiple actors attest
+ * "[subject] is type" for the same subject. Instead of rendering each
+ * individually, we consolidate them into a single result line per subject
+ * showing the turnstile symbol, type color, label, and field count.
+ */
+
+import type { Attestation } from '../../generated/proto/plugin/grpc/protocol/atsstore';
+import { Type } from '@generated/sym.js';
+import { el } from '../../html-utils';
+
+/** Check if an attestation is a type attestation */
+export function isTypeAttestation(attestation: Attestation): boolean {
+    return attestation.predicates?.[0] === 'type';
+}
+
+interface TypeGroup {
+    subject: string;
+    attestations: Attestation[];
+    label: string;
+    color: string;
+    richFieldCount: number;
+    arrayFieldCount: number;
+    deprecated: boolean;
+}
+
+/** Parse type attributes from an attestation */
+function parseTypeAttrs(attestation: Attestation): Record<string, unknown> | null {
+    if (!attestation.attributes) return null;
+    if (typeof attestation.attributes === 'string') {
+        try { return JSON.parse(attestation.attributes as string); } catch { return null; }
+    }
+    return attestation.attributes as Record<string, unknown>;
+}
+
+/**
+ * Group type attestations by subject. Takes the latest attestation's
+ * attributes as the canonical view (attestations come sorted by timestamp DESC).
+ */
+export function groupTypeAttestations(attestations: Attestation[]): TypeGroup[] {
+    const groups = new Map<string, TypeGroup>();
+
+    for (const att of attestations) {
+        const subject = att.subjects?.[0];
+        if (!subject) continue;
+
+        if (groups.has(subject)) {
+            groups.get(subject)!.attestations.push(att);
+            continue;
+        }
+
+        const attrs = parseTypeAttrs(att);
+        const richFields = attrs?.rich_string_fields;
+        const arrayFields = attrs?.array_fields;
+
+        groups.set(subject, {
+            subject,
+            attestations: [att],
+            label: (attrs?.display_label as string) || subject,
+            color: (attrs?.display_color as string) || '#666666',
+            richFieldCount: Array.isArray(richFields) ? richFields.length : 0,
+            arrayFieldCount: Array.isArray(arrayFields) ? arrayFields.length : 0,
+            deprecated: attrs?.deprecated === true,
+        });
+    }
+
+    return Array.from(groups.values());
+}
+
+/** Render a grouped type as a single result line */
+export function renderTypeResultLine(group: TypeGroup): HTMLElement {
+    const item = el('div', {
+        class: 'ax-glyph-result-item has-tooltip',
+        style: {
+            padding: '8px', marginBottom: '4px',
+            backgroundColor: 'rgba(60, 50, 80, 0.35)',
+            borderRadius: '2px', cursor: 'pointer',
+        },
+    });
+
+    // Store first attestation for tooltip/spawn
+    item.dataset.attestation = JSON.stringify(group.attestations[0]);
+    item.dataset.tooltip = group.attestations[0].id || group.subject;
+
+    const text = el('div', {
+        style: {
+            fontSize: '11px', fontFamily: 'monospace',
+            wordBreak: 'break-word', overflowWrap: 'break-word',
+        },
+    });
+
+    // Turnstile symbol in the type's color
+    const turnstile = el('span', {
+        text: Type + ' ',
+        style: { color: group.color, fontWeight: 'bold' },
+    });
+
+    // Type name
+    const nameSpan = el('span', {
+        text: group.subject,
+        style: { color: '#e0d0f0' },
+    });
+
+    text.append(turnstile, nameSpan);
+
+    // Label (if different from name)
+    if (group.label !== group.subject) {
+        const sep = el('span', { text: ' · ', style: { color: '#7a6a8a' } });
+        const labelSpan = el('span', {
+            text: group.label,
+            style: { color: '#c0b0d0' },
+        });
+        text.append(sep, labelSpan);
+    }
+
+    // Field count
+    const totalFields = group.richFieldCount + group.arrayFieldCount;
+    if (totalFields > 0) {
+        const sep = el('span', { text: ' · ', style: { color: '#7a6a8a' } });
+        const fieldSpan = el('span', {
+            text: `${totalFields} field${totalFields !== 1 ? 's' : ''}`,
+            style: { color: '#7a6a8a' },
+        });
+        text.append(sep, fieldSpan);
+    }
+
+    // Attestation count (how many actors attested this type)
+    if (group.attestations.length > 1) {
+        const sep = el('span', { text: ' · ', style: { color: '#7a6a8a' } });
+        const countSpan = el('span', {
+            text: `${group.attestations.length} attestations`,
+            style: { color: '#7a6a8a' },
+        });
+        text.append(sep, countSpan);
+    }
+
+    // Deprecated marker
+    if (group.deprecated) {
+        const sep = el('span', { text: ' · ', style: { color: '#7a6a8a' } });
+        const depSpan = el('span', {
+            text: 'deprecated',
+            style: { color: '#8a5050', fontStyle: 'italic' },
+        });
+        text.append(sep, depSpan);
+    }
+
+    // Color swatch
+    const swatch = el('span', {
+        style: {
+            display: 'inline-block', width: '8px', height: '8px',
+            backgroundColor: group.color, borderRadius: '2px',
+            marginLeft: '6px', verticalAlign: 'middle',
+        },
+    });
+    text.appendChild(swatch);
+
+    item.appendChild(text);
+    return item;
+}

--- a/web/ts/components/glyph/type-result-line.ts
+++ b/web/ts/components/glyph/type-result-line.ts
@@ -16,7 +16,7 @@ export function isTypeAttestation(attestation: Attestation): boolean {
     return attestation.predicates?.[0] === 'type';
 }
 
-interface TypeGroup {
+export interface TypeGroup {
     subject: string;
     attestations: Attestation[];
     label: string;
@@ -27,7 +27,7 @@ interface TypeGroup {
 }
 
 /** Parse type attributes from an attestation */
-function parseTypeAttrs(attestation: Attestation): Record<string, unknown> | null {
+export function parseTypeAttrs(attestation: Attestation): Record<string, unknown> | null {
     if (!attestation.attributes) return null;
     if (typeof attestation.attributes === 'string') {
         try { return JSON.parse(attestation.attributes as string); } catch { return null; }
@@ -83,6 +83,12 @@ export function renderTypeResultLine(group: TypeGroup): HTMLElement {
     // Store first attestation for tooltip/spawn
     item.dataset.attestation = JSON.stringify(group.attestations[0]);
     item.dataset.tooltip = group.attestations[0].id || group.subject;
+
+    // Double-click spawns type glyph on canvas (lazy import to avoid circular dep)
+    item.addEventListener('dblclick', (e) => {
+        e.stopPropagation();
+        import('./type-glyph').then(m => m.spawnTypeGlyph(group.attestations, e.clientX, e.clientY));
+    });
 
     const text = el('div', {
         style: {


### PR DESCRIPTION
Types self-certify —
the name is its own actor,
context was a lie,
compact identities now:
`TY-COMIT-7K4M3B9X`.

Turnstile joins sigma:
`⊢` asserts this has type —
a pattern named.

Many actors attest
the same subject; result lines
collapse by subject,
double-click spawns what it is:
name, color, fields, who spoke it.

## Lineage

- #660 — `qntx-id` crate, ASUID generation, type definitions to Rust
- #807 — Sigma: the result line → canvas glyph lifecycle this follows