### PR TITLE
plugins: fetch from the latest release, and keep it current

### DIFF
--- a/am.example.toml
+++ b/am.example.toml
@@ -33,8 +33,7 @@ path = "qntx.db"
 
 [storage.sqlite.bounded_storage]
 # Bounded storage limits prevent unbounded database growth.
-# Oldest attestations are deleted when a limit is exceeded; each
-# deletion is logged to the storage_events table.
+# Oldest attestations are deleted when a limit is exceeded.
 
 # Maximum attestations per (actor, context) pair. Default: 32
 actor_context_limit = 32
@@ -46,10 +45,9 @@ actor_contexts_limit = 64
 entity_actors_limit = 64
 
 # ── Parquet backend (ADR-024) ───────────────────────────────────
-# Uncomment when backend = "parquet". Location is a URL:
-# "s3://..." for production (AWS Lightsail + S3) or
-# "file:///..." for local development. Credentials come from the
-# AWS SDK default chain — no keys in this file.
+# Uncomment when backend = "parquet". Location is a URL: "s3://..."
+# or "file:///...". Credentials come from the AWS SDK default
+# chain — no keys in this file.
 #
 # [storage.parquet]
 # location = "s3://bucket/prefix"
@@ -57,8 +55,6 @@ entity_actors_limit = 64
 # ════════════════════════════════════════════════════════════════
 # Attestation Distillation (ADR-020)
 # Folds old attestations into compressed summaries before deletion.
-# Enforcement-path distillation (Rust) is always on.
-# Age-based distillation (Go Pulse) requires interval_seconds.
 # ════════════════════════════════════════════════════════════════
 
 [distill]
@@ -134,9 +130,8 @@ log_theme = "everforest"
 # enabled = false
 # session_expiry_hours = 24
 #
-# WebAuthn Relying Party ID and Origins. Browsers reject any passkey
-# ceremony whose rp.id isn't a registrable domain suffix of the origin's
-# effective domain, so these MUST be set for any public deployment.
+# WebAuthn Relying Party ID and Origins. MUST be set for any public
+# deployment.
 #   rp_id      — single domain, no scheme, no port: "q.sbvh.nl"
 #   rp_origins — full URLs the browser will present: ["https://q.sbvh.nl"]
 # Empty rp_id falls back to "localhost"; empty rp_origins falls back to
@@ -181,21 +176,8 @@ ticker_interval_seconds = 1
 # Allowlist. Nothing loads unless named here.
 # Hot-swap: adding/removing takes effect without restart.
 #
-# An entry is either a bare name or a repo URL — mixing forms is legal:
-#
-#   "meili"                            must already be on disk
-#   "https://github.com/sbvh-nl/duif"  fetched from the latest release if absent
-#
-# A repo URL derives everything else from its last path segment:
-#
-#   name        duif
-#   binary      qntx-duif-plugin
-#   destination ~/.qntx/plugins/qntx-duif-plugin
-#   asset       *-<GOOS>-<GOARCH>.tar.gz, verified against <asset>.sha256
-#
-# The name must equal the plugin's own gRPC Metadata().Name or the launch is
-# rejected. Present or absent is all this knows — no pinning, no update check,
-# no rollback. `qntx-duif-plugin --version` is the only statement of what runs.
+# A URL tracks that repo's latest release. A bare name must already be on disk
+# and is yours to manage. Mixing forms is legal.
 # enabled = ["spindle", "meili", "https://github.com/sbvh-nl/duif"]
 
 # Forge credentials, one per host, needed only for private repos.

--- a/am.example.toml
+++ b/am.example.toml
@@ -199,14 +199,23 @@ ticker_interval_seconds = 1
 # enabled = ["spindle", "meili", "https://github.com/sbvh-nl/duif"]
 
 # Forge credentials, one per host, needed only for private repos.
+# The host is a value, not a key — the config keyspace is dot-delimited and
+# every forge host contains a dot, so a host used as a key reads as a nested
+# table. As a value there is nothing to split.
+#
 # Values are references, never secrets: am.toml ships as a world-readable SSM
 # String parameter, so a literal token here is disclosed, not configured.
 # A literal is rejected at config load.
 #
 #   ssm:///q/box/github-token   read via the box's existing credentials
 #   env:GITHUB_TOKEN            read from the environment
-# [plugin.access_token]
-# "github.com" = "ssm:///q/box/github-token"
+# [[plugin.access_token]]
+# host = "github.com"
+# ref  = "ssm:///q/box/github-token"
+#
+# [[plugin.access_token]]
+# host = "codeberg.org"
+# ref  = "env:CODEBERG_TOKEN"
 
 # ────────────────────────────────────────────────────────────────
 # MeiliSearch Plugin (ADR-015)

--- a/am.example.toml
+++ b/am.example.toml
@@ -178,8 +178,35 @@ ticker_interval_seconds = 1
 # ════════════════════════════════════════════════════════════════
 
 [plugin]
-# Plugins to enable. Hot-swap: adding/removing takes effect without restart.
-# enabled = ["spindle", "meili"]
+# Allowlist. Nothing loads unless named here.
+# Hot-swap: adding/removing takes effect without restart.
+#
+# An entry is either a bare name or a repo URL — mixing forms is legal:
+#
+#   "meili"                            must already be on disk
+#   "https://github.com/sbvh-nl/duif"  fetched from the latest release if absent
+#
+# A repo URL derives everything else from its last path segment:
+#
+#   name        duif
+#   binary      qntx-duif-plugin
+#   destination ~/.qntx/plugins/qntx-duif-plugin
+#   asset       *-<GOOS>-<GOARCH>.tar.gz, verified against <asset>.sha256
+#
+# The name must equal the plugin's own gRPC Metadata().Name or the launch is
+# rejected. Present or absent is all this knows — no pinning, no update check,
+# no rollback. `qntx-duif-plugin --version` is the only statement of what runs.
+# enabled = ["spindle", "meili", "https://github.com/sbvh-nl/duif"]
+
+# Forge credentials, one per host, needed only for private repos.
+# Values are references, never secrets: am.toml ships as a world-readable SSM
+# String parameter, so a literal token here is disclosed, not configured.
+# A literal is rejected at config load.
+#
+#   ssm:///q/box/github-token   read via the box's existing credentials
+#   env:GITHUB_TOKEN            read from the environment
+# [plugin.access_token]
+# "github.com" = "ssm:///q/box/github-token"
 
 # ────────────────────────────────────────────────────────────────
 # MeiliSearch Plugin (ADR-015)

--- a/cmd/qntx/commands/server.go
+++ b/cmd/qntx/commands/server.go
@@ -94,7 +94,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	logPath := cfg.GetLogPath(serverPort)
 
 	// Print startup banner
-	printStartupBanner(verbosity, dbPath, logPath, cfg.Plugin.Enabled)
+	printStartupBanner(verbosity, dbPath, logPath, cfg.Plugin.EnabledNames())
 
 	// Create server with pre-created attestation store
 	srvStart := time.Now()

--- a/cmd/qntx/main.go
+++ b/cmd/qntx/main.go
@@ -134,7 +134,7 @@ func initializePluginRegistry() {
 	}
 
 	// Pre-register plugin names immediately so routes can be registered
-	for _, pluginName := range cfg.Plugin.Enabled {
+	for _, pluginName := range cfg.Plugin.EnabledNames() {
 		registry.PreRegister(pluginName)
 	}
 	pluginLogger.Debugf("Pre-registered %d plugins, loading in background", len(cfg.Plugin.Enabled))
@@ -154,8 +154,10 @@ func loadPluginsAsync(cfg *config.Config, pluginLogger *zap.SugaredLogger, regis
 		pluginLogger.Warnw("Plugin configuration errors detected", "error", err)
 	}
 
-	// Load plugins into the existing manager (created in initializePluginRegistry)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Load plugins into the existing manager (created in initializePluginRegistry).
+	// Sized for a plugin fetch, not just a local launch — a plugin enabled by
+	// repo URL downloads its binary here on first boot.
+	ctx, cancel := context.WithTimeout(context.Background(), grpc.PluginFetchTimeout)
 	defer cancel()
 
 	manager := grpc.GetDefaultPluginManager()
@@ -194,7 +196,7 @@ func loadPluginsAsync(cfg *config.Config, pluginLogger *zap.SugaredLogger, regis
 
 	// Mark any pre-registered plugins that never loaded as failed, with the real error
 	failedErrors := manager.GetFailedPlugins()
-	for _, name := range cfg.Plugin.Enabled {
+	for _, name := range cfg.Plugin.EnabledNames() {
 		if registeredNames[name] {
 			continue
 		}
@@ -286,18 +288,17 @@ func loadPluginsAsync(cfg *config.Config, pluginLogger *zap.SugaredLogger, regis
 					initDone <- p.Initialize(initCtx, services)
 				}()
 
+				// Each branch owns initCtx: the fast path cancels here, the slow
+				// path hands ownership to the background goroutine below.
 				var initErr error
-				var timedOut bool
 				select {
 				case initErr = <-initDone:
 					cancel()
+
 				case <-time.After(initTimeout):
-					timedOut = true
 					pluginLogger.Warnw("Initialize not responding, continuing startup",
 						"plugin", meta.Name, "timeout", initTimeout)
-				}
 
-				if timedOut {
 					// Pre-register HTTP proxy routes so the plugin is reachable now
 					defaultServer.RegisterPluginMux(meta.Name)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.65.1
 	github.com/bluesky-social/indigo v0.0.0-20251010013709-8f2296eee90f
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-webauthn/webauthn v0.15.0
@@ -46,9 +47,9 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.0 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.6 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
@@ -76,7 +77,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.95.0 h1:MIWra+MSq53CFaXXAywB2qg9YvVZi
 github.com/aws/aws-sdk-go-v2/service/s3 v1.95.0/go.mod h1:79S2BdqCJpScXZA2y+cpZuocWsjGjJINyXnOsf5DTz8=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 h1:HpI7aMmJ+mm1wkSHIA2t5EaFFv5EFYXePW30p1EIrbQ=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.4/go.mod h1:C5RdGMYGlfM0gYq/tifqgn4EbyX99V15P2V3R+VHbQU=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.65.1 h1:TFg6XiS7EsHN0/jpV3eVNczZi/sPIVP5jxIs+euIESQ=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.65.1/go.mod h1:OIezd9K0sM/64DDP4kXx/i0NdgXu6R5KE6SCsIPJsjc=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.8 h1:aM/Q24rIlS3bRAhTyFurowU8A0SMyGDtEOY/l/s/1Uw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.8/go.mod h1:+fWt2UHSb4kS7Pu8y+BMBvJF0EWx+4H0hzNwtDNRTrg=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 h1:AHDr0DaHIAo8c9t1emrzAlVDFp+iMMKnPdYy6XO4MCE=

--- a/internal/config/access_token_test.go
+++ b/internal/config/access_token_test.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// writeConfig writes a temporary am.toml and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "am.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// Why the host is a value and not a key.
+//
+// A host used as a key survives a direct Get, but not the Unmarshal that
+// building Config goes through: mapstructure splits "github.com" at the dot and
+// then finds a nested map where it wants a string. Because Load unmarshals, that
+// error fails the whole config load — every other setting included. A host as a
+// value has nothing to split.
+//
+// This pins the behaviour instead of arguing about it. If it ever starts
+// passing, the array-of-tables shape may no longer be necessary.
+func TestHostAsKeyBreaksConfigLoad(t *testing.T) {
+	path := writeConfig(t, `
+[plugin.access_token]
+"github.com" = "ssm:///q/box/github-token"
+"codeberg.org" = "env:CODEBERG_TOKEN"
+`)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetConfigType("toml")
+	if err := v.ReadInConfig(); err != nil {
+		t.Fatalf("ReadInConfig = %v", err)
+	}
+
+	// A direct lookup keeps the dotted key intact — this path was never broken.
+	direct := v.GetStringMapString("plugin.access_token")
+	if direct["github.com"] != "ssm:///q/box/github-token" {
+		t.Errorf("GetStringMapString lost the host key: %#v", direct)
+	}
+
+	// The path Config actually takes does not survive it.
+	var viaStruct struct {
+		Plugin struct {
+			AccessToken map[string]string `mapstructure:"access_token"`
+		} `mapstructure:"plugin"`
+	}
+	err := v.Unmarshal(&viaStruct)
+	if err == nil {
+		t.Fatalf("Unmarshal accepted a host-keyed map (%#v) — dots in keys are no longer split",
+			viaStruct.Plugin.AccessToken)
+	}
+
+	// The error names the split fragment, not the host.
+	if !strings.Contains(err.Error(), "access_token[github]") {
+		t.Errorf("expected the host to be split at the dot, got: %v", err)
+	}
+	t.Logf("confirmed, host-keyed map fails config load: %v", err)
+}
+
+// A forge host is a value, not a key. The config keyspace splits on dots, and
+// every forge host has one, so this is the case that matters.
+func TestAccessTokenHostWithDots(t *testing.T) {
+	path := writeConfig(t, `
+[plugin]
+enabled = ["https://github.com/sbvh-nl/duif"]
+
+[[plugin.access_token]]
+host = "github.com"
+ref  = "ssm:///q/box/github-token"
+`)
+
+	cfg, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile = %v, want nil — a host containing a dot must survive config load", err)
+	}
+
+	if len(cfg.Plugin.AccessToken) != 1 {
+		t.Fatalf("AccessToken has %d entries, want 1: %+v", len(cfg.Plugin.AccessToken), cfg.Plugin.AccessToken)
+	}
+
+	entry := cfg.Plugin.AccessToken[0]
+	if entry.Host != "github.com" {
+		t.Errorf("Host = %q, want %q — the dot must not become nesting", entry.Host, "github.com")
+	}
+	if entry.Ref != "ssm:///q/box/github-token" {
+		t.Errorf("Ref = %q, want the ssm reference", entry.Ref)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate = %v, want nil", err)
+	}
+}
+
+// Several forges, one credential each, set centrally rather than per plugin.
+func TestAccessTokenMultipleHosts(t *testing.T) {
+	path := writeConfig(t, `
+[[plugin.access_token]]
+host = "github.com"
+ref  = "ssm:///q/box/github-token"
+
+[[plugin.access_token]]
+host = "codeberg.org"
+ref  = "env:CODEBERG_TOKEN"
+`)
+
+	cfg, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile = %v", err)
+	}
+
+	if got := cfg.Plugin.RefForHost("github.com"); got != "ssm:///q/box/github-token" {
+		t.Errorf("RefForHost(github.com) = %q, want the ssm reference", got)
+	}
+	if got := cfg.Plugin.RefForHost("codeberg.org"); got != "env:CODEBERG_TOKEN" {
+		t.Errorf("RefForHost(codeberg.org) = %q, want the env reference", got)
+	}
+
+	// An unconfigured host is not an error — a public repo needs no credential.
+	if got := cfg.Plugin.RefForHost("gitlab.com"); got != "" {
+		t.Errorf("RefForHost(gitlab.com) = %q, want \"\"", got)
+	}
+
+	// Hosts are case-insensitive.
+	if got := cfg.Plugin.RefForHost("GitHub.com"); got != "ssm:///q/box/github-token" {
+		t.Errorf("RefForHost(GitHub.com) = %q, want the ssm reference", got)
+	}
+}
+
+// The literal-token rejection must survive the shape change, and must name the
+// host so the operator knows which entry to fix.
+func TestAccessTokenLiteralRejected(t *testing.T) {
+	path := writeConfig(t, `
+[[plugin.access_token]]
+host = "github.com"
+ref  = "ghp_averyrealisticlookingliteral"
+`)
+
+	cfg, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile = %v", err)
+	}
+
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate accepted a literal token")
+	}
+	if !strings.Contains(err.Error(), "github.com") {
+		t.Errorf("error does not name the host: %v", err)
+	}
+	// Still must not echo the value it rejected.
+	if strings.Contains(err.Error(), "ghp_averyrealisticlookingliteral") {
+		t.Errorf("error leaked the rejected value: %v", err)
+	}
+}
+
+// An entry with a ref but no host is unusable and must not load silently.
+func TestAccessTokenMissingHostRejected(t *testing.T) {
+	path := writeConfig(t, `
+[[plugin.access_token]]
+ref = "ssm:///q/box/github-token"
+`)
+
+	cfg, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile = %v", err)
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate accepted an access_token entry with no host")
+	}
+}
+
+// No access_token section at all is valid — public repos need no credential.
+func TestAccessTokenAbsent(t *testing.T) {
+	path := writeConfig(t, `
+[plugin]
+enabled = ["meili"]
+`)
+
+	cfg, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile = %v", err)
+	}
+	if len(cfg.Plugin.AccessToken) != 0 {
+		t.Errorf("AccessToken = %+v, want empty", cfg.Plugin.AccessToken)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate = %v, want nil", err)
+	}
+	if got := cfg.Plugin.RefForHost("github.com"); got != "" {
+		t.Errorf("RefForHost = %q, want \"\"", got)
+	}
+}

--- a/internal/config/am.go
+++ b/internal/config/am.go
@@ -157,10 +157,11 @@ type AxConfig struct {
 
 // PluginConfig configures the domain plugin system
 type PluginConfig struct {
-	Enabled   []string              `mapstructure:"enabled"`   // Whitelist of enabled plugins (e.g., ["code"])
-	Paths     []string              `mapstructure:"paths"`     // Plugin search paths (e.g., ["~/.qntx/plugins", "./plugins"])
-	Runtime   PluginRuntimeConfig   `mapstructure:"runtime"`   // Runtime configuration
-	WebSocket PluginWebSocketConfig `mapstructure:"websocket"` // WebSocket configuration
+	Enabled     []string              `mapstructure:"enabled"`      // Allowlist of enabled plugins: bare names or repo URLs (see EnabledPlugin)
+	Paths       []string              `mapstructure:"paths"`        // Plugin search paths (e.g., ["~/.qntx/plugins", "./plugins"])
+	AccessToken map[string]string     `mapstructure:"access_token"` // Forge host → secret reference (ssm:// or env:) for private plugin repos; literals rejected
+	Runtime     PluginRuntimeConfig   `mapstructure:"runtime"`      // Runtime configuration
+	WebSocket   PluginWebSocketConfig `mapstructure:"websocket"`    // WebSocket configuration
 }
 
 // PluginRuntimeConfig configures plugin runtime environments

--- a/internal/config/am.go
+++ b/internal/config/am.go
@@ -159,9 +159,19 @@ type AxConfig struct {
 type PluginConfig struct {
 	Enabled     []string              `mapstructure:"enabled"`      // Allowlist of enabled plugins: bare names or repo URLs (see EnabledPlugin)
 	Paths       []string              `mapstructure:"paths"`        // Plugin search paths (e.g., ["~/.qntx/plugins", "./plugins"])
-	AccessToken map[string]string     `mapstructure:"access_token"` // Forge host → secret reference (ssm:// or env:) for private plugin repos; literals rejected
+	AccessToken []AccessTokenRef      `mapstructure:"access_token"` // One credential per forge host, for private plugin repos
 	Runtime     PluginRuntimeConfig   `mapstructure:"runtime"`      // Runtime configuration
 	WebSocket   PluginWebSocketConfig `mapstructure:"websocket"`    // WebSocket configuration
+}
+
+// AccessTokenRef points at the credential for one forge host.
+//
+// The host is a value, not a key. The config keyspace is dot-delimited, and
+// every forge host contains a dot — as a key, "github.com" is indistinguishable
+// from a nested table. Keeping it a value leaves nothing to split.
+type AccessTokenRef struct {
+	Host string `mapstructure:"host"` // Forge host, e.g. "github.com"
+	Ref  string `mapstructure:"ref"`  // ssm:// or env: reference — a literal is rejected
 }
 
 // PluginRuntimeConfig configures plugin runtime environments

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -475,6 +475,15 @@ func GetStringSlice(key string) []string {
 	return v.GetStringSlice(key)
 }
 
+// GetStringMapString returns a configuration value as a string map using dot notation
+func GetStringMapString(key string) map[string]string {
+	v, _ := initViper()
+	if v == nil {
+		return nil
+	}
+	return v.GetStringMapString(key)
+}
+
 // Set sets a configuration value using dot notation (runtime override)
 func Set(key string, value interface{}) {
 	v, _ := initViper()

--- a/internal/config/plugin_source.go
+++ b/internal/config/plugin_source.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+// EnabledPlugin is one parsed entry from [plugin] enabled.
+//
+// An entry says which plugin the operator wants and, optionally, where it comes
+// from. A bare name asserts the binary is already on disk and never reaches the
+// network. A repo URL says QNTX may go get it when it is absent.
+type EnabledPlugin struct {
+	// Name is the plugin identity used everywhere else: registry key, config
+	// section, log field, and the name the binary must report over gRPC.
+	Name string
+
+	// Repo is the source to fetch from when the binary is absent.
+	// Empty for bare-name entries.
+	Repo string
+}
+
+// ParseEnabledEntry splits a [plugin] enabled entry into name and source.
+// An entry is a URL if it parses as one, a name otherwise — so both forms
+// can be mixed freely in the same list.
+func ParseEnabledEntry(entry string) EnabledPlugin {
+	entry = strings.TrimSpace(entry)
+
+	u, err := url.Parse(entry)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return EnabledPlugin{Name: entry}
+	}
+
+	return EnabledPlugin{Name: PluginNameFromRepo(entry), Repo: entry}
+}
+
+// PluginNameFromRepo derives the plugin name from a repo URL: the last path
+// segment, with any .git suffix removed.
+//
+//	https://github.com/sbvh-nl/duif → duif
+func PluginNameFromRepo(repo string) string {
+	trimmed := strings.TrimSuffix(strings.TrimRight(repo, "/"), ".git")
+	return path.Base(trimmed)
+}
+
+// EnabledPlugins returns the parsed [plugin] enabled list.
+func (c *PluginConfig) EnabledPlugins() []EnabledPlugin {
+	parsed := make([]EnabledPlugin, 0, len(c.Enabled))
+	for _, entry := range c.Enabled {
+		parsed = append(parsed, ParseEnabledEntry(entry))
+	}
+	return parsed
+}
+
+// EnabledNames returns the plugin names from [plugin] enabled, with repo URLs
+// reduced to the name they derive.
+func (c *PluginConfig) EnabledNames() []string {
+	names := make([]string, 0, len(c.Enabled))
+	for _, entry := range c.Enabled {
+		names = append(names, ParseEnabledEntry(entry).Name)
+	}
+	return names
+}
+
+// RepoFor returns the source repo declared for a plugin, or "" when the plugin
+// was enabled by bare name and must already be on disk.
+func (c *PluginConfig) RepoFor(name string) string {
+	for _, entry := range c.Enabled {
+		if parsed := ParseEnabledEntry(entry); parsed.Name == name {
+			return parsed.Repo
+		}
+	}
+	return ""
+}
+
+// PluginRepo reads the source repo for a plugin from the loaded configuration.
+// Used where only the plugin name is in hand — runtime enable and restart.
+func PluginRepo(name string) string {
+	for _, entry := range GetStringSlice("plugin.enabled") {
+		if parsed := ParseEnabledEntry(entry); parsed.Name == name {
+			return parsed.Repo
+		}
+	}
+	return ""
+}
+
+// PluginAccessToken reads the secret reference configured for a forge host.
+// Tokens are set once per host in [plugin.access_token], not per plugin.
+// Returns "" for a host with no entry — public repos need none.
+func PluginAccessToken(host string) string {
+	return GetStringMapString("plugin.access_token")[strings.ToLower(host)]
+}

--- a/internal/config/plugin_source.go
+++ b/internal/config/plugin_source.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/teranos/errors"
 )
 
 // EnabledPlugin is one parsed entry from [plugin] enabled.
@@ -85,9 +87,37 @@ func PluginRepo(name string) string {
 	return ""
 }
 
-// PluginAccessToken reads the secret reference configured for a forge host.
-// Tokens are set once per host in [plugin.access_token], not per plugin.
-// Returns "" for a host with no entry — public repos need none.
-func PluginAccessToken(host string) string {
-	return GetStringMapString("plugin.access_token")[strings.ToLower(host)]
+// RefForHost returns the secret reference configured for a forge host, or ""
+// when the host has no entry — public repos need no credential.
+// Credentials are set once per host, not per plugin.
+func (c *PluginConfig) RefForHost(host string) string {
+	for _, entry := range c.AccessToken {
+		if strings.EqualFold(entry.Host, host) {
+			return entry.Ref
+		}
+	}
+	return ""
+}
+
+// PluginAccessToken reads the secret reference for a forge host from the loaded
+// configuration. Used where only the host is in hand — runtime fetch.
+//
+// Decodes [[plugin.access_token]] into the slice rather than indexing a map by
+// host: the host is a value here, so a dot in it stays a dot.
+func PluginAccessToken(host string) (string, error) {
+	v, err := initViper()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load configuration to read plugin.access_token")
+	}
+	if v == nil {
+		return "", nil
+	}
+
+	var refs []AccessTokenRef
+	if err := v.UnmarshalKey("plugin.access_token", &refs); err != nil {
+		return "", errors.Wrap(err, "failed to decode plugin.access_token")
+	}
+
+	cfg := PluginConfig{AccessToken: refs}
+	return cfg.RefForHost(host), nil
 }

--- a/internal/config/plugin_source_test.go
+++ b/internal/config/plugin_source_test.go
@@ -1,0 +1,97 @@
+package config
+
+import "testing"
+
+func TestParseEnabledEntry(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    string
+		wantName string
+		wantRepo string
+	}{
+		{
+			name:     "bare name has no source",
+			entry:    "duif",
+			wantName: "duif",
+		},
+		{
+			name:     "repo URL derives name from last segment",
+			entry:    "https://github.com/sbvh-nl/duif",
+			wantName: "duif",
+			wantRepo: "https://github.com/sbvh-nl/duif",
+		},
+		{
+			name:     "trailing slash does not become the name",
+			entry:    "https://github.com/sbvh-nl/duif/",
+			wantName: "duif",
+			wantRepo: "https://github.com/sbvh-nl/duif/",
+		},
+		{
+			name:     "git suffix is stripped",
+			entry:    "https://github.com/sbvh-nl/duif.git",
+			wantName: "duif",
+			wantRepo: "https://github.com/sbvh-nl/duif.git",
+		},
+		{
+			name:     "hyphenated name survives",
+			entry:    "https://github.com/teranos/pty-glyph",
+			wantName: "pty-glyph",
+			wantRepo: "https://github.com/teranos/pty-glyph",
+		},
+		{
+			name:     "surrounding space is not part of the name",
+			entry:    "  duif  ",
+			wantName: "duif",
+		},
+		{
+			name:     "a host with no path is not a plugin name",
+			entry:    "https://github.com",
+			wantName: "github.com",
+			wantRepo: "https://github.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseEnabledEntry(tt.entry)
+			if got.Name != tt.wantName {
+				t.Errorf("ParseEnabledEntry(%q).Name = %q, want %q", tt.entry, got.Name, tt.wantName)
+			}
+			if got.Repo != tt.wantRepo {
+				t.Errorf("ParseEnabledEntry(%q).Repo = %q, want %q", tt.entry, got.Repo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestEnabledFormsMixFreely(t *testing.T) {
+	cfg := PluginConfig{Enabled: []string{
+		"meili",
+		"https://github.com/sbvh-nl/duif",
+		"spindle",
+	}}
+
+	names := cfg.EnabledNames()
+	want := []string{"meili", "duif", "spindle"}
+	if len(names) != len(want) {
+		t.Fatalf("EnabledNames() = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("EnabledNames()[%d] = %q, want %q", i, names[i], want[i])
+		}
+	}
+
+	if repo := cfg.RepoFor("duif"); repo != "https://github.com/sbvh-nl/duif" {
+		t.Errorf("RepoFor(duif) = %q, want the repo URL", repo)
+	}
+
+	// A bare name must never produce a source — that is what keeps it off the network.
+	if repo := cfg.RepoFor("meili"); repo != "" {
+		t.Errorf("RepoFor(meili) = %q, want \"\" for a bare-name entry", repo)
+	}
+
+	if repo := cfg.RepoFor("absent"); repo != "" {
+		t.Errorf("RepoFor(absent) = %q, want \"\"", repo)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -66,9 +66,12 @@ func (c *Config) Validate() error {
 
 	// Plugin access tokens are references, never secrets. am.toml ships as a
 	// world-readable SSM String parameter, so a literal here is already leaked.
-	for host, ref := range c.Plugin.AccessToken {
-		if err := secretref.Validate(ref); err != nil {
-			return errors.Wrapf(err, "plugin.access_token.%q is invalid", host)
+	for i, entry := range c.Plugin.AccessToken {
+		if entry.Host == "" {
+			return errors.Newf("plugin.access_token[%d] has no host", i)
+		}
+		if err := secretref.Validate(entry.Ref); err != nil {
+			return errors.Wrapf(err, "plugin.access_token for host %q is invalid", entry.Host)
 		}
 	}
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 
+	"github.com/teranos/QNTX/internal/secretref"
 	"github.com/teranos/errors"
 )
 
@@ -61,6 +62,14 @@ func (c *Config) Validate() error {
 	}
 	if c.Pulse.CostPerScoreUSD < 0 {
 		return errors.Newf("pulse.cost_per_score_usd must be >= 0, got %f", c.Pulse.CostPerScoreUSD)
+	}
+
+	// Plugin access tokens are references, never secrets. am.toml ships as a
+	// world-readable SSM String parameter, so a literal here is already leaked.
+	for host, ref := range c.Plugin.AccessToken {
+		if err := secretref.Validate(ref); err != nil {
+			return errors.Wrapf(err, "plugin.access_token.%q is invalid", host)
+		}
 	}
 
 	// Plugin keepalive: validate when enabled (nil = default, 0 is invalid per "zero means zero")

--- a/internal/secretref/secretref.go
+++ b/internal/secretref/secretref.go
@@ -1,0 +1,102 @@
+// Package secretref resolves references to secrets without ever storing one.
+//
+// am.toml is delivered as an SSM parameter of type String and is world-readable
+// in tofu state. A secret written there is disclosed, not configured. So config
+// carries only a reference — a place to go look — and the value is fetched at
+// the moment it is used. A literal is rejected rather than accepted with a
+// warning, because a warning does not un-publish a token.
+package secretref
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/teranos/errors"
+)
+
+const (
+	// SchemeSSM reads from AWS Systems Manager Parameter Store using the
+	// box's ambient credentials: ssm:///q/box/github-token
+	SchemeSSM = "ssm://"
+
+	// SchemeEnv reads from the process environment: env:GITHUB_TOKEN
+	SchemeEnv = "env:"
+)
+
+// Validate reports whether ref is a reference rather than a secret.
+// An empty ref is valid — it means no credential is configured.
+func Validate(ref string) error {
+	switch {
+	case ref == "":
+		return nil
+
+	case strings.HasPrefix(ref, SchemeSSM):
+		if strings.TrimPrefix(ref, SchemeSSM) == "" {
+			return errors.Newf("%s reference names no parameter", SchemeSSM)
+		}
+		return nil
+
+	case strings.HasPrefix(ref, SchemeEnv):
+		if strings.TrimPrefix(ref, SchemeEnv) == "" {
+			return errors.Newf("%s reference names no variable", SchemeEnv)
+		}
+		return nil
+	}
+
+	// Deliberately does not echo ref — it may be the secret itself, and this
+	// error reaches logs.
+	err := errors.Newf("value is a literal, not a %s or %s reference", SchemeSSM, SchemeEnv)
+	return errors.WithHint(err, "am.toml is world-readable; store the secret in SSM and reference it as ssm:///path or env:VAR")
+}
+
+// Resolve fetches the secret a reference points at.
+// An empty ref resolves to an empty value with no error — no credential.
+func Resolve(ctx context.Context, ref string) (string, error) {
+	if err := Validate(ref); err != nil {
+		return "", err
+	}
+
+	switch {
+	case ref == "":
+		return "", nil
+
+	case strings.HasPrefix(ref, SchemeEnv):
+		name := strings.TrimPrefix(ref, SchemeEnv)
+		value := os.Getenv(name)
+		if value == "" {
+			err := errors.Newf("environment variable %s is unset or empty", name)
+			return "", errors.WithHintf(err, "export %s before starting QNTX, or point the reference elsewhere", name)
+		}
+		return value, nil
+
+	default:
+		return resolveSSM(ctx, strings.TrimPrefix(ref, SchemeSSM))
+	}
+}
+
+// resolveSSM reads a parameter through the box's existing credentials.
+// WithDecryption covers SecureString parameters, which is what a token should be.
+func resolveSSM(ctx context.Context, name string) (string, error) {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to load AWS credentials to read SSM parameter %s", name)
+	}
+
+	out, err := ssm.NewFromConfig(awsCfg).GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(name),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read SSM parameter %s in region %s", name, awsCfg.Region)
+	}
+
+	if out.Parameter == nil || aws.ToString(out.Parameter.Value) == "" {
+		return "", errors.Newf("SSM parameter %s is empty", name)
+	}
+
+	return aws.ToString(out.Parameter.Value), nil
+}

--- a/internal/secretref/secretref_test.go
+++ b/internal/secretref/secretref_test.go
@@ -1,0 +1,90 @@
+package secretref
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidateRejectsLiterals(t *testing.T) {
+	literals := []string{
+		"ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+		"github_pat_11ABCDEFG",
+		"not-a-reference",
+		"https://github.com/token",
+		"ssm:",
+		"ssm://",
+		"env:",
+	}
+
+	for _, ref := range literals {
+		t.Run(ref, func(t *testing.T) {
+			if err := Validate(ref); err == nil {
+				t.Errorf("Validate(%q) accepted a value that is not a resolvable reference", ref)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsReferences(t *testing.T) {
+	refs := []string{
+		"",
+		"ssm:///q/box/github-token",
+		"env:GITHUB_TOKEN",
+	}
+
+	for _, ref := range refs {
+		t.Run(ref, func(t *testing.T) {
+			if err := Validate(ref); err != nil {
+				t.Errorf("Validate(%q) = %v, want nil", ref, err)
+			}
+		})
+	}
+}
+
+// A rejected literal must not be echoed back — the error travels to logs, and
+// the whole point is that the value may itself be the secret.
+func TestValidateDoesNotEchoTheValue(t *testing.T) {
+	const secret = "ghp_thisMustNeverAppearInAnError"
+
+	err := Validate(secret)
+	if err == nil {
+		t.Fatal("Validate accepted a literal token")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Errorf("Validate error leaked the value it rejected: %v", err)
+	}
+}
+
+func TestResolveEnv(t *testing.T) {
+	t.Setenv("QNTX_TEST_TOKEN", "resolved-value")
+
+	got, err := Resolve(context.Background(), "env:QNTX_TEST_TOKEN")
+	if err != nil {
+		t.Fatalf("Resolve = %v, want nil", err)
+	}
+	if got != "resolved-value" {
+		t.Errorf("Resolve = %q, want %q", got, "resolved-value")
+	}
+}
+
+func TestResolveEnvUnsetIsAnError(t *testing.T) {
+	t.Setenv("QNTX_TEST_TOKEN", "")
+
+	if _, err := Resolve(context.Background(), "env:QNTX_TEST_TOKEN"); err == nil {
+		t.Error("Resolve accepted an unset variable, want an error naming it")
+	} else if !strings.Contains(err.Error(), "QNTX_TEST_TOKEN") {
+		t.Errorf("Resolve error does not name the variable: %v", err)
+	}
+}
+
+// No reference means no credential, which is correct for a public repo.
+func TestResolveEmptyIsNotAnError(t *testing.T) {
+	got, err := Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Resolve(\"\") = %v, want nil", err)
+	}
+	if got != "" {
+		t.Errorf("Resolve(\"\") = %q, want \"\"", got)
+	}
+}

--- a/nix/vendor-hash.nix
+++ b/nix/vendor-hash.nix
@@ -1,4 +1,4 @@
 # Shared Go vendorHash for all builds from repo root
 # To update: set vendorHash = pkgs.lib.fakeHash; in flake.nix,
 # run `nix build .#qntx`, copy the hash from the error, paste it here.
-"sha256-lojWJbyZSRJyjDWxzDlrk/LSoHZ3obR4l2j9wi6dWI4="
+"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/nix/vendor-hash.nix
+++ b/nix/vendor-hash.nix
@@ -1,4 +1,4 @@
 # Shared Go vendorHash for all builds from repo root
 # To update: set vendorHash = pkgs.lib.fakeHash; in flake.nix,
 # run `nix build .#qntx`, copy the hash from the error, paste it here.
-"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+"sha256-/4fVjRvb7cCRhUezz09++vEduIH0GpKHUknriCX9zWg="

--- a/plugin/grpc/discovery.go
+++ b/plugin/grpc/discovery.go
@@ -1209,8 +1209,9 @@ func (m *PluginManager) EnablePlugin(ctx context.Context, name string, searchPat
 		return errors.Newf("plugin '%s' is already loaded", name)
 	}
 
-	// Discover binary
-	pluginCfg, err := discoverPlugin(name, searchPaths, m.logger)
+	// Discover binary, fetching from the plugin's repo if it isn't on disk yet.
+	// This is what makes adding a repo URL to a running box work in place.
+	pluginCfg, err := resolvePlugin(ctx, name, searchPaths, m.logger)
 	if err != nil {
 		return errors.Wrapf(err, "failed to discover plugin '%s'", name)
 	}

--- a/plugin/grpc/fetch.go
+++ b/plugin/grpc/fetch.go
@@ -118,14 +118,17 @@ func pluginAccessToken(ctx context.Context, repo string) (string, error) {
 		return "", errors.Wrapf(err, "failed to parse plugin source URL %s", repo)
 	}
 
-	ref := config.PluginAccessToken(u.Host)
+	ref, err := config.PluginAccessToken(u.Host)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read the access token configured for %s", u.Host)
+	}
 	if ref == "" {
 		return "", nil
 	}
 
 	token, err := secretref.Resolve(ctx, ref)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to resolve plugin.access_token.%q", u.Host)
+		return "", errors.Wrapf(err, "failed to resolve the access token configured for host %q", u.Host)
 	}
 	return token, nil
 }

--- a/plugin/grpc/fetch.go
+++ b/plugin/grpc/fetch.go
@@ -78,15 +78,21 @@ func pluginAssetSuffix() string {
 	return "-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
 }
 
-// PluginInstallPath is where a fetched binary is placed: ~/.qntx/plugins/.
-// Fetched plugins land in one known directory regardless of search paths, so
-// what arrived over the network is always in the same place to inspect.
+// PluginInstallPath is the directory a fetched plugin is unpacked into:
+// ~/.qntx/plugins/<name>/. Fetched plugins land in one known place regardless
+// of search paths, so what arrived over the network is always in the same
+// directory to inspect.
+//
+// A directory rather than a file because an archive may carry more than the
+// binary — a plugin that cannot statically link everything ships its libraries
+// in lib/ beside it. Unpacking to a directory per plugin keeps one plugin's
+// libraries from colliding with another's.
 func PluginInstallPath(name string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to resolve home directory for plugin %s install path", name)
 	}
-	return filepath.Join(home, ".qntx", "plugins", PluginBinaryName(name)), nil
+	return filepath.Join(home, ".qntx", "plugins", name), nil
 }
 
 // githubRepoPath splits a plugin repo URL into owner and repo.
@@ -187,25 +193,21 @@ func fetchPlugin(ctx context.Context, name, repo string, logger *zap.SugaredLogg
 		return "", errors.WithHint(err, "the release asset and its .sha256 disagree; nothing was installed")
 	}
 
-	binary, err := extractBinary(archive, PluginBinaryName(name))
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to extract %s from %s", PluginBinaryName(name), asset.Name)
-	}
-
-	dest, err := PluginInstallPath(name)
+	dir, err := PluginInstallPath(name)
 	if err != nil {
 		return "", err
 	}
 
-	if err := install(binary, dest); err != nil {
-		return "", errors.Wrapf(err, "failed to install plugin %s to %s", name, dest)
+	binary, files, err := install(archive, dir, PluginBinaryName(name))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to install plugin %s to %s from %s", name, dir, asset.Name)
 	}
 
-	logger.Infow("Installed plugin binary",
+	logger.Infow("Installed plugin",
 		"plugin", name, "repo", repo, "release", rel.TagName,
-		"path", dest, "bytes", len(binary), "sha256", got)
+		"binary", binary, "files", files, "sha256", got)
 
-	return dest, nil
+	return binary, nil
 }
 
 // latestRelease reads the repo's latest release.
@@ -345,19 +347,27 @@ func get(ctx context.Context, endpoint, token, accept string) (io.ReadCloser, er
 	return resp.Body, nil
 }
 
-// extractBinary pulls one named file out of a .tar.gz.
+// extractArchive unpacks a .tar.gz into dir, preserving its layout, and returns
+// the path to binaryName within it along with the number of files written.
 //
-// Only the archive entry's base name is compared and the destination is chosen
-// by QNTX, so a path in the archive can never steer where bytes land.
-func extractBinary(archive []byte, binaryName string) ([]byte, error) {
+// The layout is preserved because it is load-bearing: a binary that ships its
+// libraries in lib/ finds them through an RPATH relative to itself, so lib/ has
+// to land beside the binary and nowhere else.
+//
+// Entry paths come from a downloaded archive, so they are not trusted. Anything
+// absolute or climbing out of dir is refused rather than sanitised — a release
+// that tries it is not one to install a corrected version of.
+func extractArchive(archive []byte, dir, binaryName string) (string, int, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(archive))
 	if err != nil {
-		return nil, errors.Wrap(err, "asset is not gzip data")
+		return "", 0, errors.Wrap(err, "asset is not gzip data")
 	}
 	defer gz.Close()
 
 	tr := tar.NewReader(gz)
 	var seen []string
+	var binary string
+	files := 0
 
 	for {
 		header, err := tr.Next()
@@ -365,66 +375,136 @@ func extractBinary(archive []byte, binaryName string) ([]byte, error) {
 			break
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to read tar entry")
+			return "", 0, errors.Wrap(err, "failed to read tar entry")
 		}
 
-		if header.Typeflag != tar.TypeReg {
+		// Symlinks and devices are skipped, as they were before trees were
+		// unpacked at all: a link is a way to name a file outside dir.
+		if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeDir {
 			continue
 		}
 
-		seen = append(seen, header.Name)
-		if filepath.Base(header.Name) != binaryName {
-			continue
-		}
-
-		data, err := io.ReadAll(tr)
+		rel, err := safeArchivePath(header.Name)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read %s out of the archive", header.Name)
+			return "", 0, err
 		}
-		return data, nil
+		if rel == "" {
+			continue
+		}
+
+		target := filepath.Join(dir, rel)
+
+		if header.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return "", 0, errors.Wrapf(err, "failed to create %s", target)
+			}
+			continue
+		}
+
+		seen = append(seen, rel)
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return "", 0, errors.Wrapf(err, "failed to create directory for %s", target)
+		}
+
+		// The archive's mode decides only whether a file is executable. A
+		// release cannot make anything group- or world-writable here.
+		mode := os.FileMode(0o644)
+		if header.Mode&0o111 != 0 {
+			mode = 0o755
+		}
+
+		out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+		if err != nil {
+			return "", 0, errors.Wrapf(err, "failed to create %s", target)
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			out.Close()
+			return "", 0, errors.Wrapf(err, "failed to write %s", target)
+		}
+		if err := out.Close(); err != nil {
+			return "", 0, errors.Wrapf(err, "failed to close %s", target)
+		}
+
+		files++
+
+		if filepath.Base(rel) == binaryName {
+			binary = target
+			// The binary must be executable whatever the archive claimed —
+			// tar modes survive some packaging pipelines and not others.
+			if err := os.Chmod(target, 0o755); err != nil {
+				return "", 0, errors.Wrapf(err, "failed to make %s executable", target)
+			}
+		}
 	}
 
-	err = errors.Newf("archive contains no file named %s (has: %s)", binaryName, strings.Join(seen, ", "))
-	return nil, errors.WithHintf(err, "the release asset must contain the plugin binary named %s", binaryName)
+	if binary == "" {
+		err := errors.Newf("archive contains no file named %s (has: %s)", binaryName, strings.Join(seen, ", "))
+		return "", 0, errors.WithHintf(err, "the release asset must contain the plugin binary named %s", binaryName)
+	}
+
+	return binary, files, nil
 }
 
-// install writes the binary to dest, executable, replacing any previous file.
-// Written to a temp file in the same directory and renamed, so a crash mid-write
-// never leaves a half-binary where a plugin is expected.
-func install(binary []byte, dest string) error {
-	dir := filepath.Dir(dest)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return errors.Wrapf(err, "failed to create plugin directory %s", dir)
+// safeArchivePath rejects an archive entry that would write outside the
+// directory it is being unpacked into. Returns the cleaned relative path, or
+// empty for an entry that names the directory itself.
+func safeArchivePath(name string) (string, error) {
+	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") {
+		return "", errors.Newf("archive entry %q is an absolute path", name)
 	}
 
-	tmp, err := os.CreateTemp(dir, filepath.Base(dest)+".partial-*")
+	clean := filepath.Clean(filepath.FromSlash(name))
+	if clean == "." || clean == string(filepath.Separator) {
+		return "", nil
+	}
+
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", errors.Newf("archive entry %q escapes the plugin directory", name)
+	}
+
+	return clean, nil
+}
+
+// install unpacks archive into dir, replacing whatever was there, and returns
+// the path to the plugin binary and the number of files written.
+//
+// Unpacked into a sibling temp directory and renamed, so a crash or a truncated
+// download never leaves a half-tree where a plugin is expected. A partial tree
+// is worse than a partial file: the binary can be complete while the library it
+// needs is missing, which fails at exec with nothing to point at.
+func install(archive []byte, dir, binaryName string) (string, int, error) {
+	parent := filepath.Dir(dir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", 0, errors.Wrapf(err, "failed to create plugin directory %s", parent)
+	}
+
+	staging, err := os.MkdirTemp(parent, filepath.Base(dir)+".partial-*")
 	if err != nil {
-		return errors.Wrapf(err, "failed to create temp file in %s", dir)
+		return "", 0, errors.Wrapf(err, "failed to create temp directory in %s", parent)
 	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer os.RemoveAll(staging)
 
-	if _, err := tmp.Write(binary); err != nil {
-		tmp.Close()
-		return errors.Wrapf(err, "failed to write %d bytes to %s", len(binary), tmpName)
-	}
-	if err := tmp.Close(); err != nil {
-		return errors.Wrapf(err, "failed to close %s", tmpName)
+	binary, files, err := extractArchive(archive, staging, binaryName)
+	if err != nil {
+		return "", 0, err
 	}
 
-	if err := os.Chmod(tmpName, 0o755); err != nil {
-		return errors.Wrapf(err, "failed to make %s executable", tmpName)
+	// Remove first: renaming over a populated directory fails, and a running
+	// binary underneath may be read-only from a previous install.
+	if err := os.RemoveAll(dir); err != nil {
+		return "", 0, errors.Wrapf(err, "failed to remove existing %s", dir)
 	}
 
-	// Remove first: renaming over a running binary fails with ETXTBSY on some
-	// systems, and the old file may be read-only (0555) from a previous install.
-	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "failed to remove existing %s", dest)
+	if err := os.Rename(staging, dir); err != nil {
+		return "", 0, errors.Wrapf(err, "failed to move %s into place at %s", staging, dir)
 	}
 
-	if err := os.Rename(tmpName, dest); err != nil {
-		return errors.Wrapf(err, "failed to move %s into place at %s", tmpName, dest)
+	// The binary's path was inside staging, which no longer exists.
+	rel, err := filepath.Rel(staging, binary)
+	if err != nil {
+		return "", 0, errors.Wrapf(err, "failed to locate %s within %s", binaryName, staging)
 	}
 
-	return nil
+	return filepath.Join(dir, rel), files, nil
 }

--- a/plugin/grpc/fetch.go
+++ b/plugin/grpc/fetch.go
@@ -47,6 +47,12 @@ const (
 	// tens of megabytes, so this is sized for a download, not an API call.
 	PluginFetchTimeout = 10 * time.Minute
 
+	// PluginDigestTimeout bounds the check of an installed plugin against its
+	// latest release. Two API calls reading a release and a 108-byte digest,
+	// on the path to every start — short, because a slow or unreachable forge
+	// must not hold up a plugin that is already on disk.
+	PluginDigestTimeout = 15 * time.Second
+
 	// maxChecksumBytes caps the .sha256 read — it holds one hex digest.
 	maxChecksumBytes = 4096
 )
@@ -95,6 +101,78 @@ func PluginInstallPath(name string) (string, error) {
 	return filepath.Join(home, ".qntx", "plugins", name), nil
 }
 
+// LegacyPluginInstallPath is where fetched plugins were installed before they
+// were unpacked as trees: a bare file in the plugins directory.
+//
+// It is still QNTX's own install location, so a file there is not somebody's
+// hand-placed build and may be superseded. It also shadows the tree — discovery
+// tries qntx-<name>-plugin before <name> — so it has to be removed when one is
+// installed, or the superseded file wins on the next start forever.
+func LegacyPluginInstallPath(name string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve home directory for plugin %s install path", name)
+	}
+	return filepath.Join(home, ".qntx", "plugins", PluginBinaryName(name)), nil
+}
+
+// removeLegacyInstall deletes the pre-tree install of name, if there is one.
+func removeLegacyInstall(name string, logger *zap.SugaredLogger) error {
+	path, err := LegacyPluginInstallPath(name)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+	if info.IsDir() {
+		return nil
+	}
+
+	if err := os.Remove(path); err != nil {
+		return errors.Wrapf(err, "failed to remove the superseded plugin binary at %s", path)
+	}
+
+	logger.Infow("Removed the superseded plugin binary",
+		"plugin", name, "path", path)
+
+	return nil
+}
+
+// installedDigestFile names the record of which archive a plugin directory was
+// unpacked from. The box keeps the same record beside the qntx binary
+// (apply.sh, $BIN.installed.sha256) and for the same reason: comparing it
+// against a cheap published digest is what makes an install reconcilable
+// rather than permanent.
+const installedDigestFile = ".installed.sha256"
+
+// recordInstalledDigest notes the archive digest dir was unpacked from.
+func recordInstalledDigest(dir, digest string) error {
+	path := filepath.Join(dir, installedDigestFile)
+	if err := os.WriteFile(path, []byte(digest), 0o644); err != nil {
+		return errors.Wrapf(err, "failed to record the installed digest at %s", path)
+	}
+	return nil
+}
+
+// installedDigest reads the digest recorded when dir was unpacked. Absent for a
+// directory QNTX did not install, and for one installed before this was kept.
+func installedDigest(dir string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, installedDigestFile))
+	if err != nil {
+		return "", false
+	}
+
+	digest := strings.TrimSpace(string(data))
+	if len(digest) != sha256.Size*2 {
+		return "", false
+	}
+
+	return digest, true
+}
+
 // githubRepoPath splits a plugin repo URL into owner and repo.
 func githubRepoPath(repo string) (string, string, error) {
 	u, err := url.Parse(repo)
@@ -139,22 +217,35 @@ func pluginAccessToken(ctx context.Context, repo string) (string, error) {
 	return token, nil
 }
 
-// fetchPlugin downloads name's binary from repo's latest release, verifies it
-// against the published .sha256, and installs it. Returns the installed path.
-func fetchPlugin(ctx context.Context, name, repo string, logger *zap.SugaredLogger) (string, error) {
+// publishedRelease is what a repo's latest release offers this platform: the
+// asset, the digest published alongside it, and the token that read them.
+type publishedRelease struct {
+	tag      string
+	asset    releaseAsset
+	checksum releaseAsset
+	token    string
+}
+
+// resolveRelease finds this platform's asset on repo's latest release.
+//
+// Split out from the download so the published digest can be read on its own.
+// That digest is 108 bytes against an asset of tens of megabytes, which is what
+// makes it affordable to ask "is what I installed still what is published?" on
+// every start rather than only when nothing is installed.
+func resolveRelease(ctx context.Context, name, repo string) (publishedRelease, error) {
 	owner, repoName, err := githubRepoPath(repo)
 	if err != nil {
-		return "", err
+		return publishedRelease{}, err
 	}
 
 	token, err := pluginAccessToken(ctx, repo)
 	if err != nil {
-		return "", err
+		return publishedRelease{}, err
 	}
 
 	rel, err := latestRelease(ctx, owner, repoName, token)
 	if err != nil {
-		return "", err
+		return publishedRelease{}, err
 	}
 
 	suffix := pluginAssetSuffix()
@@ -162,34 +253,61 @@ func fetchPlugin(ctx context.Context, name, repo string, logger *zap.SugaredLogg
 	if !ok {
 		err := errors.Newf("release %s of %s/%s publishes no asset ending in %s (has: %s)",
 			rel.TagName, owner, repoName, suffix, strings.Join(assetNames(rel), ", "))
-		return "", errors.WithHintf(err, "the release must ship an asset named for this platform, e.g. %s%s", PluginBinaryName(name), suffix)
+		return publishedRelease{}, errors.WithHintf(err, "the release must ship an asset named for this platform, e.g. %s%s", PluginBinaryName(name), suffix)
 	}
 
 	checksumAsset, ok := findAssetNamed(rel, asset.Name+".sha256")
 	if !ok {
 		err := errors.Newf("release %s of %s/%s publishes %s without %s.sha256",
 			rel.TagName, owner, repoName, asset.Name, asset.Name)
-		return "", errors.WithHint(err, "every asset must ship a .sha256 alongside it; an unverifiable binary is not installed")
+		return publishedRelease{}, errors.WithHint(err, "every asset must ship a .sha256 alongside it; an unverifiable binary is not installed")
+	}
+
+	return publishedRelease{tag: rel.TagName, asset: asset, checksum: checksumAsset, token: token}, nil
+}
+
+// publishedDigest reads the digest the latest release publishes for this
+// platform's asset, without downloading the asset.
+func publishedDigest(ctx context.Context, name, repo string) (string, error) {
+	rel, err := resolveRelease(ctx, name, repo)
+	if err != nil {
+		return "", err
+	}
+
+	digest, err := publishedChecksum(ctx, rel.checksum, rel.token)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read %s from release %s", rel.checksum.Name, rel.tag)
+	}
+
+	return digest, nil
+}
+
+// fetchPlugin downloads name's binary from repo's latest release, verifies it
+// against the published .sha256, and installs it. Returns the installed path.
+func fetchPlugin(ctx context.Context, name, repo string, logger *zap.SugaredLogger) (string, error) {
+	rel, err := resolveRelease(ctx, name, repo)
+	if err != nil {
+		return "", err
 	}
 
 	logger.Infow("Fetching plugin release asset",
-		"plugin", name, "repo", repo, "release", rel.TagName,
-		"asset", asset.Name, "bytes", asset.Size)
+		"plugin", name, "repo", repo, "release", rel.tag,
+		"asset", rel.asset.Name, "bytes", rel.asset.Size)
 
-	archive, err := downloadAsset(ctx, asset, token)
+	archive, err := downloadAsset(ctx, rel.asset, rel.token)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to download %s from release %s of %s/%s", asset.Name, rel.TagName, owner, repoName)
+		return "", errors.Wrapf(err, "failed to download %s from release %s", rel.asset.Name, rel.tag)
 	}
 
-	want, err := publishedChecksum(ctx, checksumAsset, token)
+	want, err := publishedChecksum(ctx, rel.checksum, rel.token)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to read %s from release %s of %s/%s", checksumAsset.Name, rel.TagName, owner, repoName)
+		return "", errors.Wrapf(err, "failed to read %s from release %s", rel.checksum.Name, rel.tag)
 	}
 
 	got := hex.EncodeToString(sha256Of(archive))
 	if got != want {
-		err := errors.Newf("checksum mismatch for %s from release %s of %s/%s: published %s, downloaded %s",
-			asset.Name, rel.TagName, owner, repoName, want, got)
+		err := errors.Newf("checksum mismatch for %s from release %s: published %s, downloaded %s",
+			rel.asset.Name, rel.tag, want, got)
 		return "", errors.WithHint(err, "the release asset and its .sha256 disagree; nothing was installed")
 	}
 
@@ -200,11 +318,23 @@ func fetchPlugin(ctx context.Context, name, repo string, logger *zap.SugaredLogg
 
 	binary, files, err := install(archive, dir, PluginBinaryName(name))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to install plugin %s to %s from %s", name, dir, asset.Name)
+		return "", errors.Wrapf(err, "failed to install plugin %s to %s from %s", name, dir, rel.asset.Name)
+	}
+
+	// Recorded so a later start can tell what is installed from what is
+	// published. Without it an install is permanent: a plugin on disk is
+	// accepted whatever it is, so a broken build stays broken and a new
+	// release never arrives.
+	if err := recordInstalledDigest(dir, got); err != nil {
+		return "", err
+	}
+
+	if err := removeLegacyInstall(name, logger); err != nil {
+		return "", err
 	}
 
 	logger.Infow("Installed plugin",
-		"plugin", name, "repo", repo, "release", rel.TagName,
+		"plugin", name, "repo", repo, "release", rel.tag,
 		"binary", binary, "files", files, "sha256", got)
 
 	return binary, nil

--- a/plugin/grpc/fetch.go
+++ b/plugin/grpc/fetch.go
@@ -1,0 +1,427 @@
+package grpc
+
+// Fetching a plugin binary from its repo's latest release.
+//
+// This layer knows exactly two states: the binary is on disk, or it is not.
+// There is no version pinning, no update check, and no rollback — adding a repo
+// URL to [plugin] enabled says "I want this plugin", not "I want this build".
+// `qntx-<name>-plugin --version` remains the only statement of what is running.
+//
+// A fetch failure is never fatal: the caller falls into the same
+// warn-and-mark-failed path as a plugin that was simply missing.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/teranos/QNTX/internal/config"
+	"github.com/teranos/QNTX/internal/secretref"
+	"github.com/teranos/errors"
+	"go.uber.org/zap"
+)
+
+// githubAPIBase is the only forge QNTX fetches from. Other hosts are rejected
+// by name rather than guessed at — release APIs are not portable.
+// A var so tests can drive the whole fetch path against a local server.
+var githubAPIBase = "https://api.github.com"
+
+const (
+	// githubHost is the host a plugin repo URL must have.
+	githubHost = "github.com"
+
+	// PluginFetchTimeout bounds a single plugin fetch. Plugin binaries run to
+	// tens of megabytes, so this is sized for a download, not an API call.
+	PluginFetchTimeout = 10 * time.Minute
+
+	// maxChecksumBytes caps the .sha256 read — it holds one hex digest.
+	maxChecksumBytes = 4096
+)
+
+// releaseAsset is one file published on a release.
+type releaseAsset struct {
+	Name string `json:"name"`
+	// URL is the API asset URL. Unlike browser_download_url it carries
+	// authorization, so the same code path serves public and private repos.
+	URL  string `json:"url"`
+	Size int64  `json:"size"`
+}
+
+// release is the subset of the GitHub release payload this needs.
+type release struct {
+	TagName string         `json:"tag_name"`
+	Assets  []releaseAsset `json:"assets"`
+}
+
+// PluginBinaryName is the file name a fetched plugin is installed as, and the
+// first name plugin discovery looks for on disk.
+func PluginBinaryName(name string) string {
+	return "qntx-" + name + "-plugin"
+}
+
+// pluginAssetSuffix is the release asset this platform needs, e.g.
+// "-darwin-arm64.tar.gz". Publishers name assets by GOOS-GOARCH.
+func pluginAssetSuffix() string {
+	return "-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
+}
+
+// PluginInstallPath is where a fetched binary is placed: ~/.qntx/plugins/.
+// Fetched plugins land in one known directory regardless of search paths, so
+// what arrived over the network is always in the same place to inspect.
+func PluginInstallPath(name string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve home directory for plugin %s install path", name)
+	}
+	return filepath.Join(home, ".qntx", "plugins", PluginBinaryName(name)), nil
+}
+
+// githubRepoPath splits a plugin repo URL into owner and repo.
+func githubRepoPath(repo string) (string, string, error) {
+	u, err := url.Parse(repo)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "failed to parse plugin source URL %s", repo)
+	}
+
+	if u.Host != githubHost {
+		err := errors.Newf("unsupported plugin source host %q in %s", u.Host, repo)
+		return "", "", errors.WithHintf(err, "plugin binaries are fetched from %s only; install this plugin to ~/.qntx/plugins/ and enable it by bare name instead", githubHost)
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		err := errors.Newf("plugin source URL %s is not an owner/repo path", repo)
+		return "", "", errors.WithHint(err, "use the repo root, e.g. https://github.com/sbvh-nl/duif")
+	}
+
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), nil
+}
+
+// pluginAccessToken resolves the credential configured for a repo's host.
+// Public repos need none, so an unset host is not an error.
+func pluginAccessToken(ctx context.Context, repo string) (string, error) {
+	u, err := url.Parse(repo)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse plugin source URL %s", repo)
+	}
+
+	ref := config.PluginAccessToken(u.Host)
+	if ref == "" {
+		return "", nil
+	}
+
+	token, err := secretref.Resolve(ctx, ref)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve plugin.access_token.%q", u.Host)
+	}
+	return token, nil
+}
+
+// fetchPlugin downloads name's binary from repo's latest release, verifies it
+// against the published .sha256, and installs it. Returns the installed path.
+func fetchPlugin(ctx context.Context, name, repo string, logger *zap.SugaredLogger) (string, error) {
+	owner, repoName, err := githubRepoPath(repo)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := pluginAccessToken(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+
+	rel, err := latestRelease(ctx, owner, repoName, token)
+	if err != nil {
+		return "", err
+	}
+
+	suffix := pluginAssetSuffix()
+	asset, ok := findAsset(rel, suffix)
+	if !ok {
+		err := errors.Newf("release %s of %s/%s publishes no asset ending in %s (has: %s)",
+			rel.TagName, owner, repoName, suffix, strings.Join(assetNames(rel), ", "))
+		return "", errors.WithHintf(err, "the release must ship an asset named for this platform, e.g. %s%s", PluginBinaryName(name), suffix)
+	}
+
+	checksumAsset, ok := findAssetNamed(rel, asset.Name+".sha256")
+	if !ok {
+		err := errors.Newf("release %s of %s/%s publishes %s without %s.sha256",
+			rel.TagName, owner, repoName, asset.Name, asset.Name)
+		return "", errors.WithHint(err, "every asset must ship a .sha256 alongside it; an unverifiable binary is not installed")
+	}
+
+	logger.Infow("Fetching plugin release asset",
+		"plugin", name, "repo", repo, "release", rel.TagName,
+		"asset", asset.Name, "bytes", asset.Size)
+
+	archive, err := downloadAsset(ctx, asset, token)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to download %s from release %s of %s/%s", asset.Name, rel.TagName, owner, repoName)
+	}
+
+	want, err := publishedChecksum(ctx, checksumAsset, token)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read %s from release %s of %s/%s", checksumAsset.Name, rel.TagName, owner, repoName)
+	}
+
+	got := hex.EncodeToString(sha256Of(archive))
+	if got != want {
+		err := errors.Newf("checksum mismatch for %s from release %s of %s/%s: published %s, downloaded %s",
+			asset.Name, rel.TagName, owner, repoName, want, got)
+		return "", errors.WithHint(err, "the release asset and its .sha256 disagree; nothing was installed")
+	}
+
+	binary, err := extractBinary(archive, PluginBinaryName(name))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to extract %s from %s", PluginBinaryName(name), asset.Name)
+	}
+
+	dest, err := PluginInstallPath(name)
+	if err != nil {
+		return "", err
+	}
+
+	if err := install(binary, dest); err != nil {
+		return "", errors.Wrapf(err, "failed to install plugin %s to %s", name, dest)
+	}
+
+	logger.Infow("Installed plugin binary",
+		"plugin", name, "repo", repo, "release", rel.TagName,
+		"path", dest, "bytes", len(binary), "sha256", got)
+
+	return dest, nil
+}
+
+// latestRelease reads the repo's latest release.
+func latestRelease(ctx context.Context, owner, repo, token string) (release, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/releases/latest", githubAPIBase, owner, repo)
+
+	body, err := get(ctx, endpoint, token, "application/vnd.github+json")
+	if err != nil {
+		return release{}, errors.Wrapf(err, "failed to read latest release of %s/%s", owner, repo)
+	}
+	defer body.Close()
+
+	var rel release
+	if err := json.NewDecoder(body).Decode(&rel); err != nil {
+		return release{}, errors.Wrapf(err, "failed to decode latest release of %s/%s", owner, repo)
+	}
+
+	if len(rel.Assets) == 0 {
+		err := errors.Newf("latest release %s of %s/%s has no assets", rel.TagName, owner, repo)
+		return release{}, errors.WithHint(err, "the release must publish built binaries, not just source archives")
+	}
+
+	return rel, nil
+}
+
+// findAsset returns the first asset whose name ends with suffix.
+func findAsset(rel release, suffix string) (releaseAsset, bool) {
+	for _, asset := range rel.Assets {
+		if strings.HasSuffix(asset.Name, suffix) {
+			return asset, true
+		}
+	}
+	return releaseAsset{}, false
+}
+
+// findAssetNamed returns the asset with exactly this name.
+func findAssetNamed(rel release, name string) (releaseAsset, bool) {
+	for _, asset := range rel.Assets {
+		if asset.Name == name {
+			return asset, true
+		}
+	}
+	return releaseAsset{}, false
+}
+
+// assetNames lists what a release actually published, for error messages that
+// show the operator why nothing matched.
+func assetNames(rel release) []string {
+	names := make([]string, 0, len(rel.Assets))
+	for _, asset := range rel.Assets {
+		names = append(names, asset.Name)
+	}
+	return names
+}
+
+// downloadAsset reads an asset's bytes through the API URL, which carries
+// authorization and so works for private repos.
+func downloadAsset(ctx context.Context, asset releaseAsset, token string) ([]byte, error) {
+	body, err := get(ctx, asset.URL, token, "application/octet-stream")
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s (%d bytes expected)", asset.Name, asset.Size)
+	}
+	return data, nil
+}
+
+// publishedChecksum reads the hex digest from a .sha256 asset. The file holds
+// either a bare digest or the `<digest>  <filename>` form; both start with it.
+func publishedChecksum(ctx context.Context, asset releaseAsset, token string) (string, error) {
+	body, err := get(ctx, asset.URL, token, "application/octet-stream")
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(body, maxChecksumBytes))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read %s", asset.Name)
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return "", errors.Newf("%s is empty", asset.Name)
+	}
+
+	digest := strings.ToLower(fields[0])
+	if len(digest) != sha256.Size*2 {
+		return "", errors.Newf("%s does not start with a sha256 digest: %q", asset.Name, digest)
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return "", errors.Wrapf(err, "%s does not start with a hex digest: %q", asset.Name, digest)
+	}
+
+	return digest, nil
+}
+
+// sha256Of hashes the downloaded bytes.
+func sha256Of(data []byte) []byte {
+	sum := sha256.Sum256(data)
+	return sum[:]
+}
+
+// get performs an authenticated GET and returns the body on success.
+func get(ctx context.Context, endpoint, token, accept string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build request for %s", endpoint)
+	}
+
+	req.Header.Set("Accept", accept)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "request to %s failed", endpoint)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, maxChecksumBytes))
+		resp.Body.Close()
+
+		err := errors.Newf("%s returned %s: %s", endpoint, resp.Status, strings.TrimSpace(string(detail)))
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized {
+			return nil, errors.WithHint(err, "a private repo needs a credential — set [plugin.access_token] for this host to an ssm:// or env: reference")
+		}
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+// extractBinary pulls one named file out of a .tar.gz.
+//
+// Only the archive entry's base name is compared and the destination is chosen
+// by QNTX, so a path in the archive can never steer where bytes land.
+func extractBinary(archive []byte, binaryName string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, errors.Wrap(err, "asset is not gzip data")
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var seen []string
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read tar entry")
+		}
+
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		seen = append(seen, header.Name)
+		if filepath.Base(header.Name) != binaryName {
+			continue
+		}
+
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read %s out of the archive", header.Name)
+		}
+		return data, nil
+	}
+
+	err = errors.Newf("archive contains no file named %s (has: %s)", binaryName, strings.Join(seen, ", "))
+	return nil, errors.WithHintf(err, "the release asset must contain the plugin binary named %s", binaryName)
+}
+
+// install writes the binary to dest, executable, replacing any previous file.
+// Written to a temp file in the same directory and renamed, so a crash mid-write
+// never leaves a half-binary where a plugin is expected.
+func install(binary []byte, dest string) error {
+	dir := filepath.Dir(dest)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errors.Wrapf(err, "failed to create plugin directory %s", dir)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(dest)+".partial-*")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create temp file in %s", dir)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(binary); err != nil {
+		tmp.Close()
+		return errors.Wrapf(err, "failed to write %d bytes to %s", len(binary), tmpName)
+	}
+	if err := tmp.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close %s", tmpName)
+	}
+
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return errors.Wrapf(err, "failed to make %s executable", tmpName)
+	}
+
+	// Remove first: renaming over a running binary fails with ETXTBSY on some
+	// systems, and the old file may be read-only (0555) from a previous install.
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to remove existing %s", dest)
+	}
+
+	if err := os.Rename(tmpName, dest); err != nil {
+		return errors.Wrapf(err, "failed to move %s into place at %s", tmpName, dest)
+	}
+
+	return nil
+}

--- a/plugin/grpc/fetch_test.go
+++ b/plugin/grpc/fetch_test.go
@@ -105,7 +105,7 @@ func TestFindAsset(t *testing.T) {
 	}
 }
 
-func TestExtractBinary(t *testing.T) {
+func TestExtractArchive(t *testing.T) {
 	want := []byte("\x7fELF pretend this is a plugin")
 	archive := tarGz(t, map[string][]byte{
 		"README.md":                  []byte("docs"),
@@ -113,21 +113,71 @@ func TestExtractBinary(t *testing.T) {
 		"dist/qntx-duif-plugin.dSYM": []byte("debug symbols"),
 	})
 
-	got, err := extractBinary(archive, "qntx-duif-plugin")
+	dir := t.TempDir()
+	binary, files, err := extractArchive(archive, dir, "qntx-duif-plugin")
 	if err != nil {
-		t.Fatalf("extractBinary = %v", err)
+		t.Fatalf("extractArchive = %v", err)
+	}
+
+	if got := filepath.Join(dir, "dist", "qntx-duif-plugin"); binary != got {
+		t.Errorf("extractArchive returned %q, want %q", binary, got)
+	}
+	if files != 3 {
+		t.Errorf("extractArchive wrote %d files, want 3", files)
+	}
+
+	got, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("read extracted binary: %v", err)
 	}
 	if !bytes.Equal(got, want) {
-		t.Errorf("extractBinary returned %q, want %q", got, want)
+		t.Errorf("extracted binary = %q, want %q", got, want)
 	}
 }
 
-func TestExtractBinaryMissing(t *testing.T) {
+// The layout is what makes an $ORIGIN-relative RPATH resolve, so a library
+// shipped beside the binary has to land beside the binary.
+func TestExtractArchivePreservesLayout(t *testing.T) {
+	archive := tarGz(t, map[string][]byte{
+		"qntx-duif-plugin": []byte("\x7fELF"),
+		"lib/libvmime.so.1": []byte("shared object"),
+	})
+
+	dir := t.TempDir()
+	binary, _, err := extractArchive(archive, dir, "qntx-duif-plugin")
+	if err != nil {
+		t.Fatalf("extractArchive = %v", err)
+	}
+
+	lib := filepath.Join(filepath.Dir(binary), "lib", "libvmime.so.1")
+	if _, err := os.Stat(lib); err != nil {
+		t.Errorf("library did not land beside the binary: %v", err)
+	}
+}
+
+func TestExtractArchiveBinaryIsExecutable(t *testing.T) {
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("\x7fELF")})
+
+	binary, _, err := extractArchive(archive, t.TempDir(), "qntx-duif-plugin")
+	if err != nil {
+		t.Fatalf("extractArchive = %v", err)
+	}
+
+	info, err := os.Stat(binary)
+	if err != nil {
+		t.Fatalf("stat extracted binary: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("extracted binary is not executable: mode %v", info.Mode())
+	}
+}
+
+func TestExtractArchiveMissing(t *testing.T) {
 	archive := tarGz(t, map[string][]byte{"README.md": []byte("docs")})
 
-	_, err := extractBinary(archive, "qntx-duif-plugin")
+	_, _, err := extractArchive(archive, t.TempDir(), "qntx-duif-plugin")
 	if err == nil {
-		t.Fatal("extractBinary accepted an archive with no plugin binary")
+		t.Fatal("extractArchive accepted an archive with no plugin binary")
 	}
 	// The error lists what was there, so the operator can see what shipped.
 	if !strings.Contains(err.Error(), "README.md") {
@@ -135,46 +185,96 @@ func TestExtractBinaryMissing(t *testing.T) {
 	}
 }
 
-func TestInstallIsExecutableAndReplaces(t *testing.T) {
-	dest := filepath.Join(t.TempDir(), "plugins", "qntx-duif-plugin")
+// Entry paths arrive from a downloaded archive. Nothing may be written outside
+// the plugin's own directory.
+func TestExtractArchiveRejectsEscapingPaths(t *testing.T) {
+	for _, name := range []string{"../evil", "dist/../../evil", "/etc/evil"} {
+		t.Run(name, func(t *testing.T) {
+			archive := tarGz(t, map[string][]byte{
+				name:               []byte("owned"),
+				"qntx-duif-plugin": []byte("\x7fELF"),
+			})
 
-	if err := install([]byte("first"), dest); err != nil {
+			dir := t.TempDir()
+			if _, _, err := extractArchive(archive, dir, "qntx-duif-plugin"); err == nil {
+				t.Fatalf("extractArchive accepted entry %q", name)
+			}
+
+			outside := filepath.Join(filepath.Dir(dir), "evil")
+			if _, err := os.Stat(outside); err == nil {
+				t.Errorf("entry %q wrote outside the plugin directory", name)
+			}
+		})
+	}
+}
+
+func TestInstallIsExecutableAndReplaces(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "plugins", "duif")
+
+	first := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("first")})
+	binary, _, err := install(first, dir, "qntx-duif-plugin")
+	if err != nil {
 		t.Fatalf("install = %v", err)
 	}
 
-	info, err := os.Stat(dest)
+	info, err := os.Stat(binary)
 	if err != nil {
-		t.Fatalf("stat %s = %v", dest, err)
+		t.Fatalf("stat %s = %v", binary, err)
 	}
 	if info.Mode()&0o111 == 0 {
-		t.Errorf("installed binary %s is not executable (mode %v)", dest, info.Mode())
+		t.Errorf("installed binary %s is not executable (mode %v)", binary, info.Mode())
 	}
 
 	// A read-only previous install must not block a replacement.
-	if err := os.Chmod(dest, 0o555); err != nil {
+	if err := os.Chmod(binary, 0o555); err != nil {
 		t.Fatalf("chmod = %v", err)
 	}
-	if err := install([]byte("second"), dest); err != nil {
+	second := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("second")})
+	binary, _, err = install(second, dir, "qntx-duif-plugin")
+	if err != nil {
 		t.Fatalf("install over an existing read-only binary = %v", err)
 	}
 
-	data, err := os.ReadFile(dest)
+	data, err := os.ReadFile(binary)
 	if err != nil {
-		t.Fatalf("read %s = %v", dest, err)
+		t.Fatalf("read %s = %v", binary, err)
 	}
 	if string(data) != "second" {
 		t.Errorf("installed content = %q, want %q", data, "second")
 	}
 
 	// Nothing partial may be left behind.
-	entries, err := os.ReadDir(filepath.Dir(dest))
+	entries, err := os.ReadDir(filepath.Dir(dir))
 	if err != nil {
 		t.Fatalf("readdir = %v", err)
 	}
 	for _, entry := range entries {
 		if strings.Contains(entry.Name(), ".partial-") {
-			t.Errorf("install left a partial file behind: %s", entry.Name())
+			t.Errorf("install left a partial directory behind: %s", entry.Name())
 		}
+	}
+}
+
+// A replacement must not leave the previous install's files behind: a stale
+// library beside a new binary is the failure this whole layout exists to avoid.
+func TestInstallReplacesWholeTree(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "plugins", "duif")
+
+	withLib := tarGz(t, map[string][]byte{
+		"qntx-duif-plugin": []byte("\x7fELF"),
+		"lib/libold.so":    []byte("old"),
+	})
+	if _, _, err := install(withLib, dir, "qntx-duif-plugin"); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+
+	withoutLib := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("\x7fELF")})
+	if _, _, err := install(withoutLib, dir, "qntx-duif-plugin"); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "lib", "libold.so")); err == nil {
+		t.Error("a library from the previous install survived the replacement")
 	}
 }
 
@@ -197,7 +297,7 @@ func TestFetchPluginRejectsChecksumMismatch(t *testing.T) {
 		t.Errorf("error = %v, want a checksum mismatch", err)
 	}
 
-	dest := filepath.Join(home, ".qntx", "plugins", "qntx-duif-plugin")
+	dest := filepath.Join(home, ".qntx", "plugins", "duif")
 	if _, statErr := os.Stat(dest); statErr == nil {
 		t.Errorf("a binary that failed verification was installed at %s", dest)
 	}
@@ -221,7 +321,7 @@ func TestFetchPluginInstallsVerifiedBinary(t *testing.T) {
 		t.Fatalf("fetchPlugin = %v", err)
 	}
 
-	want := filepath.Join(home, ".qntx", "plugins", "qntx-duif-plugin")
+	want := filepath.Join(home, ".qntx", "plugins", "duif", "dist", "qntx-duif-plugin")
 	if got != want {
 		t.Errorf("fetchPlugin installed at %q, want %q", got, want)
 	}

--- a/plugin/grpc/fetch_test.go
+++ b/plugin/grpc/fetch_test.go
@@ -1,0 +1,373 @@
+package grpc
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func testLogger(t *testing.T) *zap.SugaredLogger {
+	t.Helper()
+	return zap.NewNop().Sugar()
+}
+
+func TestGithubRepoPath(t *testing.T) {
+	tests := []struct {
+		repo      string
+		wantOwner string
+		wantRepo  string
+		wantErr   string
+	}{
+		{repo: "https://github.com/sbvh-nl/duif", wantOwner: "sbvh-nl", wantRepo: "duif"},
+		{repo: "https://github.com/sbvh-nl/duif.git", wantOwner: "sbvh-nl", wantRepo: "duif"},
+		{repo: "https://github.com/teranos/pty-glyph", wantOwner: "teranos", wantRepo: "pty-glyph"},
+		{repo: "https://codeberg.org/sbvh-nl/duif", wantErr: "unsupported plugin source host"},
+		{repo: "https://gitlab.com/sbvh-nl/duif", wantErr: "unsupported plugin source host"},
+		{repo: "https://github.com/sbvh-nl", wantErr: "not an owner/repo path"},
+		{repo: "https://github.com/sbvh-nl/duif/releases", wantErr: "not an owner/repo path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.repo, func(t *testing.T) {
+			owner, repo, err := githubRepoPath(tt.repo)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("githubRepoPath(%q) = %q/%q, want error %q", tt.repo, owner, repo, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("githubRepoPath(%q) error = %v, want it to mention %q", tt.repo, err, tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("githubRepoPath(%q) = %v", tt.repo, err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("githubRepoPath(%q) = %q/%q, want %q/%q", tt.repo, owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+// The rejection message must name the host the operator actually wrote, so the
+// fix is obvious from the log line alone.
+func TestUnsupportedHostErrorNamesTheHost(t *testing.T) {
+	_, _, err := githubRepoPath("https://codeberg.org/sbvh-nl/duif")
+	if err == nil {
+		t.Fatal("githubRepoPath accepted a non-github host")
+	}
+	if !strings.Contains(err.Error(), "codeberg.org") {
+		t.Errorf("error does not name the host: %v", err)
+	}
+}
+
+func TestPluginBinaryName(t *testing.T) {
+	if got := PluginBinaryName("duif"); got != "qntx-duif-plugin" {
+		t.Errorf("PluginBinaryName(duif) = %q, want qntx-duif-plugin", got)
+	}
+}
+
+func TestFindAsset(t *testing.T) {
+	rel := release{
+		TagName: "v1.2.0",
+		Assets: []releaseAsset{
+			{Name: "qntx-duif-plugin-linux-amd64.tar.gz"},
+			{Name: "qntx-duif-plugin-linux-amd64.tar.gz.sha256"},
+			{Name: "qntx-duif-plugin-darwin-arm64.tar.gz"},
+		},
+	}
+
+	got, ok := findAsset(rel, "-darwin-arm64.tar.gz")
+	if !ok {
+		t.Fatal("findAsset found no darwin-arm64 asset")
+	}
+	if got.Name != "qntx-duif-plugin-darwin-arm64.tar.gz" {
+		t.Errorf("findAsset = %q, want the darwin-arm64 asset", got.Name)
+	}
+
+	if _, ok := findAsset(rel, "-windows-amd64.tar.gz"); ok {
+		t.Error("findAsset matched a platform the release does not publish")
+	}
+}
+
+func TestExtractBinary(t *testing.T) {
+	want := []byte("\x7fELF pretend this is a plugin")
+	archive := tarGz(t, map[string][]byte{
+		"README.md":                  []byte("docs"),
+		"dist/qntx-duif-plugin":      want,
+		"dist/qntx-duif-plugin.dSYM": []byte("debug symbols"),
+	})
+
+	got, err := extractBinary(archive, "qntx-duif-plugin")
+	if err != nil {
+		t.Fatalf("extractBinary = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("extractBinary returned %q, want %q", got, want)
+	}
+}
+
+func TestExtractBinaryMissing(t *testing.T) {
+	archive := tarGz(t, map[string][]byte{"README.md": []byte("docs")})
+
+	_, err := extractBinary(archive, "qntx-duif-plugin")
+	if err == nil {
+		t.Fatal("extractBinary accepted an archive with no plugin binary")
+	}
+	// The error lists what was there, so the operator can see what shipped.
+	if !strings.Contains(err.Error(), "README.md") {
+		t.Errorf("error does not list the archive contents: %v", err)
+	}
+}
+
+func TestInstallIsExecutableAndReplaces(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "plugins", "qntx-duif-plugin")
+
+	if err := install([]byte("first"), dest); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat %s = %v", dest, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("installed binary %s is not executable (mode %v)", dest, info.Mode())
+	}
+
+	// A read-only previous install must not block a replacement.
+	if err := os.Chmod(dest, 0o555); err != nil {
+		t.Fatalf("chmod = %v", err)
+	}
+	if err := install([]byte("second"), dest); err != nil {
+		t.Fatalf("install over an existing read-only binary = %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read %s = %v", dest, err)
+	}
+	if string(data) != "second" {
+		t.Errorf("installed content = %q, want %q", data, "second")
+	}
+
+	// Nothing partial may be left behind.
+	entries, err := os.ReadDir(filepath.Dir(dest))
+	if err != nil {
+		t.Fatalf("readdir = %v", err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".partial-") {
+			t.Errorf("install left a partial file behind: %s", entry.Name())
+		}
+	}
+}
+
+// A binary whose bytes disagree with the published digest is never installed.
+func TestFetchPluginRejectsChecksumMismatch(t *testing.T) {
+	binary := []byte("\x7fELF the real plugin")
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": binary})
+
+	srv := releaseServer(t, archive, strings.Repeat("0", sha256.Size*2), "")
+	defer srv.Close()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := fetchPlugin(context.Background(), "duif", "https://github.com/sbvh-nl/duif", testLogger(t))
+	if err == nil {
+		t.Fatal("fetchPlugin installed a binary that failed its checksum")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("error = %v, want a checksum mismatch", err)
+	}
+
+	dest := filepath.Join(home, ".qntx", "plugins", "qntx-duif-plugin")
+	if _, statErr := os.Stat(dest); statErr == nil {
+		t.Errorf("a binary that failed verification was installed at %s", dest)
+	}
+}
+
+func TestFetchPluginInstallsVerifiedBinary(t *testing.T) {
+	binary := []byte("\x7fELF the real plugin")
+	archive := tarGz(t, map[string][]byte{"dist/qntx-duif-plugin": binary})
+
+	sum := sha256.Sum256(archive)
+	digest := hex.EncodeToString(sum[:])
+
+	srv := releaseServer(t, archive, digest, "")
+	defer srv.Close()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := fetchPlugin(context.Background(), "duif", "https://github.com/sbvh-nl/duif", testLogger(t))
+	if err != nil {
+		t.Fatalf("fetchPlugin = %v", err)
+	}
+
+	want := filepath.Join(home, ".qntx", "plugins", "qntx-duif-plugin")
+	if got != want {
+		t.Errorf("fetchPlugin installed at %q, want %q", got, want)
+	}
+
+	data, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read %s = %v", got, err)
+	}
+	if !bytes.Equal(data, binary) {
+		t.Errorf("installed bytes do not match the archived binary")
+	}
+
+	info, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat = %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("installed binary is not executable (mode %v)", info.Mode())
+	}
+}
+
+// A release that ships an asset without its .sha256 is not installable —
+// there is nothing to verify against.
+func TestFetchPluginRequiresPublishedChecksum(t *testing.T) {
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("bytes")})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := release{
+			TagName: "v1.0.0",
+			Assets: []releaseAsset{{
+				Name: "qntx-duif-plugin" + pluginAssetSuffix(),
+				URL:  "http://" + r.Host + "/asset",
+				Size: int64(len(archive)),
+			}},
+		}
+		json.NewEncoder(w).Encode(rel)
+	}))
+	defer srv.Close()
+
+	oldBase := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = oldBase }()
+
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := fetchPlugin(context.Background(), "duif", "https://github.com/sbvh-nl/duif", testLogger(t))
+	if err == nil {
+		t.Fatal("fetchPlugin installed an asset with no published checksum")
+	}
+	if !strings.Contains(err.Error(), ".sha256") {
+		t.Errorf("error = %v, want it to name the missing .sha256", err)
+	}
+}
+
+// A private repo answers 404 without credentials; the error must say so rather
+// than read as "this plugin does not exist".
+func TestFetchPluginPrivateRepoHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	oldBase := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = oldBase }()
+
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := fetchPlugin(context.Background(), "duif", "https://github.com/sbvh-nl/duif", testLogger(t))
+	if err == nil {
+		t.Fatal("fetchPlugin succeeded against a 404")
+	}
+
+	// The fix lives in the hint, which is what formatHints puts in the log line.
+	if !strings.Contains(formatHints(err), "access_token") {
+		t.Errorf("hints = %q, want them to point at [plugin.access_token] (error: %v)", formatHints(err), err)
+	}
+}
+
+// releaseServer serves one release whose single platform asset is archive,
+// with digest published alongside it. When token is non-empty, every request
+// must carry it.
+func releaseServer(t *testing.T, archive []byte, digest, token string) *httptest.Server {
+	t.Helper()
+
+	assetName := "qntx-duif-plugin" + pluginAssetSuffix()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token != "" && r.Header.Get("Authorization") != "Bearer "+token {
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/asset":
+			w.Write(archive)
+		case "/asset.sha256":
+			fmt.Fprintf(w, "%s  %s\n", digest, assetName)
+		default:
+			rel := release{
+				TagName: "v1.0.0",
+				Assets: []releaseAsset{
+					{Name: assetName, URL: "http://" + r.Host + "/asset", Size: int64(len(archive))},
+					{Name: assetName + ".sha256", URL: "http://" + r.Host + "/asset.sha256"},
+				},
+			}
+			json.NewEncoder(w).Encode(rel)
+		}
+	}))
+
+	oldBase := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = oldBase })
+
+	return srv
+}
+
+// tarGz builds a .tar.gz holding the given paths.
+func tarGz(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	for name, content := range files {
+		header := &tar.Header{
+			Name:     name,
+			Mode:     0o755,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatalf("write tar header for %s: %v", name, err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("write tar body for %s: %v", name, err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+
+	return buf.Bytes()
+}

--- a/plugin/grpc/fetch_test.go
+++ b/plugin/grpc/fetch_test.go
@@ -139,7 +139,7 @@ func TestExtractArchive(t *testing.T) {
 // shipped beside the binary has to land beside the binary.
 func TestExtractArchivePreservesLayout(t *testing.T) {
 	archive := tarGz(t, map[string][]byte{
-		"qntx-duif-plugin": []byte("\x7fELF"),
+		"qntx-duif-plugin":  []byte("\x7fELF"),
 		"lib/libvmime.so.1": []byte("shared object"),
 	})
 
@@ -275,6 +275,99 @@ func TestInstallReplacesWholeTree(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dir, "lib", "libold.so")); err == nil {
 		t.Error("a library from the previous install survived the replacement")
+	}
+}
+
+// An install records what it installed. Without this an install is permanent:
+// nothing can tell a current plugin from a stale one.
+func TestInstallDigestIsRecordedAndRead(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "plugins", "duif")
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("\x7fELF")})
+
+	if _, _, err := install(archive, dir, "qntx-duif-plugin"); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+
+	if _, ok := installedDigest(dir); ok {
+		t.Fatal("installedDigest read a digest that install had not recorded yet")
+	}
+
+	sum := sha256.Sum256(archive)
+	digest := hex.EncodeToString(sum[:])
+	if err := recordInstalledDigest(dir, digest); err != nil {
+		t.Fatalf("recordInstalledDigest = %v", err)
+	}
+
+	got, ok := installedDigest(dir)
+	if !ok {
+		t.Fatal("installedDigest found no digest after one was recorded")
+	}
+	if got != digest {
+		t.Errorf("installedDigest = %q, want %q", got, digest)
+	}
+}
+
+// A replacement rewrites the record. Reading a previous install's digest would
+// make an up-to-date plugin look stale on every start.
+func TestInstallDigestDoesNotSurviveReplacement(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "plugins", "duif")
+
+	first := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("first")})
+	if _, _, err := install(first, dir, "qntx-duif-plugin"); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+	if err := recordInstalledDigest(dir, strings.Repeat("a", 64)); err != nil {
+		t.Fatalf("recordInstalledDigest = %v", err)
+	}
+
+	second := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("second")})
+	if _, _, err := install(second, dir, "qntx-duif-plugin"); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+
+	if got, ok := installedDigest(dir); ok {
+		t.Errorf("a replacement kept the previous digest %q", got)
+	}
+}
+
+// Anything that is not a full-length hex digest is treated as no record at all,
+// so a truncated write cannot be compared against a published digest.
+func TestInstalledDigestRejectsMalformedRecord(t *testing.T) {
+	for _, content := range []string{"", "  ", "not-a-digest", strings.Repeat("a", 63)} {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, installedDigestFile), []byte(content), 0o644); err != nil {
+			t.Fatalf("write digest file: %v", err)
+		}
+
+		if got, ok := installedDigest(dir); ok {
+			t.Errorf("installedDigest accepted %q as %q", content, got)
+		}
+	}
+}
+
+// fetchPlugin records the digest, so the very next start can reconcile.
+func TestFetchPluginRecordsInstalledDigest(t *testing.T) {
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("\x7fELF the real plugin")})
+
+	sum := sha256.Sum256(archive)
+	digest := hex.EncodeToString(sum[:])
+
+	srv := releaseServer(t, archive, digest, "")
+	defer srv.Close()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, err := fetchPlugin(context.Background(), "duif", "https://github.com/sbvh-nl/duif", testLogger(t)); err != nil {
+		t.Fatalf("fetchPlugin = %v", err)
+	}
+
+	got, ok := installedDigest(filepath.Join(home, ".qntx", "plugins", "duif"))
+	if !ok {
+		t.Fatal("fetchPlugin installed a plugin without recording its digest")
+	}
+	if got != digest {
+		t.Errorf("recorded digest = %q, want %q", got, digest)
 	}
 }
 

--- a/plugin/grpc/loader.go
+++ b/plugin/grpc/loader.go
@@ -25,9 +25,10 @@ func LoadPluginsFromConfig(ctx context.Context, manager *PluginManager, cfg *con
 		return nil
 	}
 
-	// Build map of enabled plugins for deduplication
+	// Build map of enabled plugins for deduplication.
+	// Entries may be bare names or repo URLs — both reduce to a plugin name.
 	enabledPlugins := make(map[string]bool)
-	for _, name := range cfg.Plugin.Enabled {
+	for _, name := range cfg.Plugin.EnabledNames() {
 		enabledPlugins[name] = true
 	}
 
@@ -38,19 +39,23 @@ func LoadPluginsFromConfig(ctx context.Context, manager *PluginManager, cfg *con
 	}
 	sort.Strings(pluginNames)
 
-	// Discover plugins from configured paths (deduplicated)
+	// Discover plugins from configured paths (deduplicated), fetching any that
+	// declared a repo and are not on disk
 	var pluginConfigs []PluginConfig
 	var failedPlugins []string
 	for _, pluginName := range pluginNames {
 		logger.Debugf("Searching for '%s' plugin binary in %d paths", pluginName, len(cfg.Plugin.Paths))
 
-		pluginConfig, err := discoverPlugin(pluginName, cfg.Plugin.Paths, logger)
+		pluginConfig, err := resolvePlugin(ctx, pluginName, cfg.Plugin.Paths, logger)
 		if err != nil {
-			logger.Warnf("Plugin '%s' not found - searched paths: %v, tried names: [qntx-%s-plugin, qntx-%s, %s]",
-				pluginName, cfg.Plugin.Paths, pluginName, pluginName, pluginName)
+			// Hints carry the actionable half of these errors ("set access_token",
+			// "install the binary") — without this they never reach the operator.
+			logger.Warnf("Plugin '%s' unavailable: %v - searched paths: %v, tried names: [qntx-%s-plugin, qntx-%s, %s]%s",
+				pluginName, err, cfg.Plugin.Paths, pluginName, pluginName, pluginName,
+				formatHints(err))
 			failedPlugins = append(failedPlugins, pluginName)
 			manager.mu.Lock()
-			manager.failedPlugins[pluginName] = fmt.Sprintf("binary not found in search paths: %v", cfg.Plugin.Paths)
+			manager.failedPlugins[pluginName] = err.Error()
 			manager.mu.Unlock()
 			continue
 		}
@@ -101,6 +106,52 @@ func LoadPluginsFromConfig(ctx context.Context, manager *PluginManager, cfg *con
 	}
 
 	return nil
+}
+
+// formatHints renders an error's hints for a log line, or "" when it has none.
+// Hints hold the fix; %v alone shows only the failure.
+func formatHints(err error) string {
+	hints := errors.GetAllHints(err)
+	if len(hints) == 0 {
+		return ""
+	}
+	return " - " + strings.Join(hints, "; ")
+}
+
+// resolvePlugin finds a plugin binary on disk, fetching it from the plugin's
+// declared repo when it is absent.
+//
+// A plugin enabled by bare name never reaches the network: no repo, no fetch.
+// A plugin enabled by repo URL is fetched only when discovery comes up empty —
+// a binary already on disk is used as-is, whatever it is.
+func resolvePlugin(ctx context.Context, name string, searchPaths []string, logger *zap.SugaredLogger) (PluginConfig, error) {
+	pluginCfg, discoverErr := discoverPlugin(name, searchPaths, logger)
+	if discoverErr == nil {
+		return pluginCfg, nil
+	}
+
+	repo := config.PluginRepo(name)
+	if repo == "" {
+		return PluginConfig{}, discoverErr
+	}
+
+	logger.Infow("Plugin binary absent, fetching from its repo",
+		"plugin", name, "repo", repo, "searched", searchPaths)
+
+	fetchCtx, cancel := context.WithTimeout(ctx, PluginFetchTimeout)
+	defer cancel()
+
+	binary, err := fetchPlugin(fetchCtx, name, repo, logger)
+	if err != nil {
+		return PluginConfig{}, errors.Wrapf(err, "failed to fetch plugin '%s' from %s", name, repo)
+	}
+
+	return PluginConfig{
+		Name:      name,
+		Enabled:   true,
+		Binary:    binary,
+		AutoStart: true,
+	}, nil
 }
 
 // discoverPlugin finds a plugin binary in the configured search paths.
@@ -193,7 +244,7 @@ func discoverPlugin(name string, searchPaths []string, logger *zap.SugaredLogger
 	}
 
 	err := errors.Newf("plugin binary not found in search paths: %s", strings.Join(expandedPaths, ", "))
-	return PluginConfig{}, errors.WithHint(err, "install the plugin using 'qntx plugin install <name>' or add its path to [plugin].paths in config")
+	return PluginConfig{}, errors.WithHintf(err, "install the binary to one of those paths, add its path to [plugin] paths, or enable '%s' by repo URL so QNTX fetches it", name)
 }
 
 // expandAndValidatePath safely expands and validates a path using go-getter.

--- a/plugin/grpc/loader.go
+++ b/plugin/grpc/loader.go
@@ -173,10 +173,9 @@ func discoverPlugin(name string, searchPaths []string, logger *zap.SugaredLogger
 	// Search for plugin binary
 	for _, searchPath := range expandedPaths {
 		// Try common plugin binary names
-		candidates := []string{
-			filepath.Join(searchPath, fmt.Sprintf("qntx-%s-plugin", name)),
-			filepath.Join(searchPath, fmt.Sprintf("qntx-%s", name)),
-			filepath.Join(searchPath, name),
+		candidates := make([]string, 0, 3)
+		for _, binaryName := range pluginBinaryNames(name) {
+			candidates = append(candidates, filepath.Join(searchPath, binaryName))
 		}
 
 		for _, candidate := range candidates {
@@ -206,6 +205,21 @@ func discoverPlugin(name string, searchPaths []string, logger *zap.SugaredLogger
 							}
 						}
 					}
+
+					// Native plugin shipped as a tree: the binary sits inside
+					// the directory with its private libraries beside it, found
+					// via an $ORIGIN-relative RPATH. QNTX's own release is
+					// packaged this way; plugins may be too.
+					if binary, ok := nativePluginInDir(candidate, name); ok {
+						logger.Debugf("Found '%s' plugin tree: %s", name, binary)
+						return PluginConfig{
+							Name:      name,
+							Enabled:   true,
+							Binary:    binary,
+							AutoStart: true,
+						}, nil
+					}
+
 					// Not a valid plugin directory, continue searching
 					continue
 				}
@@ -245,6 +259,43 @@ func discoverPlugin(name string, searchPaths []string, logger *zap.SugaredLogger
 
 	err := errors.Newf("plugin binary not found in search paths: %s", strings.Join(expandedPaths, ", "))
 	return PluginConfig{}, errors.WithHintf(err, "install the binary to one of those paths, add its path to [plugin] paths, or enable '%s' by repo URL so QNTX fetches it", name)
+}
+
+// nativePluginInDir looks for an executable plugin binary inside dir, trying
+// the same names discovery tries at the top level. Returns the path to it.
+//
+// A tree is how a native plugin ships anything it cannot statically link: the
+// binary plus a lib/ directory, reached by an RPATH relative to the binary. The
+// alternative is a single file that must find its libraries on the host, which
+// only holds when the host and the build machine agree — the assumption that
+// makes a binary built on one distro fail to exec on another.
+func nativePluginInDir(dir, name string) (string, bool) {
+	for _, candidate := range pluginBinaryNames(name) {
+		path := filepath.Join(dir, candidate)
+
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if info.Mode()&0111 == 0 {
+			continue
+		}
+
+		return path, true
+	}
+
+	return "", false
+}
+
+// pluginBinaryNames lists the file names a plugin binary may have, most
+// specific first. Discovery and tree lookup must agree on these, so they read
+// them from here rather than each spelling them out.
+func pluginBinaryNames(name string) []string {
+	return []string{
+		PluginBinaryName(name),
+		fmt.Sprintf("qntx-%s", name),
+		name,
+	}
 }
 
 // expandAndValidatePath safely expands and validates a path using go-getter.

--- a/plugin/grpc/loader.go
+++ b/plugin/grpc/loader.go
@@ -119,30 +119,51 @@ func formatHints(err error) string {
 }
 
 // resolvePlugin finds a plugin binary on disk, fetching it from the plugin's
-// declared repo when it is absent.
+// declared repo when it is absent or no longer matches what that repo
+// publishes.
 //
 // A plugin enabled by bare name never reaches the network: no repo, no fetch.
-// A plugin enabled by repo URL is fetched only when discovery comes up empty —
-// a binary already on disk is used as-is, whatever it is.
+// A binary QNTX did not install is used as-is, whatever it is — hand-placing
+// one stays a way to run a build of your own choosing.
+//
+// A plugin QNTX installed is reconciled against the release on every start, the
+// way the box reconciles the qntx binary itself. Without that, the first build
+// to land is the last one that ever runs: a broken binary retries forever and a
+// new release never arrives, both of them fixable only by deleting the file by
+// hand on every machine.
 func resolvePlugin(ctx context.Context, name string, searchPaths []string, logger *zap.SugaredLogger) (PluginConfig, error) {
 	pluginCfg, discoverErr := discoverPlugin(name, searchPaths, logger)
-	if discoverErr == nil {
-		return pluginCfg, nil
-	}
 
 	repo := config.PluginRepo(name)
 	if repo == "" {
-		return PluginConfig{}, discoverErr
+		if discoverErr != nil {
+			return PluginConfig{}, discoverErr
+		}
+		return pluginCfg, nil
 	}
 
-	logger.Infow("Plugin binary absent, fetching from its repo",
-		"plugin", name, "repo", repo, "searched", searchPaths)
+	if discoverErr == nil && !managedPluginIsStale(ctx, name, repo, pluginCfg.Binary, logger) {
+		return pluginCfg, nil
+	}
+
+	if discoverErr != nil {
+		logger.Infow("Plugin binary absent, fetching from its repo",
+			"plugin", name, "repo", repo, "searched", searchPaths)
+	}
 
 	fetchCtx, cancel := context.WithTimeout(ctx, PluginFetchTimeout)
 	defer cancel()
 
 	binary, err := fetchPlugin(fetchCtx, name, repo, logger)
 	if err != nil {
+		// Replacing an installed plugin is an improvement, not a requirement.
+		// Losing a working plugin because the forge was unreachable would make
+		// every start depend on the network.
+		if discoverErr == nil {
+			logger.Warnw("Could not fetch the newer plugin; keeping the installed one",
+				"plugin", name, "repo", repo, "binary", pluginCfg.Binary, "error", err)
+			return pluginCfg, nil
+		}
 		return PluginConfig{}, errors.Wrapf(err, "failed to fetch plugin '%s' from %s", name, repo)
 	}
 
@@ -259,6 +280,61 @@ func discoverPlugin(name string, searchPaths []string, logger *zap.SugaredLogger
 
 	err := errors.Newf("plugin binary not found in search paths: %s", strings.Join(expandedPaths, ", "))
 	return PluginConfig{}, errors.WithHintf(err, "install the binary to one of those paths, add its path to [plugin] paths, or enable '%s' by repo URL so QNTX fetches it", name)
+}
+
+// managedPluginIsStale reports whether an installed plugin no longer matches
+// what its repo publishes, and so should be fetched again.
+//
+// Only a plugin under QNTX's own install directory is considered. A binary
+// found anywhere else was put there deliberately and is never replaced.
+//
+// Every uncertain answer is false. A release that cannot be reached, a digest
+// that cannot be read, a plugin installed before digests were recorded — none
+// of those are grounds to discard a plugin that is on disk and may well work. A
+// box with no network keeps running what it has.
+func managedPluginIsStale(ctx context.Context, name, repo, binary string, logger *zap.SugaredLogger) bool {
+	// An install from before plugins were unpacked as trees. QNTX put it there
+	// and it can never carry a digest, so there is nothing to compare — but it
+	// also shadows the tree that would replace it, so it is always superseded.
+	if legacy, err := LegacyPluginInstallPath(name); err == nil && binary == legacy {
+		logger.Infow("Plugin was installed before plugins were unpacked as trees, fetching it again",
+			"plugin", name, "repo", repo, "binary", binary)
+		return true
+	}
+
+	dir, err := PluginInstallPath(name)
+	if err != nil {
+		return false
+	}
+
+	rel, err := filepath.Rel(dir, binary)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	installed, ok := installedDigest(dir)
+	if !ok {
+		return false
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, PluginDigestTimeout)
+	defer cancel()
+
+	published, err := publishedDigest(checkCtx, name, repo)
+	if err != nil {
+		logger.Warnw("Could not check the plugin against its latest release; keeping what is installed",
+			"plugin", name, "repo", repo, "error", err)
+		return false
+	}
+
+	if published == installed {
+		return false
+	}
+
+	logger.Infow("Installed plugin differs from the latest release, fetching it again",
+		"plugin", name, "repo", repo, "installed", installed, "published", published)
+
+	return true
 }
 
 // nativePluginInDir looks for an executable plugin binary inside dir, trying

--- a/plugin/grpc/loader_test.go
+++ b/plugin/grpc/loader_test.go
@@ -2,6 +2,11 @@ package grpc
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,5 +90,193 @@ func TestGetAllPlugins_ReturnsUniqueInstances(t *testing.T) {
 		name := p.Metadata().Name
 		assert.False(t, pluginNames[name], "Plugin %s returned twice", name)
 		pluginNames[name] = true
+	}
+}
+
+// installManagedPlugin puts a plugin where QNTX's own installs go and returns
+// the path to its binary.
+func installManagedPlugin(t *testing.T, archive []byte) string {
+	t.Helper()
+
+	dir, err := PluginInstallPath("duif")
+	if err != nil {
+		t.Fatalf("PluginInstallPath = %v", err)
+	}
+
+	binary, _, err := install(archive, dir, "qntx-duif-plugin")
+	if err != nil {
+		t.Fatalf("install = %v", err)
+	}
+
+	return binary
+}
+
+// The reconcile exists to replace a build that is no longer the published one —
+// the case that otherwise needs someone deleting the file by hand on every box.
+func TestManagedPluginIsStaleWhenDigestDiffers(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("installed build")})
+	binary := installManagedPlugin(t, archive)
+
+	dir, _ := PluginInstallPath("duif")
+	if err := recordInstalledDigest(dir, strings.Repeat("a", 64)); err != nil {
+		t.Fatalf("recordInstalledDigest = %v", err)
+	}
+
+	published := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("published build")})
+	sum := sha256.Sum256(published)
+	srv := releaseServer(t, published, hex.EncodeToString(sum[:]), "")
+	defer srv.Close()
+
+	if !managedPluginIsStale(context.Background(), "duif", "https://github.com/sbvh-nl/duif", binary, testLogger(t)) {
+		t.Error("an installed plugin that differs from the published release was not stale")
+	}
+}
+
+func TestManagedPluginIsCurrentWhenDigestMatches(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("the build")})
+	binary := installManagedPlugin(t, archive)
+
+	sum := sha256.Sum256(archive)
+	digest := hex.EncodeToString(sum[:])
+
+	dir, _ := PluginInstallPath("duif")
+	if err := recordInstalledDigest(dir, digest); err != nil {
+		t.Fatalf("recordInstalledDigest = %v", err)
+	}
+
+	srv := releaseServer(t, archive, digest, "")
+	defer srv.Close()
+
+	if managedPluginIsStale(context.Background(), "duif", "https://github.com/sbvh-nl/duif", binary, testLogger(t)) {
+		t.Error("an installed plugin matching the published release was called stale")
+	}
+}
+
+// Hand-placing a binary stays a way to run a build of your own choosing. A
+// plugin outside QNTX's install directory is never reconciled away, however far
+// it is from what the repo publishes.
+func TestUnmanagedPluginIsNeverStale(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	elsewhere := t.TempDir()
+	binary := filepath.Join(elsewhere, "qntx-duif-plugin")
+	if err := os.WriteFile(binary, []byte("my own build"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	published := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("something else entirely")})
+	sum := sha256.Sum256(published)
+	srv := releaseServer(t, published, hex.EncodeToString(sum[:]), "")
+	defer srv.Close()
+
+	if managedPluginIsStale(context.Background(), "duif", "https://github.com/sbvh-nl/duif", binary, testLogger(t)) {
+		t.Error("a hand-placed plugin was treated as stale")
+	}
+}
+
+// An unreachable forge must not cost a box the plugin it already has.
+func TestUnreachableReleaseLeavesPluginInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("the build")})
+	binary := installManagedPlugin(t, archive)
+
+	dir, _ := PluginInstallPath("duif")
+	if err := recordInstalledDigest(dir, strings.Repeat("b", 64)); err != nil {
+		t.Fatalf("recordInstalledDigest = %v", err)
+	}
+
+	// A server that is listening and then is not, so the check fails the way
+	// an offline box fails rather than by pointing at a port nobody claimed.
+	srv := releaseServer(t, archive, strings.Repeat("c", 64), "")
+	srv.Close()
+
+	if managedPluginIsStale(context.Background(), "duif", "https://github.com/sbvh-nl/duif", binary, testLogger(t)) {
+		t.Error("an unreachable release discarded a plugin that was already installed")
+	}
+}
+
+// A pre-tree install is QNTX's own, not a hand-placed build, and it shadows the
+// tree that would replace it. It is always superseded.
+func TestLegacyInstallIsStale(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	legacy, err := LegacyPluginInstallPath("duif")
+	if err != nil {
+		t.Fatalf("LegacyPluginInstallPath = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("the build that will not run"), 0o755); err != nil {
+		t.Fatalf("write legacy binary: %v", err)
+	}
+
+	// No server: the decision must not depend on reaching the forge, since the
+	// legacy file has no digest to compare against in the first place.
+	if !managedPluginIsStale(context.Background(), "duif", "https://github.com/sbvh-nl/duif", legacy, testLogger(t)) {
+		t.Error("a pre-tree install was not superseded")
+	}
+}
+
+// Installing the tree removes the file it supersedes. Left in place, discovery
+// tries qntx-<name>-plugin before <name> and the old file wins every start.
+func TestFetchRemovesTheInstallItSupersedes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	legacy, err := LegacyPluginInstallPath("duif")
+	if err != nil {
+		t.Fatalf("LegacyPluginInstallPath = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("superseded"), 0o755); err != nil {
+		t.Fatalf("write legacy binary: %v", err)
+	}
+
+	archive := tarGz(t, map[string][]byte{
+		"qntx-duif-plugin":  []byte("\x7fELF"),
+		"lib/libvmime.so.1": []byte("shared object"),
+	})
+	sum := sha256.Sum256(archive)
+	srv := releaseServer(t, archive, hex.EncodeToString(sum[:]), "")
+	defer srv.Close()
+
+	binary, err := fetchPlugin(context.Background(), "duif", "https://github.com/sbvh-nl/duif", testLogger(t))
+	if err != nil {
+		t.Fatalf("fetchPlugin = %v", err)
+	}
+
+	if _, err := os.Stat(legacy); err == nil {
+		t.Error("the superseded plugin binary survived the install and will shadow the tree")
+	}
+
+	// And what replaced it is the tree, libraries included.
+	if _, err := os.Stat(filepath.Join(filepath.Dir(binary), "lib", "libvmime.so.1")); err != nil {
+		t.Errorf("the installed tree is missing its libraries: %v", err)
+	}
+}
+
+// A plugin installed before digests were recorded has no record to compare, and
+// is left alone rather than re-downloaded on every start.
+func TestPluginWithNoRecordedDigestIsNotStale(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	archive := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("the build")})
+	binary := installManagedPlugin(t, archive)
+
+	published := tarGz(t, map[string][]byte{"qntx-duif-plugin": []byte("newer build")})
+	sum := sha256.Sum256(published)
+	srv := releaseServer(t, published, hex.EncodeToString(sum[:]), "")
+	defer srv.Close()
+
+	if managedPluginIsStale(context.Background(), "duif", "https://github.com/sbvh-nl/duif", binary, testLogger(t)) {
+		t.Error("a plugin with no recorded digest was treated as stale")
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -654,7 +654,7 @@ func (s *QNTXServer) HandlePluginAction(w http.ResponseWriter, r *http.Request) 
 		preCheckCfg, preCheckErr := appcfg.Load()
 		if preCheckErr == nil {
 			enabled := false
-			for _, p := range preCheckCfg.Plugin.Enabled {
+			for _, p := range preCheckCfg.Plugin.EnabledNames() {
 				if p == name {
 					enabled = true
 					break

--- a/server/init.go
+++ b/server/init.go
@@ -267,7 +267,7 @@ func setupConfigWatcher(server *QNTXServer, db *sql.DB, serverLogger *zap.Sugare
 		}
 
 		nowEnabled := make(map[string]bool, len(newCfg.Plugin.Enabled))
-		for _, name := range newCfg.Plugin.Enabled {
+		for _, name := range newCfg.Plugin.EnabledNames() {
 			nowEnabled[name] = true
 		}
 		currentlyLoaded := make(map[string]bool)
@@ -295,7 +295,9 @@ func setupConfigWatcher(server *QNTXServer, db *sql.DB, serverLogger *zap.Sugare
 							serverLogger.Errorw("Plugin enable panicked", "plugin", pluginName, "panic", r)
 						}
 					}()
-					ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+					// Sized for a plugin fetch — adding a repo URL to a running
+					// box downloads the binary here before it loads.
+					ctx, cancel := context.WithTimeout(context.Background(), grpcplugin.PluginFetchTimeout)
 					defer cancel()
 					services := server.GetServices()
 					if err := manager.EnablePlugin(ctx, pluginName, newCfg.Plugin.Paths, registry, services); err != nil {


### PR DESCRIPTION
Fetching a plugin from its repo's latest release, and keeping it current.

A plugin binary, once on disk, was never replaced. `resolvePlugin` fetched only
when discovery came up empty, so the first build to land was the last one that
ever ran — a broken binary retried forever, a new release never arrived, and
both were fixable only by deleting the file by hand on every host.

Plugins were also held to a stricter packaging contract than QNTX holds itself.
QNTX ships as a tree: interpreter patched to the target's loader, `$ORIGIN`
RPATH, binary tarred alongside the libraries it needs. `extractBinary` took one
regular file and discarded the rest, so a plugin that cannot statically link
everything had nowhere to put its libraries.

Now: fetched plugins unpack whole into `~/.qntx/plugins/<name>/`, and the
installed digest is compared against the published one on every start.

Every uncertain answer leaves the plugin alone — unreachable forge, failed
fetch, no recorded digest, or a binary placed by hand. A host with no network
keeps running what it has, and hand-placing a binary stays the way to run a
build of your own choosing.
