### PR TITLE
ui-impl: document UIState must not import api/*

### DIFF
--- a/web/ts/state/ui-impl.ts
+++ b/web/ts/state/ui-impl.ts
@@ -9,6 +9,12 @@
  * - localStorage persistence via storage.ts utility
  * - Type-safe state access
  *
+ * Dependency direction (load-bearing invariant):
+ *   UIState MUST NOT import the api/* layer. State publishes changes;
+ *   the sync layer subscribes. Importing api/* re-introduces the
+ *   ui-impl → api/canvas → canvas-sync → ui → ui-impl cycle that puts
+ *   UIState in the temporal dead zone at module load.
+ *
  * The singleton instance lives in ui.ts (which re-exports everything from here).
  * Tests that need the real UIState class import from this file directly,
  * bypassing the process-global mock.module that replaces ui.ts.


### PR DESCRIPTION
Captures the architectural invariant for UIState as a header docstring, ahead of the code change that breaks the cycle.

UIState currently imports from api/canvas, creating
ui-impl → api/canvas → canvas-sync → ui → ui-impl
which puts UIState in the temporal dead zone at module load. The pre-existing failure shows up immediately as `ReferenceError: Cannot access 'UIState' before initialization` at ui.ts:17 when any test imports ui-impl directly (e.g. canvas-id.test.ts).

This doc commit asserts the invariant; the code change to make it true follows.

## Test plan
- [ ] CI shows the existing test failure (canvas-id.test.ts) is reproducible on this branch (no behavior change yet).