### PR TITLE
Signer identity on parquet, and namespaces to put it under

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: cli typegen web run-web test-web test-jsdom test test-parquet test-ocaml test-d test-coverage test-verbose clean server dev dev-mobile types types-check desktop-prepare desktop-dev desktop-build install proto code-plugin atproto-plugin github-plugin ix-json-plugin ix-bin-plugin ix-net-plugin faal-plugin openrouter-plugin pty-glyph-plugin loom-plugin kern-plugin llama-cpp-plugin meili-plugin rust-sqlite ats laye rust-reduce parity
+.PHONY: cli typegen web run-web test-web test-jsdom test test-parquet test-ocaml test-d test-coverage test-verbose clean server dev dev-mobile types types-check desktop-prepare desktop-dev desktop-build install proto code-plugin atproto-plugin github-plugin ix-json-plugin ix-bin-plugin ix-net-plugin faal-plugin openrouter-plugin pty-glyph-plugin loom-plugin kern-plugin llama-cpp-plugin meili-plugin rust-sqlite ats rust-reduce parity
 
 # Installation prefix (override with PREFIX=/custom/path make install)
 PREFIX ?= $(HOME)/.qntx
@@ -432,24 +432,6 @@ ats: ## Build ats as WASM module (for wazero integration + browser)
 	@cp -r crates/ats-wasm/pkg/* web/wasm/
 	@echo "  ✓ Browser WASM built and copied to web/wasm/"
 	@ls -lh web/wasm/*.wasm 2>/dev/null | awk '{print "    Size: " $$5 " - " $$9}' || (echo "    ERROR: wasm-pack ran but produced no .wasm files"; exit 1)
-
-
-# LAYE identity layer. Why the deploy and not a checkout: docs/laye-sibling-wasm.md
-LAYE_URL ?= https://laye.sbvh.nl
-
-# A main push overwrites these URLs in place, so the pin is the hash.
-LAYE_REV := 0e2aabc6fa8d85368ee08a8892496fc25eb1b852
-LAYE_WASM_SHA256 := e902c042fcae6c6cfc20bcf9098c093f4e7a5cad7b590b8fc6ba43c59085bcd5
-LAYE_JS_SHA256 := c84fc3b1dbebb150f569da5b3d3820ca67e624c23ff593ec1e0d00a1c1e76121
-
-laye: ## Fetch LAYE p2p WASM (identity layer) into web/wasm/, verified against pinned hashes
-	@echo "Fetching laye-p2p from $(LAYE_URL) — pinned at $(LAYE_REV)"
-	@curl -fsS --max-time 180 -o web/wasm/laye_p2p_bg.wasm "$(LAYE_URL)/laye_p2p_bg.wasm" || (echo "  ERROR: could not fetch $(LAYE_URL)/laye_p2p_bg.wasm"; exit 1)
-	@curl -fsS --max-time 60 -o web/wasm/laye_p2p.js "$(LAYE_URL)/laye_p2p.js" || (echo "  ERROR: could not fetch $(LAYE_URL)/laye_p2p.js"; exit 1)
-	@echo "$(LAYE_WASM_SHA256)  web/wasm/laye_p2p_bg.wasm" | shasum -a 256 -c - >/dev/null || (echo "  ERROR: laye_p2p_bg.wasm does not match LAYE_WASM_SHA256 — upstream redeployed since this pin was taken"; exit 1)
-	@echo "$(LAYE_JS_SHA256)  web/wasm/laye_p2p.js" | shasum -a 256 -c - >/dev/null || (echo "  ERROR: laye_p2p.js does not match LAYE_JS_SHA256 — upstream redeployed since this pin was taken"; exit 1)
-	@echo "  ✓ laye-p2p verified against pinned hashes"
-	@ls -lh web/wasm/laye_p2p_bg.wasm | awk '{print "    Size: " $$5}'
 
 
 # TODO: move to its own plugin Makefile:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: cli typegen web run-web test-web test-jsdom test test-parquet test-ocaml test-d test-coverage test-verbose clean server dev dev-mobile types types-check desktop-prepare desktop-dev desktop-build install proto code-plugin atproto-plugin github-plugin ix-json-plugin ix-bin-plugin ix-net-plugin faal-plugin openrouter-plugin pty-glyph-plugin loom-plugin kern-plugin llama-cpp-plugin meili-plugin rust-sqlite ats rust-reduce parity
+.PHONY: cli typegen web run-web test-web test-jsdom test test-parquet test-ocaml test-d test-coverage test-verbose clean server dev dev-mobile types types-check desktop-prepare desktop-dev desktop-build install proto code-plugin atproto-plugin github-plugin ix-json-plugin ix-bin-plugin ix-net-plugin faal-plugin openrouter-plugin pty-glyph-plugin loom-plugin kern-plugin llama-cpp-plugin meili-plugin rust-sqlite ats laye rust-reduce parity
 
 # Installation prefix (override with PREFIX=/custom/path make install)
 PREFIX ?= $(HOME)/.qntx
@@ -206,6 +206,7 @@ test-parquet: ## Run parquet backend tests (requires Nix for libduckdb)
 	@nix develop .#default --command cargo build --release -p ats-duckdb --features ffi --lib
 	@nix develop .#default --command cargo test -p ats-duckdb --lib --features ffi
 	@nix develop .#default --command go test -tags "rustsqlite,qntxwasm,rustduckdb" -short ./ats/storage/duckdbcgo/...
+	@nix develop .#default --command go build -tags "rustsqlite,qntxwasm,rustduckdb" ./...
 
 test-ocaml: ## Run OCaml plugin tests (loom, kern)
 	@echo "Running OCaml tests..."
@@ -431,6 +432,24 @@ ats: ## Build ats as WASM module (for wazero integration + browser)
 	@cp -r crates/ats-wasm/pkg/* web/wasm/
 	@echo "  ✓ Browser WASM built and copied to web/wasm/"
 	@ls -lh web/wasm/*.wasm 2>/dev/null | awk '{print "    Size: " $$5 " - " $$9}' || (echo "    ERROR: wasm-pack ran but produced no .wasm files"; exit 1)
+
+
+# LAYE identity layer. Why the deploy and not a checkout: docs/laye-sibling-wasm.md
+LAYE_URL ?= https://laye.sbvh.nl
+
+# A main push overwrites these URLs in place, so the pin is the hash.
+LAYE_REV := 0e2aabc6fa8d85368ee08a8892496fc25eb1b852
+LAYE_WASM_SHA256 := e902c042fcae6c6cfc20bcf9098c093f4e7a5cad7b590b8fc6ba43c59085bcd5
+LAYE_JS_SHA256 := c84fc3b1dbebb150f569da5b3d3820ca67e624c23ff593ec1e0d00a1c1e76121
+
+laye: ## Fetch LAYE p2p WASM (identity layer) into web/wasm/, verified against pinned hashes
+	@echo "Fetching laye-p2p from $(LAYE_URL) — pinned at $(LAYE_REV)"
+	@curl -fsS --max-time 180 -o web/wasm/laye_p2p_bg.wasm "$(LAYE_URL)/laye_p2p_bg.wasm" || (echo "  ERROR: could not fetch $(LAYE_URL)/laye_p2p_bg.wasm"; exit 1)
+	@curl -fsS --max-time 60 -o web/wasm/laye_p2p.js "$(LAYE_URL)/laye_p2p.js" || (echo "  ERROR: could not fetch $(LAYE_URL)/laye_p2p.js"; exit 1)
+	@echo "$(LAYE_WASM_SHA256)  web/wasm/laye_p2p_bg.wasm" | shasum -a 256 -c - >/dev/null || (echo "  ERROR: laye_p2p_bg.wasm does not match LAYE_WASM_SHA256 — upstream redeployed since this pin was taken"; exit 1)
+	@echo "$(LAYE_JS_SHA256)  web/wasm/laye_p2p.js" | shasum -a 256 -c - >/dev/null || (echo "  ERROR: laye_p2p.js does not match LAYE_JS_SHA256 — upstream redeployed since this pin was taken"; exit 1)
+	@echo "  ✓ laye-p2p verified against pinned hashes"
+	@ls -lh web/wasm/laye_p2p_bg.wasm | awk '{print "    Size: " $$5}'
 
 
 # TODO: move to its own plugin Makefile:

--- a/ats/storage/duckdbcgo/benchmark_test.go
+++ b/ats/storage/duckdbcgo/benchmark_test.go
@@ -31,7 +31,7 @@ const (
 func TestPerformanceFloor(t *testing.T) {
 	loc := "file://" + filepath.Join(t.TempDir(), "qntx-parquet")
 
-	store, err := NewDuckdbStore(loc)
+	store, err := NewDuckdbStore(loc, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewDuckdbStore(%q) failed: %v", loc, err)
 	}

--- a/ats/storage/duckdbcgo/nodeidentity_cgo.go
+++ b/ats/storage/duckdbcgo/nodeidentity_cgo.go
@@ -1,0 +1,117 @@
+//go:build cgo && rustduckdb
+
+package duckdbcgo
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../../crates/ats-duckdb/include
+
+#include "duckdb_ffi.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"unsafe"
+
+	"github.com/teranos/QNTX/server/nodedid"
+	"github.com/teranos/errors"
+)
+
+// IdentityStore is the parquet-backend implementation of nodedid.IdentityStore.
+// ADR-026 makes the system namespace the node, so there is one record here.
+type IdentityStore struct {
+	ptr unsafe.Pointer // *C.IdentityStore
+	mu  sync.Mutex
+}
+
+// identityRecord is the wire shape of crates/ats-duckdb/src/nodeidentity.rs.
+// Keys are hex because the stored object is JSON.
+type identityRecord struct {
+	PrivateKeyHex string `json:"private_key_hex"`
+	PublicKeyHex  string `json:"public_key_hex"`
+	DID           string `json:"did"`
+}
+
+// NewIdentityStore opens the identity store at a storage location URL.
+func NewIdentityStore(location string) (*IdentityStore, error) {
+	cLocation := C.CString(location)
+	defer C.free(unsafe.Pointer(cLocation))
+
+	ptr := C.duckdb_identity_new(cLocation)
+	if ptr == nil {
+		return nil, errors.Newf("failed to open the node identity store at %s", location)
+	}
+	return &IdentityStore{ptr: unsafe.Pointer(ptr)}, nil
+}
+
+// Close releases the Rust-owned store.
+func (s *IdentityStore) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ptr != nil {
+		C.duckdb_identity_free((*C.IdentityStore)(s.ptr))
+		s.ptr = nil
+	}
+}
+
+// Load returns the stored identity, or nil when the node has never generated
+// one. Nil is how nodedid.NewWithStore decides to mint a key rather than abort.
+func (s *IdentityStore) Load() (*nodedid.Identity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := C.duckdb_identity_load((*C.IdentityStore)(s.ptr))
+	defer C.duckdb_tokens_result_free(result)
+
+	if !bool(result.success) {
+		return nil, errors.Newf("failed to load the node identity: %s", C.GoString(result.error_msg))
+	}
+	body := C.GoString(result.tokens_json)
+	if body == "" {
+		return nil, nil
+	}
+
+	var record identityRecord
+	if err := json.Unmarshal([]byte(body), &record); err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize the node identity")
+	}
+
+	priv, err := hex.DecodeString(record.PrivateKeyHex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "node identity %s has an unreadable private key", record.DID)
+	}
+	pub, err := hex.DecodeString(record.PublicKeyHex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "node identity %s has an unreadable public key", record.DID)
+	}
+
+	return &nodedid.Identity{
+		PrivateKey: ed25519.PrivateKey(priv),
+		PublicKey:  ed25519.PublicKey(pub),
+		DID:        record.DID,
+	}, nil
+}
+
+// Save writes the node's identity, replacing whatever was there.
+func (s *IdentityStore) Save(id *nodedid.Identity) error {
+	body, err := json.Marshal(identityRecord{
+		PrivateKeyHex: hex.EncodeToString(id.PrivateKey),
+		PublicKeyHex:  hex.EncodeToString(id.PublicKey),
+		DID:           id.DID,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to serialize node identity %s", id.DID)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cBody := C.CString(string(body))
+	defer C.free(unsafe.Pointer(cBody))
+
+	result := C.duckdb_identity_save((*C.IdentityStore)(s.ptr), cBody)
+	return storageResultErr(result, "save node identity "+id.DID)
+}

--- a/ats/storage/duckdbcgo/nodeidentity_cgo_test.go
+++ b/ats/storage/duckdbcgo/nodeidentity_cgo_test.go
@@ -1,0 +1,119 @@
+//go:build cgo && rustduckdb
+
+package duckdbcgo
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/teranos/QNTX/server/nodedid"
+)
+
+// Same caveat as tokens_cgo_test.go: `make test` builds with rustsqlite, not
+// rustduckdb, so this is the only thing exercising the FFI for node identity.
+
+// nodedid must be able to use whatever this is.
+var _ nodedid.IdentityStore = (*IdentityStore)(nil)
+
+func newIdentityStore(t *testing.T) *IdentityStore {
+	t.Helper()
+	store, err := NewIdentityStore("file://" + t.TempDir())
+	if err != nil {
+		t.Fatalf("NewIdentityStore: %v", err)
+	}
+	t.Cleanup(store.Close)
+	return store
+}
+
+// First boot has no identity, and that is not a failure. nodedid.NewWithStore
+// reads nil as "generate one" — an error here would abort startup instead.
+func TestLoadOnAFreshLocationReturnsNothing(t *testing.T) {
+	store := newIdentityStore(t)
+
+	id, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load on a fresh location: %v", err)
+	}
+	if id != nil {
+		t.Errorf("a fresh location yielded an identity: %+v", id)
+	}
+}
+
+// Namespace is the top-level prefix in a location. ADR-026 makes the system
+// namespace the node, so its identity lands under that prefix — never at the
+// root, where a later namespace would have nowhere to go beside it.
+func TestIdentityLandsUnderTheSystemNamespace(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := NewIdentityStore("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewIdentityStore: %v", err)
+	}
+	t.Cleanup(store.Close)
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := store.Save(&nodedid.Identity{PrivateKey: priv, PublicKey: pub, DID: "did:key:ztest"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, "system"))
+	if err != nil {
+		t.Fatalf("nothing was written under the system namespace: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("the system namespace prefix is empty after Save")
+	}
+}
+
+// The node's signing key has to survive a restart. If it does not, every
+// attestation the node ever signed becomes unverifiable against its DID.
+func TestIdentitySurvivesReopen(t *testing.T) {
+	location := "file://" + t.TempDir()
+
+	first, err := NewIdentityStore(location)
+	if err != nil {
+		t.Fatalf("NewIdentityStore: %v", err)
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	saved := &nodedid.Identity{
+		PrivateKey: priv,
+		PublicKey:  pub,
+		DID:        "did:key:ztest",
+	}
+	if err := first.Save(saved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	first.Close()
+
+	second, err := NewIdentityStore(location)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(second.Close)
+
+	loaded, err := second.Load()
+	if err != nil {
+		t.Fatalf("Load after reopen: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("the identity did not survive reopening the location")
+	}
+	if loaded.DID != saved.DID {
+		t.Errorf("DID = %q, want %q", loaded.DID, saved.DID)
+	}
+	if !bytes.Equal(loaded.PrivateKey, saved.PrivateKey) {
+		t.Error("the private key did not round-trip")
+	}
+	if !bytes.Equal(loaded.PublicKey, saved.PublicKey) {
+		t.Error("the public key did not round-trip")
+	}
+}

--- a/ats/storage/duckdbcgo/schedules_cgo.go
+++ b/ats/storage/duckdbcgo/schedules_cgo.go
@@ -27,14 +27,17 @@ type ScheduleStore struct {
 	mu  sync.Mutex
 }
 
-// NewScheduleStore opens the schedule store at a storage location URL.
-func NewScheduleStore(location string) (*ScheduleStore, error) {
+// NewScheduleStore opens the schedule store for a namespace at a storage
+// location. A schedule created in a namespace stays there.
+func NewScheduleStore(location, namespace string) (*ScheduleStore, error) {
 	cLocation := C.CString(location)
 	defer C.free(unsafe.Pointer(cLocation))
+	cNamespace := C.CString(namespace)
+	defer C.free(unsafe.Pointer(cNamespace))
 
-	ptr := C.duckdb_schedules_new(cLocation)
+	ptr := C.duckdb_schedules_new(cLocation, cNamespace)
 	if ptr == nil {
-		return nil, errors.Newf("failed to open the schedule store at %s", location)
+		return nil, errors.Newf("failed to open the schedule store at %s for %s", location, namespace)
 	}
 	return &ScheduleStore{ptr: unsafe.Pointer(ptr)}, nil
 }

--- a/ats/storage/duckdbcgo/schedules_cgo_test.go
+++ b/ats/storage/duckdbcgo/schedules_cgo_test.go
@@ -14,7 +14,7 @@ import (
 
 func newScheduleStore(t *testing.T, location string) *ScheduleStore {
 	t.Helper()
-	store, err := NewScheduleStore("file://" + location)
+	store, err := NewScheduleStore("file://"+location, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewScheduleStore: %v", err)
 	}

--- a/ats/storage/duckdbcgo/storage_cgo.go
+++ b/ats/storage/duckdbcgo/storage_cgo.go
@@ -44,16 +44,18 @@ type DuckdbStore struct {
 	mu       sync.Mutex
 }
 
-// NewDuckdbStore opens a DuckDB-backed store at the given location URL
-// (e.g. "s3://bucket/prefix" or "file:///path"). Returns an error if the
-// underlying Rust call returns NULL.
-func NewDuckdbStore(location string) (*DuckdbStore, error) {
+// NewDuckdbStore opens a DuckDB-backed store for a namespace at the given
+// location URL (e.g. "s3://bucket/prefix" or "file:///path"). Attestations
+// land under the namespace and a store reads no other.
+func NewDuckdbStore(location, namespace string) (*DuckdbStore, error) {
 	cLoc := C.CString(location)
 	defer C.free(unsafe.Pointer(cLoc))
+	cNamespace := C.CString(namespace)
+	defer C.free(unsafe.Pointer(cNamespace))
 
-	ptr := C.duckdb_storage_new(cLoc)
+	ptr := C.duckdb_storage_new(cLoc, cNamespace)
 	if ptr == nil {
-		return nil, errors.Newf("failed to open DuckDB store at %s (see stderr for details)", location)
+		return nil, errors.Newf("failed to open DuckDB store at %s for %s (see stderr for details)", location, namespace)
 	}
 	return &DuckdbStore{ptr: unsafe.Pointer(ptr), location: location}, nil
 }

--- a/ats/storage/duckdbcgo/storage_cgo_test.go
+++ b/ats/storage/duckdbcgo/storage_cgo_test.go
@@ -17,7 +17,7 @@ import (
 func TestRoundTrip(t *testing.T) {
 	loc := "file://" + filepath.Join(t.TempDir(), "qntx-parquet")
 
-	store, err := NewDuckdbStore(loc)
+	store, err := NewDuckdbStore(loc, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewDuckdbStore(%q) failed: %v", loc, err)
 	}
@@ -91,7 +91,7 @@ func TestFlushAndReopen(t *testing.T) {
 	loc := "file://" + filepath.Join(dir, "qntx-parquet")
 
 	// First lifetime: put + flush + close.
-	first, err := NewDuckdbStore(loc)
+	first, err := NewDuckdbStore(loc, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewDuckdbStore(%q) failed: %v", loc, err)
 	}
@@ -117,7 +117,7 @@ func TestFlushAndReopen(t *testing.T) {
 
 	// Second lifetime: reopen at the same location; the flushed row must
 	// be visible without any writes on the new instance.
-	second, err := NewDuckdbStore(loc)
+	second, err := NewDuckdbStore(loc, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("second NewDuckdbStore(%q) failed: %v", loc, err)
 	}
@@ -148,7 +148,7 @@ func TestFlushAndReopen(t *testing.T) {
 // ats/storage/ats_store.go:88.
 func TestGetAttestationsFilter(t *testing.T) {
 	loc := "file://" + filepath.Join(t.TempDir(), "qntx-parquet")
-	store, err := NewDuckdbStore(loc)
+	store, err := NewDuckdbStore(loc, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewDuckdbStore(%q) failed: %v", loc, err)
 	}
@@ -316,7 +316,7 @@ func keys(m map[string]bool) []string {
 func TestGetMissingReturnsNil(t *testing.T) {
 	loc := "file://" + filepath.Join(t.TempDir(), "qntx-parquet")
 
-	store, err := NewDuckdbStore(loc)
+	store, err := NewDuckdbStore(loc, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewDuckdbStore() failed: %v", err)
 	}

--- a/ats/storage/duckdbcgo/tokens_cgo.go
+++ b/ats/storage/duckdbcgo/tokens_cgo.go
@@ -24,6 +24,13 @@ import (
 	"github.com/teranos/errors"
 )
 
+// The two namespaces a deployment always has (ADR-026). Every other namespace
+// is created by SUPER; these two cannot be deleted.
+const (
+	NamespaceSystem  = "system"
+	NamespaceDefault = "default"
+)
+
 // TokenStore is the parquet-backend implementation of auth.TokenStore
 // (ADR-025). Tokens are one object each under `<location>/access_tokens/`,
 // held by the Rust crate.
@@ -59,14 +66,17 @@ type tokenSummary struct {
 	RevokedAt  *int64 `json:"revoked_at,omitempty"`
 }
 
-// NewTokenStore opens the token store at a storage location URL.
-func NewTokenStore(location string) (*TokenStore, error) {
+// NewTokenStore opens the token store for a namespace at a storage location.
+// A token writes into the namespace it belongs to (ADR-027).
+func NewTokenStore(location, namespace string) (*TokenStore, error) {
 	cLocation := C.CString(location)
 	defer C.free(unsafe.Pointer(cLocation))
+	cNamespace := C.CString(namespace)
+	defer C.free(unsafe.Pointer(cNamespace))
 
-	ptr := C.duckdb_tokens_new(cLocation)
+	ptr := C.duckdb_tokens_new(cLocation, cNamespace)
 	if ptr == nil {
-		return nil, errors.Newf("failed to open the access token store at %s", location)
+		return nil, errors.Newf("failed to open the access token store at %s for %s", location, namespace)
 	}
 	return &TokenStore{ptr: unsafe.Pointer(ptr)}, nil
 }

--- a/ats/storage/duckdbcgo/tokens_cgo.go
+++ b/ats/storage/duckdbcgo/tokens_cgo.go
@@ -24,11 +24,10 @@ import (
 	"github.com/teranos/errors"
 )
 
-// The two namespaces a deployment always has (ADR-026). Every other namespace
-// is created by SUPER; these two cannot be deleted.
+// Defined once in server/auth, where Caller carries a namespace.
 const (
-	NamespaceSystem  = "system"
-	NamespaceDefault = "default"
+	NamespaceSystem  = auth.NamespaceSystem
+	NamespaceDefault = auth.NamespaceDefault
 )
 
 // TokenStore is the parquet-backend implementation of auth.TokenStore

--- a/ats/storage/duckdbcgo/tokens_cgo_test.go
+++ b/ats/storage/duckdbcgo/tokens_cgo_test.go
@@ -17,7 +17,7 @@ import (
 
 func newStore(t *testing.T) *TokenStore {
 	t.Helper()
-	store, err := NewTokenStore("file://" + t.TempDir())
+	store, err := NewTokenStore("file://"+t.TempDir(), NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewTokenStore: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestRevokeUnknownIDFails(t *testing.T) {
 func TestTokensSurviveReopen(t *testing.T) {
 	location := "file://" + t.TempDir()
 
-	first, err := NewTokenStore(location)
+	first, err := NewTokenStore(location, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewTokenStore: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestTokensSurviveReopen(t *testing.T) {
 	}
 	first.Close()
 
-	second, err := NewTokenStore(location)
+	second, err := NewTokenStore(location, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/ats/storage/duckdbcgo/watchers_cgo.go
+++ b/ats/storage/duckdbcgo/watchers_cgo.go
@@ -58,14 +58,17 @@ type Tally struct {
 	LastError   *string `json:"last_error"`
 }
 
-// NewWatcherStore opens the watcher store at a storage location URL.
-func NewWatcherStore(location string) (*WatcherStore, error) {
+// NewWatcherStore opens the watcher store for a namespace at a storage
+// location. A watcher only ever reads under its own namespace (ADR-026).
+func NewWatcherStore(location, namespace string) (*WatcherStore, error) {
 	cLocation := C.CString(location)
 	defer C.free(unsafe.Pointer(cLocation))
+	cNamespace := C.CString(namespace)
+	defer C.free(unsafe.Pointer(cNamespace))
 
-	ptr := C.duckdb_watchers_new(cLocation)
+	ptr := C.duckdb_watchers_new(cLocation, cNamespace)
 	if ptr == nil {
-		return nil, errors.Newf("failed to open the watcher store at %s", location)
+		return nil, errors.Newf("failed to open the watcher store at %s for %s", location, namespace)
 	}
 	return &WatcherStore{ptr: unsafe.Pointer(ptr)}, nil
 }

--- a/ats/storage/duckdbcgo/watchers_cgo_test.go
+++ b/ats/storage/duckdbcgo/watchers_cgo_test.go
@@ -12,7 +12,7 @@ import (
 
 func newWatcherStore(t *testing.T, location string) *WatcherStore {
 	t.Helper()
-	store, err := NewWatcherStore("file://" + location)
+	store, err := NewWatcherStore("file://"+location, NamespaceDefault)
 	if err != nil {
 		t.Fatalf("NewWatcherStore: %v", err)
 	}

--- a/ats/storage/subject_warn.go
+++ b/ats/storage/subject_warn.go
@@ -1,6 +1,10 @@
 package storage
 
-import "go.uber.org/zap"
+import (
+	"strings"
+
+	"go.uber.org/zap"
+)
 
 // looksLikeID returns a non-empty reason if subject matches an id-like
 // heuristic. Subjects should be claim-bearing names, not identifiers.
@@ -9,6 +13,10 @@ import "go.uber.org/zap"
 // -<digits>, all-numeric. Dates (e.g. 2026-05-20) and bare years are
 // correctly caught — time belongs in the temporal slot, not the subject.
 func looksLikeID(subject string) string {
+	// A did:key is a claim-bearing name for a signer, not a row identifier.
+	if strings.HasPrefix(subject, "did:key:") {
+		return ""
+	}
 	if isUUIDShape(subject) {
 		return "UUID shape"
 	}

--- a/ats/storage/subject_warn_test.go
+++ b/ats/storage/subject_warn_test.go
@@ -41,6 +41,12 @@ func TestLooksLikeID(t *testing.T) {
 		{"foo-", ""},
 		{"foo_bar", ""},
 		{"-42", ""},
+
+		// did:key is a claim-bearing name for a signer, exempt from every
+		// heuristic — including ones it would otherwise trip.
+		{"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK", ""},
+		{"did:key:zabcdef0123456789abcdef", ""},
+		{"did:key:z6Mk-42", ""},
 	}
 
 	for _, tc := range cases {

--- a/cmd/parity/prefixes.go
+++ b/cmd/parity/prefixes.go
@@ -95,6 +95,7 @@ func PrefixesNamed(source string) []string {
 	}
 	collect(`.join("`, `"`)
 	collect(`"{}/`, `/`, `"`)
+	collectNamespaced(source, found)
 
 	names := make([]string, 0, len(found))
 	for name := range found {
@@ -102,6 +103,43 @@ func PrefixesNamed(source string) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// collectNamespaced reads the kind out of `namespace::prefix(location, ns,
+// "kind")`. Namespace became the top-level prefix, so a store no longer
+// formats its own path — the thing it owns is the last argument.
+func collectNamespaced(source string, found map[string]bool) {
+	const opener = `prefix(`
+	from := 0
+	for {
+		idx := strings.Index(source[from:], opener)
+		if idx < 0 {
+			return
+		}
+		cursor := from + idx + len(opener)
+		from = cursor
+
+		end := strings.Index(source[cursor:], ")")
+		if end < 0 {
+			return
+		}
+		if name, ok := lastQuoted(source[cursor : cursor+end]); ok && isPrefixName(name) {
+			found[name] = true
+		}
+	}
+}
+
+// lastQuoted returns the final double-quoted literal in s.
+func lastQuoted(s string) (string, bool) {
+	close := strings.LastIndex(s, `"`)
+	if close <= 0 {
+		return "", false
+	}
+	open := strings.LastIndex(s[:close], `"`)
+	if open < 0 {
+		return "", false
+	}
+	return s[open+1 : close], true
 }
 
 // isPrefixName rejects anything that is not a bare path segment — a format

--- a/cmd/qntx/commands/database_parquet.go
+++ b/cmd/qntx/commands/database_parquet.go
@@ -73,7 +73,7 @@ func openParquetDatabase(cfg *config.Config, dbPath string) (*sql.DB, ats.Attest
 
 	// Watchers live here too: a declaration is an object, a fire is a row in a
 	// stream, and neither belongs in the operational SQLite above.
-	watcherStore, err := duckdbcgo.NewWatcherStore(location)
+	watcherStore, err := duckdbcgo.NewWatcherStore(location, duckdbcgo.NamespaceDefault)
 	if err != nil {
 		database.Close()
 		rustStore.Close()

--- a/cmd/qntx/commands/database_parquet.go
+++ b/cmd/qntx/commands/database_parquet.go
@@ -63,7 +63,7 @@ func openParquetDatabase(cfg *config.Config, dbPath string) (*sql.DB, ats.Attest
 
 	// The parquet-backed attestation store — this is where attestations
 	// actually land.
-	duckStore, err := duckdbcgo.NewDuckdbStore(location)
+	duckStore, err := duckdbcgo.NewDuckdbStore(location, duckdbcgo.NamespaceDefault)
 	if err != nil {
 		database.Close()
 		rustStore.Close()

--- a/crates/ats-duckdb/include/duckdb_ffi.h
+++ b/crates/ats-duckdb/include/duckdb_ffi.h
@@ -50,7 +50,7 @@ typedef struct {
  * Returns NULL on failure (details logged to stderr).
  * Must call duckdb_storage_free() when done.
  */
-DuckdbStore *duckdb_storage_new(const char *location);
+DuckdbStore *duckdb_storage_new(const char *location, const char *namespace_did);
 
 /**
  * Free a store and release all resources. Safe to call with NULL.

--- a/crates/ats-duckdb/include/duckdb_ffi.h
+++ b/crates/ats-duckdb/include/duckdb_ffi.h
@@ -99,7 +99,7 @@ typedef struct {
     char *tokens_json;
 } TokensResultC;
 
-TokenStore *duckdb_tokens_new(const char *location);
+TokenStore *duckdb_tokens_new(const char *location, const char *namespace_did);
 void        duckdb_tokens_free(TokenStore *store);
 
 /** Store a token. record_json is a TokenRecord (crates/ats-duckdb/src/tokens.rs).
@@ -148,7 +148,7 @@ typedef struct {
     char *watchers_json;
 } WatchersResultC;
 
-WatcherStore *duckdb_watchers_new(const char *location);
+WatcherStore *duckdb_watchers_new(const char *location, const char *namespace_did);
 
 /** Flushes buffered fires before closing. */
 void duckdb_watchers_free(WatcherStore *store);
@@ -190,7 +190,7 @@ typedef struct {
     char *schedules_json;
 } SchedulesResultC;
 
-ScheduleStore *duckdb_schedules_new(const char *location);
+ScheduleStore *duckdb_schedules_new(const char *location, const char *namespace_did);
 
 /** Flushes buffered ticks before closing. */
 void duckdb_schedules_free(ScheduleStore *store);

--- a/crates/ats-duckdb/include/duckdb_ffi.h
+++ b/crates/ats-duckdb/include/duckdb_ffi.h
@@ -124,6 +124,18 @@ StorageResultC duckdb_tokens_enable(TokenStore *store, const char *id);
 /** Record that the token with this hash was used at now_ms. */
 StorageResultC duckdb_tokens_touch(TokenStore *store, const char *hash, int64_t now_ms);
 
+/** The system namespace's signer identity (ADR-026): one record per location. */
+typedef struct IdentityStore IdentityStore;
+
+IdentityStore *duckdb_identity_new(const char *location);
+void           duckdb_identity_free(IdentityStore *store);
+
+/** Identity JSON in tokens_json, empty when there is none — first boot, not an
+ *  error. Free with duckdb_tokens_result_free. */
+TokensResultC  duckdb_identity_load(const IdentityStore *store);
+
+StorageResultC duckdb_identity_save(IdentityStore *store, const char *record_json);
+
 /* Watchers: a declaration is one object under `<location>/watchers/`; a fire
  * is a row under `<location>/watcher_fires/`, and the tally aggregates those
  * rather than being a column anyone writes. */

--- a/crates/ats-duckdb/src/ffi.rs
+++ b/crates/ats-duckdb/src/ffi.rs
@@ -1034,3 +1034,78 @@ pub extern "C" fn duckdb_count_result_free(result: CountResultC) {
 // ============================================================================
 
 qntx_ffi_common::define_version_fn!(duckdb_storage_version);
+
+use crate::nodeidentity::{IdentityRecord, IdentityStore};
+
+/// Open the system namespace's identity store. NULL on failure, details to stderr.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn duckdb_identity_new(location: *const c_char) -> *mut IdentityStore {
+    let loc = match unsafe { cstr_to_str(location) } {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ats-duckdb: invalid identity location string: {}", e);
+            return ptr::null_mut();
+        }
+    };
+    match IdentityStore::open(loc) {
+        Ok(store) => Box::into_raw(Box::new(store)),
+        Err(e) => {
+            eprintln!("ats-duckdb: failed to open node identity at {}: {}", loc, e);
+            ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn duckdb_identity_free(store: *mut IdentityStore) {
+    unsafe { free_boxed(store) };
+}
+
+/// The identity as JSON, empty when there is none — first boot, not an error.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn duckdb_identity_load(store: *const IdentityStore) -> TokensResultC {
+    if store.is_null() {
+        return TokensResultC::error("null identity store pointer");
+    }
+    let store = unsafe { &*store };
+    match store.current() {
+        Some(record) => match serde_json::to_string(record) {
+            Ok(json) => TokensResultC::ok(json),
+            Err(e) => TokensResultC::error(&format!("failed to encode node identity: {}", e)),
+        },
+        None => TokensResultC::ok(String::new()),
+    }
+}
+
+/// Write the node's identity. `record_json` is an `IdentityRecord`.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn duckdb_identity_save(
+    store: *mut IdentityStore,
+    record_json: *const c_char,
+) -> StorageResultC {
+    if store.is_null() {
+        return StorageResultC::error("null identity store pointer");
+    }
+    let json_str = match unsafe { cstr_to_str(record_json) } {
+        Ok(s) => s,
+        Err(e) => return StorageResultC::error(e),
+    };
+    if json_str.len() > MAX_JSON_LENGTH {
+        return StorageResultC::error("node identity JSON exceeds maximum length");
+    }
+    let record: IdentityRecord = match serde_json::from_str(json_str) {
+        Ok(r) => r,
+        Err(e) => {
+            return StorageResultC::error(&format!("failed to parse node identity JSON: {}", e))
+        }
+    };
+    let store = unsafe { &mut *store };
+    match store.save(record) {
+        Ok(()) => StorageResultC::ok(),
+        Err(e) => StorageResultC::error(&format!("{}", e)),
+    }
+}

--- a/crates/ats-duckdb/src/ffi.rs
+++ b/crates/ats-duckdb/src/ffi.rs
@@ -380,7 +380,10 @@ impl FfiResult for TokensResultC {
 /// Returns NULL on failure (details go to stderr).
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn duckdb_tokens_new(location: *const c_char) -> *mut TokenStore {
+pub extern "C" fn duckdb_tokens_new(
+    location: *const c_char,
+    namespace: *const c_char,
+) -> *mut TokenStore {
     let loc = match unsafe { cstr_to_str(location) } {
         Ok(s) => s,
         Err(e) => {
@@ -388,10 +391,20 @@ pub extern "C" fn duckdb_tokens_new(location: *const c_char) -> *mut TokenStore 
             return ptr::null_mut();
         }
     };
-    match TokenStore::open(loc) {
+    let ns = match unsafe { cstr_to_str(namespace) } {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ats-duckdb: invalid token namespace string: {}", e);
+            return ptr::null_mut();
+        }
+    };
+    match TokenStore::open(loc, ns) {
         Ok(store) => Box::into_raw(Box::new(store)),
         Err(e) => {
-            eprintln!("ats-duckdb: failed to open tokens at {}: {}", loc, e);
+            eprintln!(
+                "ats-duckdb: failed to open tokens at {} for {}: {}",
+                loc, ns, e
+            );
             ptr::null_mut()
         }
     }
@@ -581,7 +594,10 @@ impl FfiResult for WatchersResultC {
 /// Open the watcher store at `location`. NULL on failure, details to stderr.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn duckdb_watchers_new(location: *const c_char) -> *mut WatcherStore {
+pub extern "C" fn duckdb_watchers_new(
+    location: *const c_char,
+    namespace: *const c_char,
+) -> *mut WatcherStore {
     let loc = match unsafe { cstr_to_str(location) } {
         Ok(s) => s,
         Err(e) => {
@@ -589,10 +605,20 @@ pub extern "C" fn duckdb_watchers_new(location: *const c_char) -> *mut WatcherSt
             return ptr::null_mut();
         }
     };
-    match WatcherStore::open(loc) {
+    let ns = match unsafe { cstr_to_str(namespace) } {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ats-duckdb: invalid watcher namespace string: {}", e);
+            return ptr::null_mut();
+        }
+    };
+    match WatcherStore::open(loc, ns) {
         Ok(store) => Box::into_raw(Box::new(store)),
         Err(e) => {
-            eprintln!("ats-duckdb: failed to open watchers at {}: {}", loc, e);
+            eprintln!(
+                "ats-duckdb: failed to open watchers at {} for {}: {}",
+                loc, ns, e
+            );
             ptr::null_mut()
         }
     }
@@ -787,7 +813,10 @@ impl FfiResult for SchedulesResultC {
 /// Open the schedule store at `location`. NULL on failure, details to stderr.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn duckdb_schedules_new(location: *const c_char) -> *mut ScheduleStore {
+pub extern "C" fn duckdb_schedules_new(
+    location: *const c_char,
+    namespace: *const c_char,
+) -> *mut ScheduleStore {
     let loc = match unsafe { cstr_to_str(location) } {
         Ok(s) => s,
         Err(e) => {
@@ -795,10 +824,20 @@ pub extern "C" fn duckdb_schedules_new(location: *const c_char) -> *mut Schedule
             return ptr::null_mut();
         }
     };
-    match ScheduleStore::open(loc) {
+    let ns = match unsafe { cstr_to_str(namespace) } {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ats-duckdb: invalid schedule namespace string: {}", e);
+            return ptr::null_mut();
+        }
+    };
+    match ScheduleStore::open(loc, ns) {
         Ok(store) => Box::into_raw(Box::new(store)),
         Err(e) => {
-            eprintln!("ats-duckdb: failed to open schedules at {}: {}", loc, e);
+            eprintln!(
+                "ats-duckdb: failed to open schedules at {} for {}: {}",
+                loc, ns, e
+            );
             ptr::null_mut()
         }
     }

--- a/crates/ats-duckdb/src/ffi.rs
+++ b/crates/ats-duckdb/src/ffi.rs
@@ -120,7 +120,10 @@ impl FfiResult for CountResultC {
 /// Returns NULL on failure (details go to stderr).
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn duckdb_storage_new(location: *const c_char) -> *mut DuckdbStore {
+pub extern "C" fn duckdb_storage_new(
+    location: *const c_char,
+    namespace: *const c_char,
+) -> *mut DuckdbStore {
     let loc = match unsafe { cstr_to_str(location) } {
         Ok(s) => s,
         Err(e) => {
@@ -128,10 +131,17 @@ pub extern "C" fn duckdb_storage_new(location: *const c_char) -> *mut DuckdbStor
             return ptr::null_mut();
         }
     };
-    match DuckdbStore::open(loc) {
+    let ns = match unsafe { cstr_to_str(namespace) } {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ats-duckdb: invalid namespace string: {}", e);
+            return ptr::null_mut();
+        }
+    };
+    match DuckdbStore::open(loc, ns) {
         Ok(store) => Box::into_raw(Box::new(store)),
         Err(e) => {
-            eprintln!("ats-duckdb: failed to open {}: {}", loc, e);
+            eprintln!("ats-duckdb: failed to open {} for {}: {}", loc, ns, e);
             ptr::null_mut()
         }
     }

--- a/crates/ats-duckdb/src/lib.rs
+++ b/crates/ats-duckdb/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod error;
 pub mod json;
 pub mod migrate;
+pub mod namespace;
 pub mod nodeidentity;
 pub mod schedules;
 pub mod tokens;

--- a/crates/ats-duckdb/src/lib.rs
+++ b/crates/ats-duckdb/src/lib.rs
@@ -197,6 +197,9 @@ pub(crate) fn assert_library_version(conn: &duckdb::Connection) -> Result<()> {
 
 pub struct DuckdbStore {
     location: String,
+    /// Where this store's attestations live. Namespace is the top-level
+    /// prefix, so a store reaches its own namespace and no other.
+    prefix: String,
     conn: duckdb::Connection,
 }
 
@@ -210,8 +213,9 @@ impl DuckdbStore {
     /// query time. They are deliberately not loaded back into the buffer:
     /// the buffer is what `flush` copies out and then clears, so anything
     /// hydrated into it would be written a second time on the next flush.
-    pub fn open(location: impl Into<String>) -> Result<Self> {
+    pub fn open(location: impl Into<String>, namespace: impl AsRef<str>) -> Result<Self> {
         let location = location.into();
+        let prefix = namespace::prefix(&location, namespace.as_ref(), "attestations");
         let conn = duckdb::Connection::open_in_memory()?;
         assert_library_version(&conn)?;
         migrate::migrate(&conn)?;
@@ -225,12 +229,16 @@ impl DuckdbStore {
         if let Some(sql) = remote_setup_sql(&location) {
             conn.execute_batch(&sql)?;
         }
-        Ok(Self { location, conn })
+        Ok(Self {
+            location,
+            prefix,
+            conn,
+        })
     }
 
     /// The glob every flushed attestation lands under.
     fn parquet_glob(&self) -> String {
-        format!("{}/attestations/*.parquet", self.location_path())
+        format!("{}/*.parquet", self.prefix)
     }
 
     /// How many Parquet files the location holds. `glob` answers zero for an
@@ -260,20 +268,14 @@ impl DuckdbStore {
                 "CREATE OR REPLACE SECRET qntx_s3 (TYPE s3, PROVIDER credential_chain);",
             )?;
         }
-        let base = self.location_path();
         if !is_remote(&self.location) {
-            let _ = std::fs::create_dir_all(format!("{}/attestations", base));
+            let _ = std::fs::create_dir_all(&self.prefix);
         }
         let ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis())
             .unwrap_or(0);
-        let file = format!(
-            "{}/attestations/{}-{}.parquet",
-            base,
-            ms,
-            uuid::Uuid::new_v4()
-        );
+        let file = format!("{}/{}-{}.parquet", self.prefix, ms, uuid::Uuid::new_v4());
         self.conn.execute_batch(&format!(
             "BEGIN TRANSACTION;
              COPY attestations TO '{}' (FORMAT PARQUET);
@@ -282,16 +284,6 @@ impl DuckdbStore {
             file
         ))?;
         Ok(())
-    }
-
-    /// The location as a path DuckDB SQL can consume. Strips the `file://`
-    /// prefix (DuckDB expects bare paths for local files); passes remote
-    /// schemes through unchanged.
-    fn location_path(&self) -> String {
-        self.location
-            .strip_prefix("file://")
-            .map(String::from)
-            .unwrap_or_else(|| self.location.clone())
     }
 
     /// The location URL configured for this store.
@@ -649,7 +641,7 @@ mod tests {
     }
 
     fn store(dir: &tempfile::TempDir) -> DuckdbStore {
-        DuckdbStore::open(at(dir)).unwrap()
+        DuckdbStore::open(at(dir), namespace::DEFAULT).unwrap()
     }
 
     #[test]

--- a/crates/ats-duckdb/src/lib.rs
+++ b/crates/ats-duckdb/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod error;
 pub mod json;
 pub mod migrate;
+pub mod nodeidentity;
 pub mod schedules;
 pub mod tokens;
 pub mod watchers;

--- a/crates/ats-duckdb/src/namespace.rs
+++ b/crates/ats-duckdb/src/namespace.rs
@@ -1,0 +1,62 @@
+//! Namespace is the top-level prefix in a storage location (ADR-026).
+
+/// The node's own namespace. Every other namespace is a signer's DID, but the
+/// node's identity names its namespace, so it cannot be keyed by itself.
+pub const SYSTEM: &str = "system";
+
+/// The default project. Visible below SUPER, where system is not (ADR-027).
+pub const DEFAULT: &str = "default";
+
+/// Everything a namespace owns at `location`.
+pub fn root(location: &str, namespace: &str) -> String {
+    let base = location.strip_prefix("file://").unwrap_or(location);
+    format!("{}/{namespace}", base.trim_end_matches('/'))
+}
+
+/// Where `kind` lives for `namespace` at `location`.
+pub fn prefix(location: &str, namespace: &str, kind: &str) -> String {
+    format!("{}/{kind}", root(location, namespace))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A namespace is a signer's DID, so it owns everything written under it.
+    #[test]
+    fn a_namespace_owns_the_top_level() {
+        assert_eq!(
+            prefix("file:///data", "did:key:zabc", "attestations"),
+            "/data/did:key:zabc/attestations"
+        );
+    }
+
+    // The node's own identity names its namespace, so it cannot live under a
+    // path derived from itself. SYSTEM is the one literal.
+    #[test]
+    fn the_system_namespace_is_a_literal_not_a_did() {
+        assert_eq!(
+            prefix("file:///data", SYSTEM, "identity"),
+            "/data/system/identity"
+        );
+    }
+
+    #[test]
+    fn a_remote_location_keeps_its_scheme() {
+        assert_eq!(
+            prefix("s3://bucket/q", "did:key:zabc", "watchers"),
+            "s3://bucket/q/did:key:zabc/watchers"
+        );
+    }
+
+    #[test]
+    fn a_trailing_slash_does_not_double() {
+        assert_eq!(prefix("file:///data/", "ns", "x"), "/data/ns/x");
+    }
+
+    // Some things sit at the namespace root rather than under a kind.
+    #[test]
+    fn a_namespace_has_a_root_of_its_own() {
+        assert_eq!(root("file:///data", SYSTEM), "/data/system");
+    }
+}

--- a/crates/ats-duckdb/src/nodeidentity.rs
+++ b/crates/ats-duckdb/src/nodeidentity.rs
@@ -22,8 +22,9 @@ pub struct IdentityRecord {
     pub did: String,
 }
 
-/// The object holding the system namespace's identity.
-const IDENTITY_OBJECT: &str = "identity.json";
+/// The object holding the identity. Named for the row it stands in for —
+/// `node_identity` keyed `'self'` (ADR-026).
+const IDENTITY_OBJECT: &str = "self.json";
 
 /// The system namespace's identity at a storage location.
 pub struct IdentityStore {
@@ -140,7 +141,7 @@ impl IdentityStore {
 
 /// Namespace is the top-level prefix, and the system namespace is the node.
 fn system_prefix(location: &str) -> String {
-    crate::namespace::root(location, crate::namespace::SYSTEM)
+    crate::namespace::prefix(location, crate::namespace::SYSTEM, "node_identity")
 }
 
 #[cfg(test)]
@@ -181,6 +182,11 @@ mod tests {
             IdentityStore::open(format!("file://{}", dir.path().display())).expect("open");
         store.save(record()).expect("save");
 
-        assert!(dir.path().join("system").join(IDENTITY_OBJECT).exists());
+        assert!(dir
+            .path()
+            .join("system")
+            .join("node_identity")
+            .join(IDENTITY_OBJECT)
+            .exists());
     }
 }

--- a/crates/ats-duckdb/src/nodeidentity.rs
+++ b/crates/ats-duckdb/src/nodeidentity.rs
@@ -1,0 +1,187 @@
+//! The system namespace's signer identity for the parquet backend. ADR-026
+//! makes the system namespace the node, so this holds one record and only one.
+
+// Namespace is the top-level prefix, so the object lands under
+// `<location>/system/` rather than at the root of the location.
+
+// Unlike access tokens, this holds an ed25519 private key. SQLite already keeps
+// it unencrypted, so reach changes rather than exposure — a bucket policy
+// question, not an application-crypto one.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{DuckdbError, Result};
+use crate::{is_remote, remote_setup_sql};
+
+/// A node's signer identity, mirroring `nodedid.Identity` in Go.
+/// Keys are hex because the object is JSON, and hex round-trips exactly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityRecord {
+    pub private_key_hex: String,
+    pub public_key_hex: String,
+    pub did: String,
+}
+
+/// The object holding the system namespace's identity.
+const IDENTITY_OBJECT: &str = "identity.json";
+
+/// The system namespace's identity at a storage location.
+pub struct IdentityStore {
+    location: String,
+    prefix: String,
+    conn: duckdb::Connection,
+    current: Option<IdentityRecord>,
+}
+
+impl IdentityStore {
+    /// Open the store at `location`, loading the identity if one is there.
+    pub fn open(location: impl Into<String>) -> Result<Self> {
+        let location = location.into();
+        if location.contains('\'') {
+            return Err(DuckdbError::Backend(format!(
+                "storage location {location} contains a quote, which cannot be used in a \
+                 DuckDB path"
+            )));
+        }
+
+        let conn = duckdb::Connection::open_in_memory()?;
+        crate::assert_library_version(&conn)?;
+        if let Some(sql) = remote_setup_sql(&location) {
+            conn.execute_batch(&sql)?;
+        }
+
+        let mut store = Self {
+            prefix: system_prefix(&location),
+            location,
+            conn,
+            current: None,
+        };
+        store.load()?;
+        Ok(store)
+    }
+
+    /// The location URL this store was opened with.
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+
+    /// The stored identity, or `None` when the node has never generated one.
+    pub fn current(&self) -> Option<&IdentityRecord> {
+        self.current.as_ref()
+    }
+
+    /// Replace the stored identity. A node writes this once, at first boot —
+    /// rewriting it mints a new DID and orphans every signature under the old.
+    pub fn save(&mut self, record: IdentityRecord) -> Result<()> {
+        self.write_object(&record)?;
+        self.current = Some(record);
+        Ok(())
+    }
+
+    /// Read the identity object, treating an unresolvable path as "none yet"
+    /// so the caller can tell first boot from a broken location.
+    fn load(&mut self) -> Result<()> {
+        let sql = format!(
+            "SELECT private_key_hex, public_key_hex, did \
+             FROM read_json('{}/{IDENTITY_OBJECT}', columns = {{ \
+                 private_key_hex: 'VARCHAR', public_key_hex: 'VARCHAR', did: 'VARCHAR' }})",
+            self.prefix
+        );
+
+        let mut stmt = match self.conn.prepare(&sql) {
+            Ok(stmt) => stmt,
+            Err(_) => return Ok(()),
+        };
+        let mut rows = match stmt.query_map([], |row| {
+            Ok(IdentityRecord {
+                private_key_hex: row.get(0)?,
+                public_key_hex: row.get(1)?,
+                did: row.get(2)?,
+            })
+        }) {
+            Ok(rows) => rows,
+            Err(_) => return Ok(()),
+        };
+
+        if let Some(row) = rows.next() {
+            self.current = Some(row.map_err(|e| {
+                DuckdbError::Backend(format!(
+                    "failed to read the node identity under {}: {e}",
+                    self.prefix
+                ))
+            })?);
+        }
+        Ok(())
+    }
+
+    /// Write the identity to its object, replacing what was there.
+    fn write_object(&self, record: &IdentityRecord) -> Result<()> {
+        if !is_remote(&self.location) {
+            let _ = std::fs::create_dir_all(&self.prefix);
+        }
+
+        let path = format!("{}/{IDENTITY_OBJECT}", self.prefix);
+        let sql = format!(
+            "COPY (SELECT ? AS private_key_hex, ? AS public_key_hex, ? AS did) \
+             TO '{path}' (FORMAT JSON)"
+        );
+
+        self.conn
+            .execute(
+                &sql,
+                duckdb::params![record.private_key_hex, record.public_key_hex, record.did],
+            )
+            .map_err(|e| {
+                DuckdbError::Backend(format!("failed to write node identity {path}: {e}"))
+            })?;
+        Ok(())
+    }
+}
+
+/// Namespace is the top-level prefix, and the system namespace is the node.
+fn system_prefix(location: &str) -> String {
+    let base = location.strip_prefix("file://").unwrap_or(location);
+    format!("{}/system", base.trim_end_matches('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record() -> IdentityRecord {
+        IdentityRecord {
+            private_key_hex: "aa".repeat(64),
+            public_key_hex: "bb".repeat(32),
+            did: "did:key:ztest".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_fresh_location_holds_no_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = IdentityStore::open(format!("file://{}", dir.path().display())).expect("open");
+        assert!(store.current().is_none());
+    }
+
+    #[test]
+    fn the_identity_survives_reopening() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let location = format!("file://{}", dir.path().display());
+
+        let mut store = IdentityStore::open(&location).expect("open");
+        store.save(record()).expect("save");
+
+        let reopened = IdentityStore::open(&location).expect("reopen");
+        assert_eq!(reopened.current(), Some(&record()));
+    }
+
+    #[test]
+    fn the_object_lands_under_the_system_namespace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut store =
+            IdentityStore::open(format!("file://{}", dir.path().display())).expect("open");
+        store.save(record()).expect("save");
+
+        assert!(dir.path().join("system").join(IDENTITY_OBJECT).exists());
+    }
+}

--- a/crates/ats-duckdb/src/nodeidentity.rs
+++ b/crates/ats-duckdb/src/nodeidentity.rs
@@ -140,8 +140,7 @@ impl IdentityStore {
 
 /// Namespace is the top-level prefix, and the system namespace is the node.
 fn system_prefix(location: &str) -> String {
-    let base = location.strip_prefix("file://").unwrap_or(location);
-    format!("{}/system", base.trim_end_matches('/'))
+    crate::namespace::root(location, crate::namespace::SYSTEM)
 }
 
 #[cfg(test)]

--- a/crates/ats-duckdb/src/schedules.rs
+++ b/crates/ats-duckdb/src/schedules.rs
@@ -26,8 +26,9 @@ pub struct ScheduleStore {
 impl ScheduleStore {
     /// Open at `location`, loading the declarations there and folding the tick
     /// stream into the progress it describes.
-    pub fn open(location: impl Into<String>) -> Result<Self> {
+    pub fn open(location: impl Into<String>, namespace: impl AsRef<str>) -> Result<Self> {
         let location = location.into();
+        let namespace = namespace.as_ref();
         if location.contains('\'') {
             return Err(DuckdbError::Backend(format!(
                 "storage location {location} contains a quote, which cannot be used in a \
@@ -42,8 +43,8 @@ impl ScheduleStore {
         }
 
         let mut store = Self {
-            prefix: schedule_prefix(&location),
-            ticks_prefix: ticks_prefix(&location),
+            prefix: schedule_prefix(&location, namespace),
+            ticks_prefix: ticks_prefix(&location, namespace),
             location,
             conn,
             by_id: HashMap::new(),
@@ -382,22 +383,24 @@ impl ScheduleStore {
 /// The directory holding schedule declarations. Named for the table it stands
 /// in for, because `make parity` pairs a backend's prefix with a SQLite table
 /// by name and a second name would read as a second thing.
-fn schedule_prefix(location: &str) -> String {
-    let base = location.strip_prefix("file://").unwrap_or(location);
-    format!("{}/scheduled_pulse_jobs", base.trim_end_matches('/'))
+/// A schedule created in a namespace stays there, so its prefix is that
+/// namespace and never another.
+fn schedule_prefix(location: &str, namespace: &str) -> String {
+    crate::namespace::prefix(location, namespace, "scheduled_pulse_jobs")
 }
 
 /// The directory holding ticks. Not the attestation store, for the same reason
 /// watcher fires are not: a tick through `CreateAttestation` would reach
 /// `NotifyObservers` and wake every empty-filter watcher.
-fn ticks_prefix(location: &str) -> String {
-    let base = location.strip_prefix("file://").unwrap_or(location);
-    format!("{}/schedule_ticks", base.trim_end_matches('/'))
+fn ticks_prefix(location: &str, namespace: &str) -> String {
+    crate::namespace::prefix(location, namespace, "schedule_ticks")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const NS: &str = "did:key:ztestnamespace";
 
     fn location(name: &str) -> String {
         let dir = std::env::temp_dir().join(format!(
@@ -428,7 +431,7 @@ mod tests {
 
     #[test]
     fn a_declared_schedule_is_read_back() {
-        let mut store = ScheduleStore::open(location("declared")).unwrap();
+        let mut store = ScheduleStore::open(location("declared"), NS).unwrap();
         store.put(declaration("s1", "capy.renew", 864_000)).unwrap();
 
         let read = store.get("s1").expect("the declaration is there");
@@ -438,7 +441,7 @@ mod tests {
 
     #[test]
     fn a_schedule_that_never_ran_is_owed_its_first_run() {
-        let mut store = ScheduleStore::open(location("first")).unwrap();
+        let mut store = ScheduleStore::open(location("first"), NS).unwrap();
         store.put(declaration("s1", "capy.renew", 600)).unwrap();
 
         assert_eq!(store.next_run_at("s1"), Some(2_000));
@@ -448,7 +451,7 @@ mod tests {
 
     #[test]
     fn a_run_moves_the_next_one_without_touching_the_declaration() {
-        let mut store = ScheduleStore::open(location("run")).unwrap();
+        let mut store = ScheduleStore::open(location("run"), NS).unwrap();
         store.put(declaration("s1", "capy.renew", 600)).unwrap();
         store.record_run("s1", 5_000, "JB-1", 605_000);
 
@@ -466,7 +469,7 @@ mod tests {
 
     #[test]
     fn a_force_trigger_moves_the_next_run_without_counting_as_a_run() {
-        let mut store = ScheduleStore::open(location("force")).unwrap();
+        let mut store = ScheduleStore::open(location("force"), NS).unwrap();
         store.put(declaration("s1", "capy.renew", 600)).unwrap();
         store.reschedule("s1", 5_000, 5_000);
 
@@ -476,7 +479,7 @@ mod tests {
 
     #[test]
     fn a_paused_schedule_keeps_its_place() {
-        let mut store = ScheduleStore::open(location("paused")).unwrap();
+        let mut store = ScheduleStore::open(location("paused"), NS).unwrap();
         let mut paused = declaration("s1", "capy.renew", 600);
         paused.state = "paused".to_string();
         store.put(paused).unwrap();
@@ -487,7 +490,7 @@ mod tests {
 
     #[test]
     fn a_withdrawn_declaration_stops_being_owed() {
-        let mut store = ScheduleStore::open(location("withdrawn")).unwrap();
+        let mut store = ScheduleStore::open(location("withdrawn"), NS).unwrap();
         store
             .put(declaration("s1", "capy.duplicate", 604_800))
             .unwrap();
@@ -502,14 +505,14 @@ mod tests {
     fn ticks_survive_a_reopen_and_the_progress_is_folded_from_them() {
         let loc = location("reopen");
         {
-            let mut store = ScheduleStore::open(loc.clone()).unwrap();
+            let mut store = ScheduleStore::open(loc.clone(), NS).unwrap();
             store.put(declaration("s1", "capy.renew", 600)).unwrap();
             store.record_run("s1", 5_000, "JB-1", 605_000);
             store.record_run("s1", 605_000, "JB-2", 1_205_000);
             store.flush().unwrap();
         }
 
-        let store = ScheduleStore::open(loc).unwrap();
+        let store = ScheduleStore::open(loc, NS).unwrap();
         let progress = store.progress("s1");
         assert_eq!(progress.run_count, 2);
         assert_eq!(progress.last_execution_id, "JB-2");
@@ -520,21 +523,21 @@ mod tests {
     fn a_withdrawn_schedule_keeps_the_ticks_it_emitted() {
         let loc = location("tombstone");
         {
-            let mut store = ScheduleStore::open(loc.clone()).unwrap();
+            let mut store = ScheduleStore::open(loc.clone(), NS).unwrap();
             store.put(declaration("s1", "capy.duplicate", 600)).unwrap();
             store.record_run("s1", 5_000, "JB-1", 605_000);
             store.flush().unwrap();
             store.delete("s1").unwrap();
         }
 
-        let store = ScheduleStore::open(loc).unwrap();
+        let store = ScheduleStore::open(loc, NS).unwrap();
         assert!(store.get("s1").is_none(), "the declaration is withdrawn");
         assert_eq!(store.progress("s1").run_count, 1, "what ran still ran");
     }
 
     #[test]
     fn a_location_nothing_has_declared_is_empty_not_broken() {
-        let store = ScheduleStore::open(location("empty")).unwrap();
+        let store = ScheduleStore::open(location("empty"), NS).unwrap();
         assert!(store.list().is_empty());
         assert!(store.due(i64::MAX).is_empty());
     }

--- a/crates/ats-duckdb/src/tokens.rs
+++ b/crates/ats-duckdb/src/tokens.rs
@@ -111,7 +111,7 @@ impl TokenStore {
     /// The connection exists to reach the location, not to hold state: object
     /// reads and writes go through DuckDB so an `s3://` prefix works through
     /// httpfs exactly as a local path does.
-    pub fn open(location: impl Into<String>) -> Result<Self> {
+    pub fn open(location: impl Into<String>, namespace: impl AsRef<str>) -> Result<Self> {
         let location = location.into();
         if location.contains('\'') {
             return Err(DuckdbError::Backend(format!(
@@ -127,7 +127,7 @@ impl TokenStore {
         }
 
         let mut store = Self {
-            prefix: token_prefix(&location),
+            prefix: token_prefix(&location, namespace.as_ref()),
             location,
             conn,
             by_hash: HashMap::new(),
@@ -317,12 +317,10 @@ impl TokenStore {
     }
 }
 
-/// The directory holding token objects, as a path DuckDB SQL can consume.
-/// Strips `file://` the way `DuckdbStore::location_path` does; remote schemes
-/// pass through for httpfs.
-fn token_prefix(location: &str) -> String {
-    let base = location.strip_prefix("file://").unwrap_or(location);
-    format!("{}/access_tokens", base.trim_end_matches('/'))
+/// The directory holding token objects for a namespace (ADR-027: a token
+/// writes into the namespace it belongs to).
+fn token_prefix(location: &str, namespace: &str) -> String {
+    crate::namespace::prefix(location, namespace, "access_tokens")
 }
 
 #[cfg(test)]
@@ -341,8 +339,21 @@ mod tests {
         }
     }
 
+    const NS: &str = "did:key:ztestnamespace";
+
     fn store(dir: &tempfile::TempDir) -> TokenStore {
-        TokenStore::open(format!("file://{}", dir.path().display())).unwrap()
+        TokenStore::open(format!("file://{}", dir.path().display()), NS).unwrap()
+    }
+
+    // A token belongs to a namespace, so its objects live under that namespace
+    // and nowhere else (ADR-027).
+    #[test]
+    fn tokens_land_under_their_namespace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut store = self::store(&dir);
+        store.put(record("id", "hash")).expect("put");
+
+        assert!(dir.path().join(NS).join("access_tokens").exists());
     }
 
     /// A token that survives nothing is a credential that stops working at the
@@ -579,7 +590,7 @@ mod tests {
     /// the string literal early. Refuse rather than build the statement.
     #[test]
     fn quoted_location_is_refused() {
-        match TokenStore::open("file:///tmp/it's-here") {
+        match TokenStore::open("file:///tmp/it's-here", NS) {
             Err(DuckdbError::Backend(msg)) => {
                 assert!(msg.contains("quote"), "unhelpful message: {msg}");
             }
@@ -588,21 +599,21 @@ mod tests {
         }
     }
 
-    /// The prefix is where ADR-025 says tokens live, and `file://` is stripped
-    /// because DuckDB wants a bare path for local files.
+    /// Tokens live under their namespace, and `file://` is stripped because
+    /// DuckDB wants a bare path for local files.
     #[test]
-    fn prefix_is_access_tokens_under_the_location() {
+    fn prefix_is_access_tokens_under_the_namespace() {
         assert_eq!(
-            token_prefix("file:///var/lib/qntx/parquet"),
-            "/var/lib/qntx/parquet/access_tokens"
+            token_prefix("file:///var/lib/qntx/parquet", crate::namespace::DEFAULT),
+            "/var/lib/qntx/parquet/default/access_tokens"
         );
         assert_eq!(
-            token_prefix("s3://bucket/prefix"),
-            "s3://bucket/prefix/access_tokens"
+            token_prefix("s3://bucket/prefix", "did:key:zabc"),
+            "s3://bucket/prefix/did:key:zabc/access_tokens"
         );
         assert_eq!(
-            token_prefix("s3://bucket/prefix/"),
-            "s3://bucket/prefix/access_tokens"
+            token_prefix("s3://bucket/prefix/", crate::namespace::DEFAULT),
+            "s3://bucket/prefix/default/access_tokens"
         );
     }
 

--- a/crates/ats-duckdb/src/watchers.rs
+++ b/crates/ats-duckdb/src/watchers.rs
@@ -64,8 +64,9 @@ pub struct WatcherStore {
 impl WatcherStore {
     /// Open at `location`, loading the declarations there and folding the fire
     /// stream into the tallies it describes.
-    pub fn open(location: impl Into<String>) -> Result<Self> {
+    pub fn open(location: impl Into<String>, namespace: impl AsRef<str>) -> Result<Self> {
         let location = location.into();
+        let namespace = namespace.as_ref();
         if location.contains('\'') {
             return Err(DuckdbError::Backend(format!(
                 "storage location {location} contains a quote, which cannot be used in a \
@@ -80,8 +81,8 @@ impl WatcherStore {
         }
 
         let mut store = Self {
-            prefix: watcher_prefix(&location),
-            fires_prefix: fires_prefix(&location),
+            prefix: watcher_prefix(&location, namespace),
+            fires_prefix: fires_prefix(&location, namespace),
             location,
             conn,
             by_id: HashMap::new(),
@@ -389,18 +390,18 @@ impl WatcherStore {
     }
 }
 
-/// The directory holding watcher declarations.
-fn watcher_prefix(location: &str) -> String {
-    let base = location.strip_prefix("file://").unwrap_or(location);
-    format!("{}/watchers", base.trim_end_matches('/'))
+/// The directory holding watcher declarations for a namespace. A watcher in
+/// namespace A does not fire on an attestation in namespace B (ADR-026), and
+/// it cannot: it only ever reads under its own prefix.
+fn watcher_prefix(location: &str, namespace: &str) -> String {
+    crate::namespace::prefix(location, namespace, "watchers")
 }
 
 /// The directory holding fire events. Not the attestation store: a fire that
 /// went through `CreateAttestation` would reach `NotifyObservers`, and a
 /// watcher with an empty filter matches everything (`engine_match.go:412`).
-fn fires_prefix(location: &str) -> String {
-    let base = location.strip_prefix("file://").unwrap_or(location);
-    format!("{}/watcher_fires", base.trim_end_matches('/'))
+fn fires_prefix(location: &str, namespace: &str) -> String {
+    crate::namespace::prefix(location, namespace, "watcher_fires")
 }
 
 #[cfg(test)]
@@ -434,12 +435,14 @@ mod tests {
         format!("file://{}", dir.path().display())
     }
 
+    const NS: &str = "did:key:ztestnamespace";
+
     fn store(dir: &tempfile::TempDir) -> WatcherStore {
-        WatcherStore::open(at(dir)).unwrap()
+        WatcherStore::open(at(dir), NS).unwrap()
     }
 
     fn fire_files(dir: &tempfile::TempDir) -> usize {
-        std::fs::read_dir(fires_prefix(&at(dir)))
+        std::fs::read_dir(fires_prefix(&at(dir), NS))
             .map(|d| d.count())
             .unwrap_or(0)
     }
@@ -530,16 +533,16 @@ mod tests {
             assert_eq!(s.buffered(), 8);
         }
 
-        // "tally private stream is OK"
+        // "tally private stream is OK", and both sit under the namespace.
         #[test]
         fn fires_land_under_their_own_prefix() {
             assert_eq!(
-                fires_prefix("file:///var/lib/qntx/parquet"),
-                "/var/lib/qntx/parquet/watcher_fires"
+                fires_prefix("file:///var/lib/qntx/parquet", NS),
+                format!("/var/lib/qntx/parquet/{NS}/watcher_fires")
             );
             assert_eq!(
-                watcher_prefix("s3://bucket/prefix/"),
-                "s3://bucket/prefix/watchers"
+                watcher_prefix("s3://bucket/prefix/", NS),
+                format!("s3://bucket/prefix/{NS}/watchers")
             );
         }
 
@@ -565,7 +568,7 @@ mod tests {
         /// A path is interpolated into SQL, so a quote would end the literal.
         #[test]
         fn quoted_location_is_refused() {
-            match WatcherStore::open("file:///tmp/it's-here") {
+            match WatcherStore::open("file:///tmp/it's-here", NS) {
                 Err(DuckdbError::Backend(msg)) => assert!(msg.contains("quote")),
                 Err(other) => panic!("expected a rejection, got {other:?}"),
                 Ok(s) => panic!("opened a quoted location at {}", s.location()),

--- a/db/sqlite/migrations/052_add_owner_to_webauthn_credentials.sql
+++ b/db/sqlite/migrations/052_add_owner_to_webauthn_credentials.sql
@@ -1,0 +1,6 @@
+-- A passkey belongs to someone. Without this a credential is interchangeable
+-- and a session can say only that somebody authenticated, never who.
+ALTER TABLE webauthn_credentials ADD COLUMN owner_did TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_owner
+    ON webauthn_credentials(owner_did);

--- a/docs/adr/ADR-024-parquet-storage-backend.md
+++ b/docs/adr/ADR-024-parquet-storage-backend.md
@@ -43,10 +43,12 @@ Multi-value fields (`subjects`, `predicates`, `contexts`, `actors`) store as Par
 
 **All other state** (watchers, canvas, aliases, node identity, WebAuthn credentials, watcher execution queue, scheduled jobs, storage events, etc.) also lives at `<location>` under distinct prefixes. Shape per class:
 
-- Small config (node identity, aliases, daemon config, WebAuthn creds, minimized windows) — one object per record, rewritten on change.
+- Small config (aliases, daemon config, WebAuthn creds, minimized windows) — one object per record, rewritten on change.
 - Append-only logs (storage_events, task_logs, pulse_executions, ai_model_usage) — Parquet, same pattern as attestations.
 - Mutable config (watchers, canvas state, canvas glyphs, compositions, edges) — one object per entity, rewritten on save.
 - State machines (scheduled jobs, job checkpoints, watcher execution queue, async jobs) — one object per record, rewritten on status transition.
+
+**Node identity is none of these.** One object, written once at first boot, holding an ed25519 private key. A rewrite is not an update — it mints a new DID and orphans every signature made under the old one. It is also the only secret in the store, so a bucket policy written for attestation data does not cover it.
 
 **Signatures** are unchanged — signing is over canonical JSON (`ats/signing/signing.go:86`), format-independent.
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -83,7 +83,10 @@ func (h *Handler) Middleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if h.tokens != nil {
 			if raw, ok := bearerToken(r); ok && h.tokens.Lookup(sha256Hex(raw)) {
-				next(w, r)
+				next(w, r.WithContext(WithCaller(r.Context(), Caller{
+					Level:     LevelToken,
+					Namespace: NamespaceDefault,
+				})))
 				return
 			}
 		}
@@ -97,7 +100,10 @@ func (h *Handler) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			http.Redirect(w, r, "/auth/login?return="+url.QueryEscape(returnURL), http.StatusSeeOther)
 			return
 		}
-		next(w, r)
+		next(w, r.WithContext(WithCaller(r.Context(), Caller{
+			Level:     LevelUser,
+			Namespace: NamespaceDefault,
+		})))
 	}
 }
 

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -81,7 +81,7 @@ func TestCredentialSaveAndRetrieve(t *testing.T) {
 		},
 	}
 
-	err = store.save(cred)
+	err = store.save(cred, "")
 	require.NoError(t, err)
 
 	exists, err = store.exists()
@@ -107,7 +107,7 @@ func TestCredentialUpdateSignCount(t *testing.T) {
 		AttestationType: "none",
 		Authenticator:   webauthn.Authenticator{AAGUID: []byte("aaguid"), SignCount: 5},
 	}
-	require.NoError(t, store.save(cred))
+	require.NoError(t, store.save(cred, ""))
 
 	require.NoError(t, store.updateSignCount(cred.ID, 10))
 

--- a/server/auth/caller.go
+++ b/server/auth/caller.go
@@ -1,0 +1,47 @@
+package auth
+
+import "context"
+
+// The two namespaces a deployment always has (ADR-026). Every other namespace
+// is created by SUPER, and neither of these can be deleted.
+const (
+	NamespaceSystem  = "system"
+	NamespaceDefault = "default"
+)
+
+// Level is what a caller may do (ADR-027). It says how much, never where.
+type Level string
+
+const (
+	// LevelSuper crosses namespaces and creates or deletes them.
+	LevelSuper Level = "SUPER"
+	// LevelRoot goes beyond QNTX — wanted on dev, not on prod.
+	LevelRoot Level = "ROOT"
+	// LevelToken is what a bearer token gets. It cannot mint tokens.
+	LevelToken Level = "TOKEN"
+	// LevelUser is a logged-in user.
+	LevelUser Level = "USER"
+)
+
+// Caller is who reached a handler: a level and the namespace they inhabit.
+// Namespace answers where, Level answers how much, and keeping them apart is
+// what lets visibility be per-namespace without privilege leaking into it.
+type Caller struct {
+	Level     Level
+	Namespace string
+}
+
+type callerKey struct{}
+
+// WithCaller returns a context carrying the caller.
+func WithCaller(ctx context.Context, caller Caller) context.Context {
+	return context.WithValue(ctx, callerKey{}, caller)
+}
+
+// CallerFrom returns the caller a handler was reached by. False means the
+// handler ran outside Middleware — a wiring mistake, not an anonymous
+// request, since Middleware never calls through without authenticating.
+func CallerFrom(ctx context.Context) (Caller, bool) {
+	caller, ok := ctx.Value(callerKey{}).(Caller)
+	return caller, ok
+}

--- a/server/auth/caller_test.go
+++ b/server/auth/caller_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testHandler() *Handler {
+	return &Handler{sessions: newSessionStore(24)}
+}
+
+// A handler behind Middleware has to be able to tell who called it. Without
+// this the only thing that reaches a handler is "someone authenticated".
+func TestMiddlewarePutsTheCallerInContext(t *testing.T) {
+	h := testHandler()
+	session, err := h.sessions.create()
+	require.NoError(t, err)
+
+	var seen Caller
+	var ok bool
+	guarded := h.Middleware(func(_ http.ResponseWriter, r *http.Request) {
+		seen, ok = CallerFrom(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/attestations", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: session})
+	guarded(httptest.NewRecorder(), req)
+
+	require.True(t, ok, "no caller reached the handler")
+	assert.Equal(t, LevelUser, seen.Level)
+	assert.Equal(t, NamespaceDefault, seen.Namespace)
+}
+
+// ADR-027 separates TOKEN from USER, so the two credentials cannot arrive
+// indistinguishable — a token cannot mint tokens, and only a level says so.
+func TestABearerTokenArrivesAsTokenNotUser(t *testing.T) {
+	h := testHandler()
+	store := newMemTokenStore()
+	h.tokens = store
+
+	raw, _, err := store.Create("ci", nil)
+	require.NoError(t, err)
+
+	var seen Caller
+	guarded := h.Middleware(func(_ http.ResponseWriter, r *http.Request) {
+		seen, _ = CallerFrom(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/attestations", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	guarded(httptest.NewRecorder(), req)
+
+	assert.Equal(t, LevelToken, seen.Level)
+}
+
+// An unauthenticated request never reaches a handler, so nothing downstream
+// has to consider a caller that is not there.
+func TestNoCallerWithoutAuthentication(t *testing.T) {
+	h := testHandler()
+
+	reached := false
+	guarded := h.Middleware(func(http.ResponseWriter, *http.Request) { reached = true })
+
+	rec := httptest.NewRecorder()
+	guarded(rec, httptest.NewRequest(http.MethodGet, "/api/attestations", nil))
+
+	assert.False(t, reached)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/server/auth/credentials.go
+++ b/server/auth/credentials.go
@@ -18,18 +18,35 @@ func newCredentialStore(db *sql.DB, logger *zap.SugaredLogger) *credentialStore 
 	return &credentialStore{db: db, logger: logger}
 }
 
-func (s *credentialStore) save(cred webauthn.Credential) error {
+func (s *credentialStore) save(cred webauthn.Credential, ownerDID string) error {
 	id := hex.EncodeToString(cred.ID)
 	_, err := s.db.Exec(
-		`INSERT INTO webauthn_credentials (id, credential_id, public_key, attestation_type, aaguid, sign_count, backup_eligible, backup_state)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO webauthn_credentials (id, credential_id, public_key, attestation_type, aaguid, sign_count, backup_eligible, backup_state, owner_did)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, cred.ID, cred.PublicKey, cred.AttestationType, cred.Authenticator.AAGUID, cred.Authenticator.SignCount,
-		cred.Flags.BackupEligible, cred.Flags.BackupState,
+		cred.Flags.BackupEligible, cred.Flags.BackupState, ownerDID,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to save credential %s", id)
+		return errors.Wrapf(err, "failed to save credential %s for %s", id, ownerDID)
 	}
 	return nil
+}
+
+// ownerOf returns who holds this credential, or empty when it is unregistered.
+// Empty is an answer, not a read failure — an unknown key has no owner.
+func (s *credentialStore) ownerOf(credID []byte) (string, error) {
+	id := hex.EncodeToString(credID)
+	var owner string
+	err := s.db.QueryRow(
+		`SELECT owner_did FROM webauthn_credentials WHERE id = ?`, id,
+	).Scan(&owner)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to read the owner of credential %s", id)
+	}
+	return owner, nil
 }
 
 func (s *credentialStore) getAll() ([]webauthn.Credential, error) {

--- a/server/auth/handlers.go
+++ b/server/auth/handlers.go
@@ -97,8 +97,10 @@ func (h *Handler) handleRegisterFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO(#577): Derive user DID from WebAuthn PRF extension
-	if err := h.creds.save(*credential); err != nil {
+	// TODO(#577): Derive user DID from WebAuthn PRF extension. Until it does,
+	// the owner is unknown rather than wrong — ownerOf answers empty and no
+	// caller is attributed to a person who was never established.
+	if err := h.creds.save(*credential, ""); err != nil {
 		h.logger.Errorw("Failed to save credential", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to save credential")
 		return

--- a/server/auth/owner_test.go
+++ b/server/auth/owner_test.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	qntxtest "github.com/teranos/QNTX/internal/testing"
+)
+
+func credentialStoreForTest(t *testing.T) *credentialStore {
+	t.Helper()
+	return newCredentialStore(qntxtest.CreateTestDB(t), zap.NewNop().Sugar())
+}
+
+func credential(id string) webauthn.Credential {
+	return webauthn.Credential{
+		ID:              []byte(id),
+		PublicKey:       []byte("pubkey-" + id),
+		AttestationType: "none",
+	}
+}
+
+// A passkey belongs to someone. Without an owner every credential is
+// interchangeable and a session can only say "somebody authenticated".
+func TestACredentialRemembersItsOwner(t *testing.T) {
+	store := credentialStoreForTest(t)
+
+	require.NoError(t, store.save(credential("laptop"), "did:key:zowner"))
+
+	owner, err := store.ownerOf([]byte("laptop"))
+	require.NoError(t, err)
+	assert.Equal(t, "did:key:zowner", owner)
+}
+
+// Several devices, one person — which is what makes the account the identity
+// and each key a device credential under it.
+func TestOneOwnerCanHoldSeveralCredentials(t *testing.T) {
+	store := credentialStoreForTest(t)
+
+	require.NoError(t, store.save(credential("laptop"), "did:key:zowner"))
+	require.NoError(t, store.save(credential("phone"), "did:key:zowner"))
+
+	laptop, err := store.ownerOf([]byte("laptop"))
+	require.NoError(t, err)
+	phone, err := store.ownerOf([]byte("phone"))
+	require.NoError(t, err)
+	assert.Equal(t, laptop, phone)
+}
+
+// An unknown credential has no owner, and that is not a failure to read.
+func TestAnUnknownCredentialHasNoOwner(t *testing.T) {
+	store := credentialStoreForTest(t)
+
+	owner, err := store.ownerOf([]byte("never-registered"))
+	require.NoError(t, err)
+	assert.Empty(t, owner)
+}

--- a/server/identity_store_duckdb.go
+++ b/server/identity_store_duckdb.go
@@ -1,0 +1,25 @@
+//go:build cgo && rustduckdb
+
+package server
+
+import (
+	"github.com/teranos/QNTX/ats/storage/duckdbcgo"
+	appcfg "github.com/teranos/QNTX/internal/config"
+	"github.com/teranos/QNTX/server/nodedid"
+	"github.com/teranos/errors"
+)
+
+// newIdentityStore returns the node identity store for the configured backend,
+// or nil on sqlite — where nodedid.New opens the database store itself.
+func newIdentityStore(cfg *appcfg.Config) (nodedid.IdentityStore, error) {
+	if cfg.Storage.Backend != "parquet" {
+		return nil, nil
+	}
+
+	location := cfg.Storage.Parquet.Location
+	store, err := duckdbcgo.NewIdentityStore(location)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open the node identity store at %s", location)
+	}
+	return store, nil
+}

--- a/server/identity_store_stub.go
+++ b/server/identity_store_stub.go
@@ -1,0 +1,23 @@
+//go:build !cgo || !rustduckdb
+
+package server
+
+import (
+	appcfg "github.com/teranos/QNTX/internal/config"
+	"github.com/teranos/QNTX/server/nodedid"
+	"github.com/teranos/errors"
+)
+
+// newIdentityStore has no backend to open in this build. A parquet deployment
+// built this way would keep its node identity in the SQLite scratch and look
+// configured, so the error carries the missing tag rather than returning nil.
+func newIdentityStore(cfg *appcfg.Config) (nodedid.IdentityStore, error) {
+	if cfg.Storage.Backend != "parquet" {
+		return nil, nil
+	}
+	return nil, errors.Newf(
+		"storage.backend is %q but this binary was built without the rustduckdb tag, "+
+			"so the node identity store is not compiled in",
+		cfg.Storage.Backend,
+	)
+}

--- a/server/identity_store_test.go
+++ b/server/identity_store_test.go
@@ -1,0 +1,34 @@
+//go:build !cgo || !rustduckdb
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appcfg "github.com/teranos/QNTX/internal/config"
+)
+
+// A sqlite deployment has no separate identity store — nodedid.New opens the
+// database one. nil is how the caller is told to take that path.
+func TestIdentityStoreIsNilOnSqlite(t *testing.T) {
+	cfg := &appcfg.Config{}
+	cfg.Storage.Backend = "sqlite"
+
+	store, err := newIdentityStore(cfg)
+	require.NoError(t, err)
+	assert.Nil(t, store)
+}
+
+// A parquet deployment built without the tag would otherwise write its node
+// identity to the SQLite scratch and look configured. Say so instead.
+func TestIdentityStoreRefusesParquetWithoutTheTag(t *testing.T) {
+	cfg := &appcfg.Config{}
+	cfg.Storage.Backend = "parquet"
+
+	_, err := newIdentityStore(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rustduckdb")
+}

--- a/server/nodedid/nodedid.go
+++ b/server/nodedid/nodedid.go
@@ -11,6 +11,21 @@ import (
 	"go.uber.org/zap"
 )
 
+// Identity is a node's signer identity (ADR-010's third layer).
+type Identity struct {
+	PrivateKey ed25519.PrivateKey
+	PublicKey  ed25519.PublicKey
+	DID        string
+}
+
+// IdentityStore is where a backend keeps the node's signer identity.
+// Load returns nil when the node has none yet, which is how first boot is
+// told apart from a read failure.
+type IdentityStore interface {
+	Load() (*Identity, error)
+	Save(*Identity) error
+}
+
 // Handler holds the node's DID identity and serves the DID document.
 type Handler struct {
 	DID         string
@@ -19,11 +34,14 @@ type Handler struct {
 	didDocument []byte
 }
 
-// New loads the node identity from the database, or generates one on first boot.
+// New loads the node identity from SQLite, or generates one on first boot.
 func New(db *sql.DB, logger *zap.SugaredLogger) (*Handler, error) {
-	s := &store{db: db}
+	return NewWithStore(&store{db: db}, logger)
+}
 
-	id, err := s.load()
+// NewWithStore is New against any backend's store.
+func NewWithStore(s IdentityStore, logger *zap.SugaredLogger) (*Handler, error) {
+	id, err := s.Load()
 	if err != nil {
 		return nil, err
 	}
@@ -33,38 +51,38 @@ func New(db *sql.DB, logger *zap.SugaredLogger) (*Handler, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := s.save(id); err != nil {
+		if err := s.Save(id); err != nil {
 			return nil, err
 		}
-		logger.Debugw("Generated node DID", "did", id.did)
+		logger.Debugw("Generated node DID", "did", id.DID)
 	} else {
-		logger.Debugw("Loaded node DID", "did", id.did)
+		logger.Debugw("Loaded node DID", "did", id.DID)
 	}
 
-	doc, err := buildDIDDocument(id.did, id.publicKey)
+	doc, err := buildDIDDocument(id.DID, id.PublicKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build DID document")
 	}
 
 	// TODO(#580): Resolve peer-attested vanity name for this node DID
 	return &Handler{
-		DID:         id.did,
-		PublicKey:   id.publicKey,
-		PrivateKey:  id.privateKey,
+		DID:         id.DID,
+		PublicKey:   id.PublicKey,
+		PrivateKey:  id.PrivateKey,
 		didDocument: doc,
 	}, nil
 }
 
-func generate() (*identity, error) {
+func generate() (*Identity, error) {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate ed25519 keypair")
 	}
 	did := encodeDIDKey(pub)
-	return &identity{
-		privateKey: priv,
-		publicKey:  pub,
-		did:        did,
+	return &Identity{
+		PrivateKey: priv,
+		PublicKey:  pub,
+		DID:        did,
 	}, nil
 }
 

--- a/server/nodedid/nodedid_test.go
+++ b/server/nodedid/nodedid_test.go
@@ -37,6 +37,36 @@ func TestGenerateAndPersist(t *testing.T) {
 	assert.Equal(t, h1.PrivateKey, h2.PrivateKey)
 }
 
+// memIdentityStore is an in-memory IdentityStore, standing in for a backend
+// that is not SQLite. ADR-024 puts node identity under a parquet prefix.
+type memIdentityStore struct {
+	saved *Identity
+}
+
+func (m *memIdentityStore) Load() (*Identity, error) { return m.saved, nil }
+
+func (m *memIdentityStore) Save(id *Identity) error {
+	m.saved = id
+	return nil
+}
+
+// Whatever implements IdentityStore has to hold the same line SQLite does:
+// generate once, then return that same key on every later load.
+func TestIdentityStoreContract(t *testing.T) {
+	store := &memIdentityStore{}
+
+	h1, err := NewWithStore(store, testLogger())
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(h1.DID, "did:key:z"))
+	assert.Len(t, h1.PrivateKey, ed25519.PrivateKeySize)
+
+	h2, err := NewWithStore(store, testLogger())
+	require.NoError(t, err)
+	assert.Equal(t, h1.DID, h2.DID)
+	assert.Equal(t, h1.PublicKey, h2.PublicKey)
+	assert.Equal(t, h1.PrivateKey, h2.PrivateKey)
+}
+
 func TestDIDKeyEncoding(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)

--- a/server/nodedid/store.go
+++ b/server/nodedid/store.go
@@ -11,13 +11,8 @@ type store struct {
 	db *sql.DB
 }
 
-type identity struct {
-	privateKey ed25519.PrivateKey
-	publicKey  ed25519.PublicKey
-	did        string
-}
-
-func (s *store) load() (*identity, error) {
+// Load returns the stored identity, or nil when the node has none yet.
+func (s *store) Load() (*Identity, error) {
 	var privKey, pubKey []byte
 	var did string
 	err := s.db.QueryRow("SELECT private_key, public_key, did FROM node_identity WHERE id = 'self'").
@@ -28,17 +23,17 @@ func (s *store) load() (*identity, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load node identity")
 	}
-	return &identity{
-		privateKey: ed25519.PrivateKey(privKey),
-		publicKey:  ed25519.PublicKey(pubKey),
-		did:        did,
+	return &Identity{
+		PrivateKey: ed25519.PrivateKey(privKey),
+		PublicKey:  ed25519.PublicKey(pubKey),
+		DID:        did,
 	}, nil
 }
 
-func (s *store) save(id *identity) error {
+func (s *store) Save(id *Identity) error {
 	_, err := s.db.Exec(
 		"INSERT INTO node_identity (id, private_key, public_key, did) VALUES ('self', ?, ?, ?)",
-		[]byte(id.privateKey), []byte(id.publicKey), id.did,
+		[]byte(id.PrivateKey), []byte(id.PublicKey), id.DID,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to save node identity")

--- a/server/sub_nodedid.go
+++ b/server/sub_nodedid.go
@@ -1,18 +1,36 @@
 package server
 
 import (
+	"database/sql"
+
 	"github.com/teranos/QNTX/ats/signing"
 	"github.com/teranos/QNTX/ats/storage"
+	appcfg "github.com/teranos/QNTX/internal/config"
 	"github.com/teranos/QNTX/server/nodedid"
 	"github.com/teranos/errors"
+	"go.uber.org/zap"
 )
 
 type nodeDIDSubsystem struct{}
 
 func (nodeDIDSubsystem) Name() string { return "node-did" }
 
+// openNodeDID loads the node identity from whichever store the backend owns.
+// A backend with its own store never falls through to the database one — that
+// is how a parquet deployment avoids keeping its signing key in the scratch.
+func openNodeDID(cfg *appcfg.Config, db *sql.DB, logger *zap.SugaredLogger) (*nodedid.Handler, error) {
+	store, err := newIdentityStore(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if store != nil {
+		return nodedid.NewWithStore(store, logger)
+	}
+	return nodedid.New(db, logger)
+}
+
 func (nodeDIDSubsystem) Init(s *QNTXServer) error {
-	nodeDIDHandler, err := nodedid.New(s.db, s.logger)
+	nodeDIDHandler, err := openNodeDID(s.deps.cfg, s.db, s.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize node DID")
 	}

--- a/server/sub_nodedid_test.go
+++ b/server/sub_nodedid_test.go
@@ -1,0 +1,38 @@
+//go:build !cgo || !rustduckdb
+
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	appcfg "github.com/teranos/QNTX/internal/config"
+	qntxtest "github.com/teranos/QNTX/internal/testing"
+)
+
+func nodeDIDTestLogger() *zap.SugaredLogger { return zap.NewNop().Sugar() }
+
+// On sqlite the identity comes from the database, as it always has.
+func TestNodeDIDUsesTheDatabaseOnSqlite(t *testing.T) {
+	cfg := &appcfg.Config{}
+	cfg.Storage.Backend = "sqlite"
+
+	handler, err := openNodeDID(cfg, qntxtest.CreateTestDB(t), nodeDIDTestLogger())
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(handler.DID, "did:key:z"))
+}
+
+// A parquet deployment must not quietly fall back to the SQLite scratch. The
+// key its DID is derived from would land in a store ADR-024 stops opening.
+func TestNodeDIDRefusesToFallBackOnParquet(t *testing.T) {
+	cfg := &appcfg.Config{}
+	cfg.Storage.Backend = "parquet"
+
+	_, err := openNodeDID(cfg, nil, nodeDIDTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rustduckdb")
+}

--- a/server/subsystem.go
+++ b/server/subsystem.go
@@ -29,8 +29,10 @@ type subsystemEntry struct {
 // subsystems defines the initialization order. Dependencies flow downward:
 // later subsystems may read fields set by earlier ones.
 var subsystems = []subsystemEntry{
-	{sub: authSubsystem{}, policy: SubsystemFatal},
+	// The node DID names the system namespace, and namespace is the top-level
+	// prefix every store writes under, so identity resolves before any store.
 	{sub: nodeDIDSubsystem{}, policy: SubsystemFatal},
+	{sub: authSubsystem{}, policy: SubsystemFatal},
 	{sub: typeRegistrationSubsystem{}, policy: SubsystemWarn},
 	{sub: pluginServicesSubsystem{}, policy: SubsystemWarn},
 	{sub: tickerSubsystem{}, policy: SubsystemFatal},

--- a/server/subsystem_order_test.go
+++ b/server/subsystem_order_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func indexOfSubsystem(t *testing.T, name string) int {
+	t.Helper()
+	for i, entry := range subsystems {
+		if entry.sub.Name() == name {
+			return i
+		}
+	}
+	t.Fatalf("no subsystem named %q in the init order", name)
+	return -1
+}
+
+// The node DID names the system namespace, and namespace is the top-level
+// prefix every other store writes under. Anything holding a store has to come
+// after the identity that decides where that store lives.
+func TestNodeDIDInitializesBeforeAnythingHoldingAStore(t *testing.T) {
+	nodeDID := indexOfSubsystem(t, "node-did")
+
+	require.Less(t, nodeDID, indexOfSubsystem(t, "auth"),
+		"auth opens the token store, which is namespace-scoped (ADR-027)")
+	require.Less(t, nodeDID, indexOfSubsystem(t, "watcher"),
+		"watchers are namespace-scoped (ADR-026)")
+	require.Less(t, nodeDID, indexOfSubsystem(t, "canvas"),
+		"a canvas lives in one namespace (ADR-026)")
+}

--- a/server/token_store_duckdb.go
+++ b/server/token_store_duckdb.go
@@ -22,7 +22,7 @@ func newTokenStore(cfg *appcfg.Config) (auth.TokenStore, error) {
 	}
 
 	location := cfg.Storage.Parquet.Location
-	store, err := duckdbcgo.NewTokenStore(location)
+	store, err := duckdbcgo.NewTokenStore(location, duckdbcgo.NamespaceDefault)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open the access token store at %s", location)
 	}


### PR DESCRIPTION
`make parity` reported `node_identity  YES  NO`. Closing that one line turned out to require the layer nothing owns, so this branch builds it: a signer identity that survives on parquet, and namespaces to put it under.

## The layer nothing owned

ADR-010 tabulates three identity layers and built one. Vanity ID was dropped, ASUID shipped, and **Node DID was described in a table and specified in no ADR** — it existed as `server/nodedid/store.go` and a public DID-document route, and nowhere else. ADR-012 made that load-bearing by accepting the browser as a node. Tracked in #840.

`nodedid` had no seam: `New` took a `*sql.DB` and built its store inline. It now names a contract — `IdentityStore`, with `Load` returning nil for "none yet", which is how first boot is told from a broken location and therefore whether to mint a key. `New(db, logger)` delegates, so every existing caller is untouched.

The parquet implementation follows `tokens.rs`: one JSON object through DuckDB's `COPY`, read back with `read_json`, so a local path and an `s3://` prefix take one code path and the `file://` tests cover what production runs.

Unlike tokens, which store only a SHA-256 hash, this holds an ed25519 private key. SQLite already keeps it unencrypted, so exposure is unchanged and reach is not — a bucket policy question, not an application-crypto one. ADR-024 is amended to say so: node identity is not "small config". It is a singleton, written once, and the only secret in the store.

Built without the `rustduckdb` tag, a parquet deployment now fails startup naming the missing tag rather than quietly signing from the SQLite scratch.

## Everything is part of a namespace

Namespace is the top-level prefix and nothing falls outside it. Tokens, watchers, fires, schedules, ticks and attestations all move from the location root to `<location>/<namespace>/<kind>`, and no store opens without being told which namespace it is.

That makes isolation structural rather than remembered. A watcher in namespace B does not fire on an attestation in A because it has no path that reaches A — not because a filter was applied correctly. A schedule created in A stays in A for the same reason.

`node-did` initialises before `auth`: a store cannot know its prefix until the identity that decides it has loaded.

## A request carries who made it

`Middleware` returned a bool, so the only thing reaching a handler was "someone authenticated". A handler now reads a `Caller` from request context: a `Level` saying how much, a `Namespace` saying where. Keeping those apart is the point — collapsing them would make visibility-per-namespace inseparable from privilege.

`webauthn_credentials` gains `owner_did`. One owner holding several credentials is the multi-device property: the account is the identity, each key a device under it.

## What is deliberately hollow

Callers pass the default namespace as a constant, and registration passes an empty owner. Deriving a user DID from the WebAuthn PRF extension is #577 and does not exist. A named gap beats inventing key management here.

## Verified on the deployment

The 540 objects at `s3://sbvh-q-attestations/attestations` were migrated to the new layout — byte-identical total before and after — and q.sbvh.nl redeployed against it.

The served DID matches the stored one exactly. The node read its identity from `system/node_identity/self.json` through the new Rust store, FFI and Go binding; a failed read would have silently minted a different key and changed the node's DID. Attestations query and return, and every flush since has landed under `default/`.

CI caught what no local target could: `NewWatcherStore` in `cmd/qntx/commands` sits behind `rustduckdb`, `make test` builds `rustsqlite`, and `test-parquet` only reached `./ats/storage/duckdbcgo/...`. `test-parquet` now builds `./...` under the tag.

`make parity` reads `node_identity  YES  YES`.

Related: #840, #577, #583, ADR-010, ADR-012, ADR-024, ADR-025.
