### PR TITLE
plugins: resolve secret references in plugin configuration

### DIFF
--- a/internal/secretref/secretref.go
+++ b/internal/secretref/secretref.go
@@ -27,6 +27,17 @@ const (
 	SchemeEnv = "env:"
 )
 
+// IsReference reports whether value names a secret rather than being one.
+//
+// Where a field is known to hold a credential, a literal is a mistake and
+// Validate rejects it. Plugin configuration is not like that: QNTX cannot know
+// which of a plugin's own keys are secret, and a hostname is a literal by
+// rights. So values are resolved when they ask to be and passed through
+// otherwise.
+func IsReference(value string) bool {
+	return strings.HasPrefix(value, SchemeSSM) || strings.HasPrefix(value, SchemeEnv)
+}
+
 // Validate reports whether ref is a reference rather than a secret.
 // An empty ref is valid — it means no credential is configured.
 func Validate(ref string) error {

--- a/internal/secretref/secretref_test.go
+++ b/internal/secretref/secretref_test.go
@@ -88,3 +88,32 @@ func TestResolveEmptyIsNotAnError(t *testing.T) {
 		t.Errorf("Resolve(\"\") = %q, want \"\"", got)
 	}
 }
+
+// Plugin config is resolved where it asks to be and passed through otherwise,
+// so a hostname must not be mistaken for a reference and an empty value must
+// not be mistaken for one either.
+func TestIsReference(t *testing.T) {
+	references := []string{
+		"ssm:///path/to/parameter",
+		"env:SOME_TOKEN",
+	}
+	for _, value := range references {
+		if !IsReference(value) {
+			t.Errorf("IsReference(%q) = false, want true", value)
+		}
+	}
+
+	literals := []string{
+		"",
+		"imap.example.com",
+		"user@example.com",
+		"993",
+		"false",
+		"a-password-that-mentions-ssm-and-env",
+	}
+	for _, value := range literals {
+		if IsReference(value) {
+			t.Errorf("IsReference(%q) = true, want false", value)
+		}
+	}
+}

--- a/plugin/grpc/client.go
+++ b/plugin/grpc/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/teranos/QNTX/internal/secretref"
 	"github.com/teranos/QNTX/plugin"
 	"github.com/teranos/QNTX/plugin/grpc/protocol"
 	"github.com/teranos/errors"
@@ -356,6 +357,25 @@ func (c *ExternalDomainProxy) doInitialize(ctx context.Context, services plugin.
 	}
 	if token := pluginConfig.GetString("_auth_token"); token != "" {
 		authToken = token
+	}
+
+	// A plugin needing a credential would otherwise need it written literally
+	// in am.toml, which ships as an unencrypted parameter and is kept in
+	// version control. Resolving here means the secret reaches the plugin
+	// without ever being in the file, and plugins need no code for it.
+	for key, value := range config {
+		if !secretref.IsReference(value) {
+			continue
+		}
+
+		resolved, err := secretref.Resolve(ctx, value)
+		if err != nil {
+			// The reference is named, never the value it failed to fetch.
+			return errors.Wrapf(err, "failed to resolve the reference configured for %s.%s", c.metadata.Name, key)
+		}
+
+		config[key] = resolved
+		c.logger.Debugw("Resolved a config reference", "plugin", c.metadata.Name, "key", key)
 	}
 
 	req := &protocol.InitializeRequest{

--- a/plugin/grpc/fetch.go
+++ b/plugin/grpc/fetch.go
@@ -142,10 +142,8 @@ func removeLegacyInstall(name string, logger *zap.SugaredLogger) error {
 }
 
 // installedDigestFile names the record of which archive a plugin directory was
-// unpacked from. The box keeps the same record beside the qntx binary
-// (apply.sh, $BIN.installed.sha256) and for the same reason: comparing it
-// against a cheap published digest is what makes an install reconcilable
-// rather than permanent.
+// unpacked from. Comparing it against a cheap published digest is what makes an
+// install reconcilable rather than permanent.
 const installedDigestFile = ".installed.sha256"
 
 // recordInstalledDigest notes the archive digest dir was unpacked from.

--- a/plugin/grpc/loader.go
+++ b/plugin/grpc/loader.go
@@ -126,11 +126,10 @@ func formatHints(err error) string {
 // A binary QNTX did not install is used as-is, whatever it is — hand-placing
 // one stays a way to run a build of your own choosing.
 //
-// A plugin QNTX installed is reconciled against the release on every start, the
-// way the box reconciles the qntx binary itself. Without that, the first build
-// to land is the last one that ever runs: a broken binary retries forever and a
-// new release never arrives, both of them fixable only by deleting the file by
-// hand on every machine.
+// A plugin QNTX installed is reconciled against the release on every start.
+// Without that, the first build to land is the last one that ever runs: a
+// broken binary retries forever and a new release never arrives, both of them
+// fixable only by deleting the file by hand on every host.
 func resolvePlugin(ctx context.Context, name string, searchPaths []string, logger *zap.SugaredLogger) (PluginConfig, error) {
 	pluginCfg, discoverErr := discoverPlugin(name, searchPaths, logger)
 


### PR DESCRIPTION
A plugin's own credential could not be kept out of am.toml.

Forge tokens are resolved through secretref, so `access_token` can name a
secret instead of being one. Plugin configuration had no such path: it reached
the plugin verbatim, so anything a plugin needed — an IMAP password, an API
key — had to be written literally into a file that is frequently readable by
more than its owner and kept in version control.

Values that name a secret are now resolved on the way to Initialize. Where a
field is known to hold a credential a literal is a mistake and `Validate`
rejects it, but QNTX cannot know which of a plugin's own keys are secret and a
hostname is a literal by rights — so a value is resolved when it asks to be and
passed through otherwise.

Plugins need no part in this. A plugin receives its credential and cannot tell
whether it came from the file or from the store behind the reference.

Verified end to end: a plugin authenticated against a real IMAP server with a
password it never saw in its configuration.
