### PR TITLE
Stop building Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,8 @@ jobs:
             - Intel (x64): `qntx-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz`
             - Apple Silicon (ARM): `qntx-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz`
 
-            **Windows:**
-            - x64: `qntx-${{ steps.version.outputs.version }}-windows-amd64.zip`
-
             ### Desktop App (Tauri)
 
-            **Windows:** `QNTX_${{ steps.version.outputs.version }}_x64-setup.exe` or `.msi`
             **macOS:** `QNTX_${{ steps.version.outputs.version }}_aarch64.dmg`
 
             ### Changes
@@ -186,87 +182,6 @@ jobs:
           name: qntx-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}
           path: release/*
 
-  build-windows:
-    # Native windows-latest so `make cli` builds the qntx-sqlite Rust static
-    # lib + wasm + Go binary end-to-end. The Rust default host is switched to
-    # the GNU toolchain — its .a static lib matches what Go's Windows CGO
-    # (MinGW gcc) expects to link against. The old CGO_ENABLED=0 Linux cross
-    # skipped both wasm and rustdriver → broken artifact.
-    runs-on: windows-latest
-    needs: create-release
-    if: always()  # Run even if create-release is skipped
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        arch: [amd64]
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Extract version
-        id: version
-        run: |
-          # For tags, extract version from tag name
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            # For branch testing, use test version
-            VERSION="test-$(git rev-parse --short HEAD)"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building version: $VERSION"
-
-      - name: Setup Rust (GNU host for Go/CGO link compatibility)
-        run: |
-          rustup toolchain install stable-x86_64-pc-windows-gnu
-          rustup default stable-x86_64-pc-windows-gnu
-          rustup target add wasm32-unknown-unknown
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Install wasm-pack
-        run: cargo install wasm-pack
-
-      - name: Build Windows binary
-        run: make cli
-
-      - name: Package binary
-        run: |
-          mkdir -p release
-          cp bin/qntx.exe release/
-          cd release
-          7z a qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip qntx.exe
-          sha256sum qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip > qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip.sha256
-          # Version-free alias — see the linux job.
-          cp qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip qntx-windows-${{ matrix.arch }}.zip
-          sha256sum qntx-windows-${{ matrix.arch }}.zip > qntx-windows-${{ matrix.arch }}.zip.sha256
-
-      - name: Upload Release Asset (tags only)
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: |
-            release/qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip
-            release/qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip.sha256
-            release/qntx-windows-${{ matrix.arch }}.zip
-            release/qntx-windows-${{ matrix.arch }}.zip.sha256
-
-      - name: Upload artifacts (testing only)
-        if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: actions/upload-artifact@v4
-        with:
-          name: qntx-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}
-          path: release/*
-
   build-macos:
     # Native macOS runner so CGO + rust-sqlite static lib + WASM all build via
     # `make cli` — the same recipe that produces the developer's local binary.
@@ -345,93 +260,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: qntx-${{ steps.version.outputs.version }}-darwin-${{ matrix.arch }}
-          path: release/*
-
-  build-tauri-windows:
-    runs-on: windows-latest
-    needs: create-release
-    if: always()
-    permissions:
-      contents: write
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Extract version
-        id: version
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION="test-$(git rev-parse --short HEAD)"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Setup Rust (GNU host for Go/CGO link compatibility)
-        # Default host switched to GNU: qntx-sqlite produces .a (matches Go
-        # CGO's MinGW linker) and Tauri builds on GNU. wasm target added for
-        # crates/qntx-wasm.
-        run: |
-          rustup toolchain install stable-x86_64-pc-windows-gnu
-          rustup default stable-x86_64-pc-windows-gnu
-          rustup target add wasm32-unknown-unknown
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Verify Tauri version parity (Rust ↔ NPM)
-        run: bash .github/scripts/check-tauri-versions.sh
-
-      - name: Install Tauri CLI and wasm-pack
-        run: cargo install tauri-cli --version "^2" && cargo install wasm-pack
-
-      - name: Build frontend
-        run: make web
-
-      - name: Build qntx CLI sidecar
-        run: make cli
-
-      - name: Prepare Tauri sidecar
-        run: |
-          mkdir -p web/src-tauri/bin
-          cp bin/qntx.exe web/src-tauri/bin/qntx-x86_64-pc-windows-gnu.exe
-
-      - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: web/src-tauri
-
-      - name: Build Tauri app
-        run: cd web/src-tauri && cargo tauri build --no-bundle
-
-      - name: Package binary
-        run: |
-          mkdir -p release
-          cp target/release/qntx.exe release/QNTX-${{ steps.version.outputs.version }}-windows-x64.exe
-          cd release
-          sha256sum *.exe > QNTX-${{ steps.version.outputs.version }}-windows-x64.exe.sha256
-
-      - name: Upload Release Asset (tags only)
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: release/*
-
-      - name: Upload artifacts (testing only)
-        if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: actions/upload-artifact@v4
-        with:
-          name: qntx-desktop-${{ steps.version.outputs.version }}-windows-amd64
           path: release/*
 
   build-tauri-macos:

--- a/docs/adr/ADR-029-windows.md
+++ b/docs/adr/ADR-029-windows.md
@@ -1,0 +1,29 @@
+# ADR-029: Windows
+
+**Status:** Accepted
+**Date:** 2026-08-07
+**Related:** ADR-001 (Domain Plugin Architecture)
+
+## Context
+
+"why does the windows pipeline keep failing, as if it doesnt want to stay
+stable and alive and no mainenance"
+
+"what is forcing the maintenence burden on it?"
+
+"why is having a windows pipeline not free"
+
+## Decision
+
+"and honestly, i think about just deleting it after all"
+
+"ok, delete it"
+
+"focus on getting rid of windows"
+
+## Consequences
+
+"and windows support should end in docs as well if there is any mention of it"
+
+"or the docs should be clear that qntx is targetted to be used on unix-like
+systems and never windows as the direct host"

--- a/docs/architecture/pulse-resource-coordination.md
+++ b/docs/architecture/pulse-resource-coordination.md
@@ -247,7 +247,7 @@ alert_on_hog = true              # Send alerts when hogs detected
 ## Migration Path
 
 1. Add SystemResourceMonitor to pulse package (initially returns dummy values)
-2. Implement nvidia-smi parsing for GPU (Linux only, graceful fallback on Mac/Windows)
+2. Implement nvidia-smi parsing for GPU (Linux only, graceful fallback on Mac)
 3. Add adaptive quota logic to Tracker.CheckBudget()
 4. Add system load check to worker.processJobs() with exponential backoff
 5. Add configuration flags: max_system_gpu_percent, backpressure_threshold

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -5,7 +5,9 @@
 ### What We Build
 - ✅ Docker images (amd64, arm64) → GHCR
 - ✅ Go CLI binary (local builds only)
-- ⚠️  Tauri apps (macOS, Windows, Android, iOS) → Only CI checks, no releases
+- ⚠️  Tauri apps (macOS, Android, iOS) → Only CI checks, no releases
+
+Unix-like hosts only — see [ADR-029](adr/ADR-029-windows.md).
 
 ### What We Distribute
 - Docker images: `ghcr.io/teranos/qntx:latest` and `ghcr.io/teranos/qntx:{version}`
@@ -23,8 +25,8 @@
 **What:** Attach binaries to git tags automatically
 
 **Platforms to distribute:**
-- CLI binaries (Linux amd64/arm64, macOS Intel/ARM, Windows x64)
-- Desktop apps (macOS .dmg, Windows .msi/.exe)
+- CLI binaries (Linux amd64/arm64, macOS Intel/ARM)
+- Desktop apps (macOS .dmg)
 - Android APK (sideload)
 
 **Implementation:**
@@ -86,12 +88,6 @@ brew install teranos/tap/qntx
 - MacPorts (lower priority)
 - Mac App Store (requires Apple Developer account + annual fee)
 
-#### Windows
-- **winget** (High priority - official Windows package manager)
-  - Submit manifest to `microsoft/winget-pkgs`
-  - Free, official, widely adopted
-- **Scoop** (Medium priority - developer-focused)
-  - Add bucket with JSON manifest
 - **Chocolatey** (Lower priority - enterprise-focused)
   - Requires moderation for community repo
 
@@ -155,7 +151,7 @@ brew install teranos/tap/qntx
 
 1. **GitHub Releases workflow**
    - Multi-platform CLI builds (goreleaser)
-   - Tauri desktop app builds (macOS .dmg, Windows .msi)
+   - Tauri desktop app builds (macOS .dmg)
    - Android APK build
    - Auto-create release on version tags
 
@@ -183,7 +179,6 @@ brew install teranos/tap/qntx
 **Deliverable:**
 ```bash
 brew install teranos/tap/qntx        # macOS/Linux
-winget install Teranos.QNTX          # Windows
 ```
 
 ---
@@ -240,7 +235,6 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
@@ -250,9 +244,6 @@ builds:
 
 archives:
   - format: tar.gz
-    format_overrides:
-      - goos: windows
-        format: zip
 
 release:
   github:
@@ -332,27 +323,6 @@ end
 ```
 
 Auto-update with `brew bump-formula-pr`.
-
----
-
-### winget Manifest
-
-**`microsoft/winget-pkgs/manifests/t/Teranos/QNTX/0.16.14/`:**
-
-```yaml
-PackageIdentifier: Teranos.QNTX
-PackageVersion: 0.16.14
-PackageLocale: en-US
-Publisher: Teranos
-PackageName: QNTX
-License: MIT
-ShortDescription: Continuous Intelligence Platform
-Installers:
-  - Architecture: x64
-    InstallerType: msi
-    InstallerUrl: https://github.com/teranos/QNTX/releases/download/v0.16.14/qntx_Windows_x64.msi
-    InstallerSha256: ...
-```
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,13 +89,6 @@ tar -xzf qntx-VERSION-darwin-arm64.tar.gz
 sudo mv qntx /usr/local/bin/
 ```
 
-**Windows:**
-```powershell
-# Download from: https://github.com/teranos/QNTX/releases/latest
-# Extract qntx-VERSION-windows-amd64.zip
-# Add qntx.exe to your PATH
-```
-
 ### Verify Download
 
 Each release includes SHA256 checksums:
@@ -111,7 +104,8 @@ sha256sum -c qntx-VERSION-linux-amd64.tar.gz.sha256
 **Available Platforms:**
 - Linux (amd64, arm64)
 - macOS (Intel, Apple Silicon)
-- Windows (x64)
+
+Unix-like hosts only — see [ADR-029](adr/ADR-029-windows.md).
 
 **Note:** Replace `VERSION` with the actual version number (e.g., `0.17.3`). See [releases page](https://github.com/teranos/QNTX/releases) for all versions.
 
@@ -198,12 +192,6 @@ The following package managers are planned:
 brew install teranos/tap/qntx
 ```
 
-### winget (Windows)
-```bash
-# Not yet available
-winget install Teranos.QNTX
-```
-
 ### APT (Debian/Ubuntu)
 ```bash
 # Not yet available
@@ -237,7 +225,6 @@ qntx am show
 | Linux | arm64 | GitHub Releases, Nix, Docker, Source | ✅ |
 | macOS | Intel (x64) | GitHub Releases, Nix, Tauri, Source | ✅ |
 | macOS | Apple Silicon (ARM) | GitHub Releases, Nix, Tauri, Source | ✅ |
-| Windows | x64 | GitHub Releases, Tauri, Source | ⚠️ (no CGO — limited functionality) |
 | Android | ARM | Tauri | ✅ |
 | iOS | ARM | Tauri | ⚠️ (experimental) |
 

--- a/docs/research/metal-scry.md
+++ b/docs/research/metal-scry.md
@@ -20,9 +20,9 @@ The token stream is not just a sequence to watch — it's a tree. At each token 
 
 **Performance is the priority.** Metal is chosen deliberately to eliminate the abstraction layers between data and pixels. This commits to the Apple ecosystem for this plugin. The same GPU running scry inference renders the visualization — zero-copy potential between inference output buffers and visualization input buffers.
 
-**Platform scope:** macOS-only via Metal. If this needs to run on Windows or Linux in the future, the viable paths are:
+**Platform scope:** macOS-only via Metal. If this needs to run on Linux in the future, the viable paths are:
 - **Vulkan** — closest cross-platform equivalent to Metal compute + render. MoltenVK already translates Vulkan to Metal on macOS, so a Vulkan-first approach would run everywhere but add a translation layer on the primary target. The trade-off: universal reach at the cost of the zero-copy Metal↔llama.cpp path.
-- **WebGPU (wgpu/Dawn)** — browser-native GPU API with Rust (wgpu) or C++ (Dawn) implementations. Maps to Metal on macOS, Vulkan on Linux, D3D12 on Windows. Higher abstraction than raw Metal, but the same shader language (WGSL or translated SPIR-V). Would require rewriting shaders but not the data pipeline.
+- **WebGPU (wgpu/Dawn)** — browser-native GPU API with Rust (wgpu) or C++ (Dawn) implementations. Maps to Metal on macOS and Vulkan on Linux. Higher abstraction than raw Metal, but the same shader language (WGSL or translated SPIR-V). Would require rewriting shaders but not the data pipeline.
 - **Rewrite in Zig + WebGPU** — Zig's comptime could generate pipeline layouts at compile time (like D's CTFE for protobuf). Cross-platform from day one, but no ecosystem precedent in QNTX yet.
 
 For now, Metal is the right call — the scry plugin already uses Metal acceleration, Tauri targets macOS, and the inference-to-visualization data path benefits from staying on the same GPU API.


### PR DESCRIPTION
"and honestly, i think about just deleting it after all"

Windows shipped once, at v0.26.6. The eight releases since produced no Windows
asset while both Windows jobs kept running and failing, and the notes kept
promising a zip that was not there.

## Why it could not stay

The break is three lines, all `syscall.Kill(-pid, SIG…)`. The pid is negative:
that is a process group, and Windows has no equivalent. QNTX supervises plugin
processes and reaps their children, so the port is a second supervisor built on
Job Objects — not a shim. Nothing else in the tree cares what OS it is on.

"why is having a windows pipeline not free"

Runner time was the smaller half. A job that is always red is a workflow nobody
reads.

## Where the decision lives

ADR-029, in your words. The docs that claimed Windows now either drop the claim
or link to it, instead of each carrying a copy of the reasoning.

macOS is deliberately untouched.
