### PR TITLE
server: the prompt wire type is the proto attestation

### DIFF
--- a/docs/types/server.md
+++ b/docs/types/server.md
@@ -391,7 +391,7 @@ type PromptDirectRequest struct {
 	Model string `json:"model,omitempty"`
 	GlyphID string `json:"glyph_id,omitempty"`
 	ParentGlyphID string `json:"parent_glyph_id,omitempty"`
-	UpstreamAttestation *types.As `json:"upstream_attestation,omitempty"`
+	UpstreamAttestation *protocol.Attestation `json:"upstream_attestation,omitempty"`
 	FileIDs []string `json:"file_ids,omitempty"`
 }
 ```
@@ -444,7 +444,7 @@ type PromptExecuteResponse struct {
 
 ## PromptSaveRequest {#promptsaverequest}
 
-**Source**: [`server/prompt_handlers.go:679`](https://github.com/teranos/QNTX/blob/main/server/prompt_handlers.go#L679)
+**Source**: [`server/prompt_handlers.go:686`](https://github.com/teranos/QNTX/blob/main/server/prompt_handlers.go#L686)
 
 
 ```go

--- a/qntx-plugins/qntx-openrouter/handlers.go
+++ b/qntx-plugins/qntx-openrouter/handlers.go
@@ -54,12 +54,12 @@ type PromptResult struct {
 
 // PromptDirectRequest represents a request to execute a prompt directly
 type PromptDirectRequest struct {
-	Template            string    `json:"template"`
-	SystemPrompt        string    `json:"system_prompt,omitempty"`
-	Model               string    `json:"model,omitempty"`
-	GlyphID             string    `json:"glyph_id,omitempty"`
-	UpstreamAttestation *types.As `json:"upstream_attestation,omitempty"`
-	FileIDs             []string  `json:"file_ids,omitempty"`
+	Template            string                `json:"template"`
+	SystemPrompt        string                `json:"system_prompt,omitempty"`
+	Model               string                `json:"model,omitempty"`
+	GlyphID             string                `json:"glyph_id,omitempty"`
+	UpstreamAttestation *protocol.Attestation `json:"upstream_attestation,omitempty"`
+	FileIDs             []string              `json:"file_ids,omitempty"`
 }
 
 // PromptDirectResponse represents the direct execution response
@@ -257,7 +257,7 @@ func (h *Handlers) HandlePromptDirect(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			promptText = doc.Body
 		} else {
-			interpolated, err := tmpl.Execute(req.UpstreamAttestation)
+			interpolated, err := tmpl.Execute(req.UpstreamAttestation.ToTypes())
 			if err != nil {
 				writeError(w, http.StatusBadRequest, fmt.Sprintf("Template interpolation failed: %v", err))
 				return

--- a/server/prompt_handlers.go
+++ b/server/prompt_handlers.go
@@ -40,14 +40,14 @@ type PromptExecuteRequest struct {
 
 // PromptDirectRequest represents a request to execute a prompt without attestations
 type PromptDirectRequest struct {
-	Template            string    `json:"template"` // Prompt template with optional {{field}} placeholders
-	SystemPrompt        string    `json:"system_prompt,omitempty"`
-	Provider            string    `json:"provider,omitempty"` // "openrouter" or "local"
-	Model               string    `json:"model,omitempty"`
-	GlyphID             string    `json:"glyph_id,omitempty"`             // Glyph that initiated execution; used as actor for the result attestation
-	ParentGlyphID       string    `json:"parent_glyph_id,omitempty"`      // Parent glyph ID for conversation history assembly (stream glyphs send their parent)
-	UpstreamAttestation *types.As `json:"upstream_attestation,omitempty"` // Triggering attestation — enables {{field}} interpolation
-	FileIDs             []string  `json:"file_ids,omitempty"`             // Attached document/image file IDs for multimodal prompts
+	Template            string                `json:"template"` // Prompt template with optional {{field}} placeholders
+	SystemPrompt        string                `json:"system_prompt,omitempty"`
+	Provider            string                `json:"provider,omitempty"` // "openrouter" or "local"
+	Model               string                `json:"model,omitempty"`
+	GlyphID             string                `json:"glyph_id,omitempty"`             // Glyph that initiated execution; used as actor for the result attestation
+	ParentGlyphID       string                `json:"parent_glyph_id,omitempty"`      // Parent glyph ID for conversation history assembly (stream glyphs send their parent)
+	UpstreamAttestation *protocol.Attestation `json:"upstream_attestation,omitempty"` // Triggering attestation — enables {{field}} interpolation
+	FileIDs             []string              `json:"file_ids,omitempty"`             // Attached document/image file IDs for multimodal prompts
 }
 
 // PromptDirectResponse represents the direct execution response
@@ -346,8 +346,15 @@ func (s *QNTXServer) HandlePromptDirect(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Resolve prompt text from template body + optional upstream attestation
-	promptText, err := resolvePromptText(doc, req.UpstreamAttestation)
+	// Resolve prompt text from template body + optional upstream attestation.
+	// The wire type is the proto attestation (ADR-006); ats/so's template engine
+	// still takes types.As, so convert at this boundary rather than making ATS
+	// import the protocol package.
+	var upstream *types.As
+	if req.UpstreamAttestation != nil {
+		upstream = req.UpstreamAttestation.ToTypes()
+	}
+	promptText, err := resolvePromptText(doc, upstream)
 	if err != nil {
 		writeWrappedError(w, s.logger, err, "Template interpolation failed", http.StatusBadRequest)
 		return


### PR DESCRIPTION
Step toward ATS types coming from proto instead of typegen (ADR-006).

## The one field

typegen generates from a fixed package list and only reads **exported struct fields**. Across all six listed packages, exactly one exported field referenced `ats/types`:

```go
// server/prompt_handlers.go
UpstreamAttestation *types.As `json:"upstream_attestation,omitempty"`
```

That field alone is why typegen must keep generating `ats/types` for the `typescript` and `markdown` targets.

| Package in typegen's list | exported fields referencing `ats/types` |
|---|---|
| `server` | **1** — this one |
| `pulse/async`, `pulse/budget`, `pulse/schedule`, `server/syscap`, `sym` | 0 |

The other 27 uses of `types.As` in `server/` are function parameters and locals, which typegen never sees.

It is now `*protocol.Attestation` — the same type its sibling `PromptDirectResponse.Attestation` has used since ADR-006 step 1, twelve lines below it in the same struct family.

## Why openrouter moves too

`forwardToProviderPlugin` re-encodes the request body and forwards it, and `qntx-openrouter` carries a mirror of `PromptDirectRequest`. Its field moves with it, or the wire shape and the parser disagree on the first `/prompt/direct` carrying an upstream attestation.

## ats/so is untouched

`Template.Execute` still takes `*types.As`. Both call sites convert with the existing `protocol.(*Attestation).ToTypes()`. Making the template engine take the proto type would mean `ats/` importing `plugin/grpc/protocol` — a new ATS→QNTX dependency, the wrong direction, and unnecessary here.

## Wire change

`upstream_attestation` timestamps go from RFC3339 string to int64 milliseconds. No producer found: nothing in `web/ts` sends the field, and `PromptDirectRequest` has no Go constructor — only the HTTP decode in `prompt_handlers.go`.

## Testing

- `go build ./...` clean
- `make test` — all 12 `ats` packages and `server` pass. `db` still fails (`TestOpen`, `TestOpenWithMigrations`), unchanged and pre-existing on `main`
- `nix run .#check-types` — **✓ Types are up to date**
- `tsc --noEmit` clean; `USE_JSDOM=1 bun test` — **767 pass, 0 fail**

`docs/types/server.md` is the regenerated consequence.

## What this does not do

typegen still generates `ats/types`, because `typescript/generator.go:100` maps `"protocol.Attestation"` → `"As"`. With that mapping in place, dropping `ats/types` from typegen's package lists leaves `server.ts` referencing a type it can no longer import — verified by running it. That line is the next blocker and lives in `teranos/typegen`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVvkpv27q7HfJVzhUcjpZ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVvkpv27q7HfJVzhUcjpZ5)_